### PR TITLE
e2e deployment from main repo

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -15,6 +15,27 @@ services:
           # this path is relative to ./.azure/gpt-rag-ingestion
           run: scripts/postdeploy.sh
           interactive: false
+  orchestrator:
+    project: ./.azure/gpt-rag-orchestrator
+    language: python
+    host: function
+  frontend:
+    # backend is python and frontend is Vite app. The frontend is built with Vite settings to output into the backend's static folder.
+    project: ./.azure/gpt-rag-frontend/backend
+    language: python
+    host: appservice
+    hooks:
+      prepackage:
+        windows:
+          shell: pwsh
+          run:  cd ../frontend;npm install;npm run build
+          interactive: false
+          continueOnError: false
+        posix:
+          shell: sh
+          run:  cd ../frontend;npm install;npm run build
+          interactive: false
+          continueOnError: false
 hooks:
   # Components are pulled from their own repo for deployment but are not persisted to this repo.
   prepackage:

--- a/azure.yaml
+++ b/azure.yaml
@@ -3,7 +3,24 @@
 name: azure-gpt-rag
 metadata:
   template: azure-gpt-rag
+services:
+  dataIngest:
+    # project is temporally pulled fro its repo during deployment.
+    project: ./.azure/gpt-rag-ingestion
+    language: python
+    host: function
+    hooks:
+      postdeploy:
+        posix:
+          # this path is relative to ./.azure/gpt-rag-ingestion
+          run: scripts/postdeploy.sh
+          interactive: false
 hooks:
+  # Components are pulled from their own repo for deployment but are not persisted to this repo.
+  prepackage:
+    posix:
+      run: scripts/fetchComponents.sh
+      interactive: false
   preprovision:
     windows:
       run: scripts/zeroTrustHeadsUp.ps1
@@ -18,3 +35,7 @@ hooks:
     windows:
       run: scripts/postprovision.ps1
       interactive: true
+  postdeploy:
+    posix:
+      run: scripts/cleanComponents.sh
+      interactive: false

--- a/azure.yaml
+++ b/azure.yaml
@@ -15,6 +15,10 @@ services:
           # this path is relative to ./.azure/gpt-rag-ingestion
           run: scripts/postdeploy.sh
           interactive: false
+        windows:
+          # this path is relative to ./.azure/gpt-rag-ingestion
+          run: scripts/postdeploy.ps1
+          interactive: false          
   orchestrator:
     project: ./.azure/gpt-rag-orchestrator
     language: python
@@ -42,6 +46,9 @@ hooks:
     posix:
       run: scripts/fetchComponents.sh
       interactive: false
+    windows:
+      run: scripts/fetchComponents.ps1
+      interactive: false      
   preprovision:
     windows:
       run: scripts/zeroTrustHeadsUp.ps1
@@ -59,4 +66,7 @@ hooks:
   postdeploy:
     posix:
       run: scripts/cleanComponents.sh
+      interactive: false
+    windows:
+      run: scripts/cleanComponents.ps1
       interactive: false

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -368,6 +368,9 @@ module keyVault './core/security/keyvault.bicep' = {
     publicNetworkAccess: networkIsolation?'Disabled':'Enabled'
     tags: tags
     principalId: principalId
+    // this is the named of the secret to store the vm password in keyvault. It matches what is used on main.parameters.json
+    vmUserPasswordKey: vmKeyVaultSecName
+    vmUserPassword: vmUserInitialPassword
   }
 }
 
@@ -983,7 +986,7 @@ output AZURE_KEY_VAULT_NAME string = keyVault.outputs.name
 output AZURE_ZERO_TRUST string = networkIsolation ? 'TRUE' : 'FALSE'
 output AZURE_VM_NAME string = networkIsolation ? ztVmName : ''
 output AZURE_VM_USERNAME string = networkIsolation ? vmUserName : ''
-output AZURE_VM_KV_NAME string = networkIsolation ? bastionKvName : ''
+output AZURE_VM_KV_NAME string = networkIsolation ? bastionKvName : keyVault.outputs.name
 output AZURE_VM_KV_SEC_NAME string = networkIsolation ? vmKeyVaultSecName : ''
 output AZURE_DATA_INGEST_FUNC_NAME string = dataIngestionFunctionAppName
 output AZURE_DATA_INGEST_FUNC_RG string = resourceGroup.name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -429,7 +429,7 @@ module orchestrator './core/host/functions.bicep' = {
     location: location
     appInsightsConnectionString: appInsights.outputs.connectionString
     appInsightsInstrumentationKey: appInsights.outputs.instrumentationKey
-    tags: tags
+    tags: union(tags, { 'azd-service-name': 'orchestrator' })
     alwaysOn: true
     functionAppScaleLimit: 2
     numberOfWorkers: 2
@@ -579,7 +579,7 @@ module frontEnd  'core/host/appservice.bicep'  = {
     vnetName: vnet.outputs.name
     appCommandLine: 'python ./app.py'
     location: location
-    tags: tags
+    tags: union(tags, { 'azd-service-name': 'frontend' })
     appServicePlanId: appServicePlan.outputs.id
     runtimeName: 'python'
     runtimeVersion: '3.10'
@@ -990,3 +990,4 @@ output AZURE_VM_KV_NAME string = networkIsolation ? bastionKvName : keyVault.out
 output AZURE_VM_KV_SEC_NAME string = networkIsolation ? vmKeyVaultSecName : ''
 output AZURE_DATA_INGEST_FUNC_NAME string = dataIngestionFunctionAppName
 output AZURE_DATA_INGEST_FUNC_RG string = resourceGroup.name
+output AZURE_ORCHESTRATOR_FUNC_NAME string = orchestratorFunctionAppName

--- a/scripts/cleanComponents.ps1
+++ b/scripts/cleanComponents.ps1
@@ -1,0 +1,14 @@
+# Delete the gpt-rag-ingestion folder from .azure if it exists
+if (Test-Path -Path ".\.azure\gpt-rag-ingestion") {
+    Remove-Item -Path ".\.azure\gpt-rag-ingestion" -Recurse -Force
+}
+
+# Delete the gpt-rag-orchestrator folder from .azure if it exists
+if (Test-Path -Path ".\.azure\gpt-rag-orchestrator") {
+    Remove-Item -Path ".\.azure\gpt-rag-orchestrator" -Recurse -Force
+}
+
+# Delete the gpt-rag-frontend folder from .azure if it exists
+if (Test-Path -Path ".\.azure\gpt-rag-frontend") {
+    Remove-Item -Path ".\.azure\gpt-rag-frontend" -Recurse -Force
+}

--- a/scripts/cleanComponents.sh
+++ b/scripts/cleanComponents.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Delete the gpt-rag-ingestion folder from .azure if it exists
+if [ -d ./.azure/gpt-rag-ingestion ]; then
+    rm -rf ./.azure/gpt-rag-ingestion
+fi

--- a/scripts/cleanComponents.sh
+++ b/scripts/cleanComponents.sh
@@ -4,3 +4,13 @@
 if [ -d ./.azure/gpt-rag-ingestion ]; then
     rm -rf ./.azure/gpt-rag-ingestion
 fi
+
+# Delete the gpt-rag-orchestrator folder from .azure if it exists
+if [ -d ./.azure/gpt-rag-orchestrator ]; then
+    rm -rf ./.azure/gpt-rag-orchestrator
+fi
+
+# Delete the gpt-rag-frontend folder from .azure if it exists
+if [ -d ./.azure/gpt-rag-frontend ]; then
+    rm -rf ./.azure/gpt-rag-frontend
+fi

--- a/scripts/fetchComponents.ps1
+++ b/scripts/fetchComponents.ps1
@@ -1,0 +1,23 @@
+# Delete the gpt-rag-ingestion folder from .azure if it exists
+if (Test-Path -Path ".\.azure\gpt-rag-ingestion") {
+    Remove-Item -Path ".\.azure\gpt-rag-ingestion" -Recurse -Force
+}
+
+# Clone the repository into the .azure folder
+git clone https://github.com/Azure/gpt-rag-ingestion .\.azure\gpt-rag-ingestion
+
+# Delete the gpt-rag-orchestrator folder from .azure if it exists
+if (Test-Path -Path ".\.azure\gpt-rag-orchestrator") {
+    Remove-Item -Path ".\.azure\gpt-rag-orchestrator" -Recurse -Force
+}
+
+# Clone the repository into the .azure folder
+git clone https://github.com/Azure/gpt-rag-orchestrator .\.azure\gpt-rag-orchestrator
+
+# Delete the gpt-rag-frontend folder from .azure if it exists
+if (Test-Path -Path ".\.azure\gpt-rag-frontend") {
+    Remove-Item -Path ".\.azure\gpt-rag-frontend" -Recurse -Force
+}
+
+# Clone the repository into the .azure folder
+git clone https://github.com/Azure/gpt-rag-frontend .\.azure\gpt-rag-frontend

--- a/scripts/fetchComponents.sh
+++ b/scripts/fetchComponents.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Delete the gpt-rag-ingestion folder from .azure if it exists
+if [ -d ./.azure/gpt-rag-ingestion ]; then
+    rm -rf ./.azure/gpt-rag-ingestion
+fi
+
+# Clone the repository into the .azure folder
+#git clone https://github.com/Azure/gpt-rag-ingestion ./.azure/gpt-rag-ingestion
+git clone https://github.com/vhvb1989/gpt-rag-ingestion ./.azure/gpt-rag-ingestion

--- a/scripts/fetchComponents.sh
+++ b/scripts/fetchComponents.sh
@@ -6,8 +6,7 @@ if [ -d ./.azure/gpt-rag-ingestion ]; then
 fi
 
 # Clone the repository into the .azure folder
-#git clone https://github.com/Azure/gpt-rag-ingestion ./.azure/gpt-rag-ingestion
-git clone https://github.com/vhvb1989/gpt-rag-ingestion ./.azure/gpt-rag-ingestion
+git clone https://github.com/Azure/gpt-rag-ingestion ./.azure/gpt-rag-ingestion
 
 # Delete the gpt-rag-orchestrator folder from .azure if it exists
 if [ -d ./.azure/gpt-rag-orchestrator ]; then
@@ -15,8 +14,7 @@ if [ -d ./.azure/gpt-rag-orchestrator ]; then
 fi
 
 # Clone the repository into the .azure folder
-#git clone https://github.com/Azure/gpt-rag-orchestrator ./.azure/gpt-rag-orchestrator
-git clone https://github.com/vhvb1989/gpt-rag-orchestrator ./.azure/gpt-rag-orchestrator
+git clone https://github.com/Azure/gpt-rag-orchestrator ./.azure/gpt-rag-orchestrator
 
 # Delete the gpt-rag-frontend folder from .azure if it exists
 if [ -d ./.azure/gpt-rag-frontend ]; then
@@ -24,5 +22,4 @@ if [ -d ./.azure/gpt-rag-frontend ]; then
 fi
 
 # Clone the repository into the .azure folder
-#git clone https://github.com/Azure/gpt-rag-frontend ./.azure/gpt-rag-frontend
-git clone https://github.com/vhvb1989/gpt-rag-frontend ./.azure/gpt-rag-frontend
+git clone https://github.com/Azure/gpt-rag-frontend ./.azure/gpt-rag-frontend

--- a/scripts/fetchComponents.sh
+++ b/scripts/fetchComponents.sh
@@ -8,3 +8,21 @@ fi
 # Clone the repository into the .azure folder
 #git clone https://github.com/Azure/gpt-rag-ingestion ./.azure/gpt-rag-ingestion
 git clone https://github.com/vhvb1989/gpt-rag-ingestion ./.azure/gpt-rag-ingestion
+
+# Delete the gpt-rag-orchestrator folder from .azure if it exists
+if [ -d ./.azure/gpt-rag-orchestrator ]; then
+    rm -rf ./.azure/gpt-rag-orchestrator
+fi
+
+# Clone the repository into the .azure folder
+#git clone https://github.com/Azure/gpt-rag-orchestrator ./.azure/gpt-rag-orchestrator
+git clone https://github.com/vhvb1989/gpt-rag-orchestrator ./.azure/gpt-rag-orchestrator
+
+# Delete the gpt-rag-frontend folder from .azure if it exists
+if [ -d ./.azure/gpt-rag-frontend ]; then
+    rm -rf ./.azure/gpt-rag-frontend
+fi
+
+# Clone the repository into the .azure folder
+#git clone https://github.com/Azure/gpt-rag-frontend ./.azure/gpt-rag-frontend
+git clone https://github.com/vhvb1989/gpt-rag-frontend ./.azure/gpt-rag-frontend


### PR DESCRIPTION
Make azd to pull the components from their own repo to deploy them, then clean the code.

Status [DO NOT MERGE until dependencies are merged]:
- data ingestion:  Depends on: https://github.com/Azure/gpt-rag-ingestion/pull/29
- orchestrator: Depends on https://github.com/Azure/gpt-rag-orchestrator/pull/36
- frontend: depends on: https://github.com/Azure/gpt-rag-frontend/pull/14

This PR is also updating infra to save the autogen-pass to make deployment-cache to work.  This is a side effect of using the same infra files for two deployments.
bicep can't have an input parameter based on another input.  The password for the VM is an input parameter that is always requested regardless of deploying the VM or not.
Azd can generate the password but if the password is not persisted in KeyVault, azd will generate a new password every time.
When checking the last deployment against a new one, a new generated password would always break the cache.
To mitigate this, we are saving the generated password within the keyvault created for the non-zero trust implementation.