### PR TITLE
Refactor raipolicies.sh to use sed instead of grep for parsing model Information

### DIFF
--- a/scripts/rai/raipolicies.sh
+++ b/scripts/rai/raipolicies.sh
@@ -85,12 +85,12 @@ while read -r line; do
     fi
 done <<< "$modelDeployments"
 
-modelSkuName=$(echo "$model" | grep -oP '"sku":\{"name":"\K[^"]+')
-modelSkuCapacity=$(echo "$model" | grep -oP '"sku":\{"name":"[^"]+","capacity":\K\d+')
-modelFormat=$(echo "$model" | grep -oP '"model":\{"format":"\K[^"]+')
-modelName=$(echo "$model" | grep -oP '"model":\{"format":"[^"]+","name":"\K[^"]+')
-modelVersion=$(echo "$model" | grep -oP '"model":\{"format":"[^"]+","name":"[^"]+","version":"\K[^"]+')
-modelVUpgOps=$(echo "$model" | grep -oP '"versionUpgradeOption":"\K[^"]+')
+modelSkuName=$(echo "$model" | sed -En 's/.*"sku":\{"name":"([^"]*).*/\1/p')
+modelSkuCapacity=$(echo "$model" | sed -En 's/.*"sku":\{"name":"[^"]*","capacity":([0-9]*).*/\1/p')
+modelFormat=$(echo "$model" | sed -En 's/.*"model":\{"format":"([^"]*).*/\1/p')
+modelName=$(echo "$model" | sed -En 's/.*"model":\{"format":"[^"]*","name":"([^"]*).*/\1/p')
+modelVersion=$(echo "$model" | sed -En 's/.*"model":\{"format":"[^"]*","name":"[^"]*","version":"([^"]*).*/\1/p')
+modelVUpgOps=$(echo "$model" | sed -En 's/.*"versionUpgradeOption":"([^"]*).*/\1/p')
 
 updatedModel=$(printf '{
     "displayName": "%s",


### PR DESCRIPTION
Fixed #162

This pull request includes changes to the `scripts/rai/raipolicies.sh` file. The changes involve replacing `grep` commands with `sed` commands for parsing specific fields from a JSON string stored in the `model` variable. This change enhances the readability and maintainability of the code.

* [`scripts/rai/raipolicies.sh`](diffhunk://#diff-ff0eb53304bbe32df03bc4cc77fe71be088efb38fedd4d15f3492d28f7f1714fL88-R93): Replaced `grep` commands with `sed` commands for parsing fields from the `model` variable. This change includes parsing for `modelSkuName`, `modelSkuCapacity`, `modelFormat`, `modelName`, `modelVersion`, and `modelVUpgOps`.