### PR TITLE
Update keyvault.bicep - remove purge protection

### DIFF
--- a/infra/core/security/keyvault.bicep
+++ b/infra/core/security/keyvault.bicep
@@ -27,7 +27,6 @@ resource newKeyVault 'Microsoft.KeyVault/vaults@2022-07-01' = if (!keyVaultReuse
     sku: { family: 'A', name: 'standard' }
     enableSoftDelete: true
     publicNetworkAccess: publicNetworkAccess
-    enablePurgeProtection: true
     accessPolicies: !empty(principalId) ? [
       {
         objectId: principalId


### PR DESCRIPTION
Purge protection prevents a deleted kV from been purged and makes azd to fail during `azd down --purge`.