### PR TITLE
save function default key in keyvault manually

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -423,6 +423,7 @@ module orchestrator './core/host/functions.bicep' = {
     vnetName: vnet.outputs.name
     networkIsolation: networkIsolation
     keyVaultName: keyVault.outputs.name
+    persistFunctionKeyToKeyVaultWithSecretName: 'orchestrator-host--functionKey'
     storageAccountName: '${storageAccountName}orc'
     appServicePlanId: appServicePlan.outputs.id
     appName: orchestratorFunctionAppName
@@ -507,14 +508,6 @@ module orchestrator './core/host/functions.bicep' = {
       {
         name: 'ORCHESTRATOR_MESSAGES_LANGUAGE'
         value: orchestratorMessagesLanguage
-      }
-      {
-        name: 'AzureWebJobsSecretStorageType'
-        value: 'keyvault'
-      }   
-      {
-        name: 'AzureWebJobsSecretStorageKeyVaultUri'
-        value: keyVault.outputs.endpoint
       }
       {
         name: 'LOGLEVEL'


### PR DESCRIPTION
Updates bicep to manually persist the functions' default key into key vault as secret.
depends on: https://github.com/Azure/gpt-rag-frontend/pull/15

The previous implementation was relying on  setting `AzureWebJobsSecretStorageType` and `AzureWebJobsSecretStorageKeyVaultUri` for the FunctionApp configuration to make it create a secret on the key vault automatically.
However, there was a chiken&egg issue there:  By the time the FunctionApp was created, it has not access to create secrets on the KeyVault, and the access can't be granted w/o creating the FunctionApp first (to get its unique id).

The implementation was changed to pull the FunctionApp default key after it is created and define a new secret as part of the deployment with it. 