### PR TITLE
extra keyvault and param match for zero trust

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -3,3 +3,18 @@
 name: azure-gpt-rag
 metadata:
   template: azure-gpt-rag
+hooks:
+  preprovision:
+    windows:
+      run: scripts/zeroTrustHeadsUp.ps1
+      interactive: true
+    posix:
+      run: scripts/zeroTrustHeadsUp.sh
+      interactive: true
+  postprovision:
+    posix:
+      run: scripts/postprovision.sh
+      interactive: true
+    windows:
+      run: scripts/postprovision.ps1
+      interactive: true

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -269,22 +269,25 @@ module searchDnsZone './core/network/private-dns-zones.bicep' = if (networkIsola
 }
 
 // VMs
+var ztVmName = 'testvm${resourceToken}'
+var bastionKvName = 'bastionkv${resourceToken}'
+var vmKeyVaultSecName = 'vmUserInitialPassword'
 
 module testvm './core/vm/dsvm.bicep' = if (networkIsolation) {
   name: 'testvm'
   scope: resourceGroup
   params: {
     location: location
-    resourceGroupName: resourceGroupName
-    name:'testvm${resourceToken}'
+    name: ztVmName
     tags: tags
     aiSubId: vnet.outputs.aiSubId
     bastionSubId: vnet.outputs.bastionSubId
     vmUserPassword: vmUserInitialPassword
     vmUserName: vmUserName
-    keyVaultName: keyVault.outputs.name
+    keyVaultName: bastionKvName
     // this is the named of the secret to store the vm password in keyvault. It matches what is used on main.parameters.json
-    vmUserPasswordKey: 'vmUserInitialPassword'
+    vmUserPasswordKey: vmKeyVaultSecName
+    principalId: principalId
   }
 }
 
@@ -971,3 +974,8 @@ module keyVaultSecret './core/security/keyvault-secrets.bicep' = {
 
 // AZURE_KEY_VAULT_NAME is used in main.parameters.json to keep the vm password
 output AZURE_KEY_VAULT_NAME string = keyVault.outputs.name
+output AZURE_ZERO_TRUST string = networkIsolation ? 'TRUE' : 'FALSE'
+output AZURE_VM_NAME string = networkIsolation ? ztVmName : ''
+output AZURE_VM_USERNAME string = networkIsolation ? vmUserName : ''
+output AZURE_VM_KV_NAME string = networkIsolation ? bastionKvName : ''
+output AZURE_VM_KV_SEC_NAME string = networkIsolation ? vmKeyVaultSecName : ''

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -18,7 +18,7 @@
       "value": "${AZURE_NETWORK_ISOLATION}"
     },
     "vmUserInitialPassword": {
-      "value": "$(secretOrRandomPassword ${AZURE_KEY_VAULT_NAME} vmUserInitialPassword)"
+      "value": "$(secretOrRandomPassword ${AZURE_VM_KV_NAME} vmUserInitialPassword)"
     },
     "vmUserName": {
       "value": "gptrag"

--- a/scripts/postprovision.ps1
+++ b/scripts/postprovision.ps1
@@ -1,0 +1,13 @@
+$YELLOW = [ConsoleColor]::Yellow
+$BLUE = [ConsoleColor]::Blue
+$NC = [ConsoleColor]::White
+
+if ($env:AZURE_ZERO_TRUST -eq "false") {
+    exit 0
+}
+
+Write-Host "For accessing the Zero Trust infrastructure, from the Azure Portal:"
+Write-Host "Virtual Machine: $($env:AZURE_VM_NAME)"
+Write-Host "Select connect using Bastion with:"
+Write-Host "  username: $($env:AZURE_VM_USERNAME)"
+Write-Host "  Key Vault/Secret: $($env:AZURE_VM_KV_NAME)/$($env:AZURE_VM_KV_SEC_NAME)"

--- a/scripts/postprovision.sh
+++ b/scripts/postprovision.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+## Provides a head's up to user for AZURE_NETWORK_ISOLATION
+
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+if [ "$AZURE_ZERO_TRUST" = "false" ]; then
+    exit 0
+fi
+
+echo "For accesing the ${YELLOW}Zero Trust infrastructure${NC}, from the Azure Portal:"
+echo "Virtual Machine: ${BLUE}$AZURE_VM_NAME${NC}"
+echo "Select connect using Bastion with:"
+echo "  username: $AZURE_VM_USERNAME"
+echo "  Key Vault/Secret: ${BLUE}$AZURE_VM_KV_NAME${NC}/${BLUE}$AZURE_VM_KV_SEC_NAME${NC}"

--- a/scripts/zeroTrustHeadsUp.ps1
+++ b/scripts/zeroTrustHeadsUp.ps1
@@ -1,0 +1,23 @@
+## Provides a head's up to user for AZURE_NETWORK_ISOLATION
+
+# Check if AZURE_NETWORK_ISOLATION environment variable is defined
+if (-not $env:AZURE_NETWORK_ISOLATION) {
+    exit 0
+}
+
+# Check if AZURE_NETWORK_ISOLATION environment variable is set to a positive value
+if ($env:AZURE_NETWORK_ISOLATION -match '^[1-9][0-9]*$' -or $env:AZURE_NETWORK_ISOLATION -match '^[Tt][Rr][Uu][Ee]$' -or $env:AZURE_NETWORK_ISOLATION -match '^[Tt]$') {
+    
+    # Display a heads up warning
+    Write-Host "Heads up! AZURE_NETWORK_ISOLATION is set to a positive value."
+
+    # Prompt for user confirmation
+    $confirmation = Read-Host "Continue with the script? [Y/n]: "
+
+    # Check if the confirmation is positive
+    if ($confirmation -ne "Y" -and $confirmation -ne "y" -and $confirmation) {
+        exit 1
+    }
+}
+
+exit 0

--- a/scripts/zeroTrustHeadsUp.sh
+++ b/scripts/zeroTrustHeadsUp.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+## Provides a head's up to user for AZURE_NETWORK_ISOLATION
+
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Check if AZURE_NETWORK_ISOLATION environment variable is defined
+if [ -z "$AZURE_NETWORK_ISOLATION" ]; then
+    exit 0
+fi
+
+# AZURE_SKIP_NETWORK_ISOLATION_WARNING explicit no-warning requested
+if [ "$AZURE_SKIP_NETWORK_ISOLATION_WARNING" -ge 1 ] 2>/dev/null || [ "$AZURE_SKIP_NETWORK_ISOLATION_WARNING" = "true" ] || [ "$AZURE_SKIP_NETWORK_ISOLATION_WARNING" = "t" ]; then
+    exit 0
+fi
+
+# Check if AZURE_NETWORK_ISOLATION environment variable is set to a positive value
+if [ "$AZURE_NETWORK_ISOLATION" -ge 1 ] 2>/dev/null || [ "$AZURE_NETWORK_ISOLATION" = "true" ] || [ "$AZURE_NETWORK_ISOLATION" = "t" ]; then
+    
+    # Display a heads up warning
+    echo "${YELLOW}Warning!${NC} AZURE_NETWORK_ISOLATION is set."
+    echo " - After provisioning, you need to switch to the ${GREEN}VirtualMachine & Bastion${NC} to continue deploying components."
+    echo " - Infrastucture will be only reachable from within the Bastion host."
+
+    # Prompt for user confirmation
+    echo -n "${BLUE}?${NC} Continue with Zero Trust provisioning? [Y/n]: "
+    read confirmation
+
+    # Check if the confirmation is positive
+    if [ "$confirmation" != "Y" ] && [ "$confirmation" != "y" ] && [ -n "$confirmation" ]; then
+        exit 1
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
For a Zero Trust deployment, this PR adds an initial warning before provisioning, like:

![image](https://github.com/Azure/GPT-RAG/assets/24213737/d6cf92d5-2f8f-49bf-8669-1ca9227724aa)

This helps the user understand what to expect after provisioning the infrastructure.

There's also a message printed at the end of provisioning to display the instructions for connecting using the VM, like:

![image](https://github.com/Azure/GPT-RAG/assets/24213737/f94e680f-4335-4ea0-bea3-7a06aa95f1e7)

Notes:
 - For the VM+Bastion+KeyVault, we are using a dedicated Key Vault with network access enabled. The password must be accessible from outside the vnet in order to access the vnet. Only the user running `azd up` gets access to read the key vault secret