### PR TITLE
update on openai API version

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -97,8 +97,8 @@ param embeddingsDeploymentName string = 'text-embedding-ada-002'
 @maxValue(240)
 param embeddingsDeploymentCapacity int = 1
 @description('Azure OpenAI API version.')
-@allowed([ '2023-05-15', '2023-06-01-preview'])
-param openaiApiVersion string = '2023-05-15'
+@allowed([ '2023-05-15', '2023-06-01-preview', '2023-08-01-preview'])
+param openaiApiVersion string
 @description('Enables LLM monitoring to generate conversation metrics.')
 @allowed([true, false])
 param chatGptLlmMonitoring bool = true

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -29,6 +29,9 @@
     "chatGptModelVersion": {
       "value": "0613"
     },
+    "openaiApiVersion": {
+      "value": "2023-08-01-preview"
+    },
     "orchestratorMessagesLanguage": {
       "value": "es"
     },


### PR DESCRIPTION
updated Azure OpenAI REST API default to '2023-08-01-preview', which is the most recent supporting the three models (gpt-4, gpt-35 and embeddings), reference: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference