### PR TITLE
data ingestion containers

### DIFF
--- a/docs/MANUAL_INSTALLATION.md
+++ b/docs/MANUAL_INSTALLATION.md
@@ -239,9 +239,9 @@ Gather Necessary Information:
    - **Storage Account**
      - Create a storage account to store documents
      - Create the following blob containers:
-        - raw_data
         - documents
-        - images
+        - documents-images
+        - documents-raw
      - Disable public access.
      - Enable soft delete for blobs.
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -399,8 +399,8 @@ var _chunkTokenOverlap = !empty(chunkTokenOverlap) ? chunkTokenOverlap : '200'
 @description('Name of the container where source documents will be stored.')
 param storageContainerName string = ''
 var _storageContainerName = !empty(storageContainerName) ? storageContainerName : 'documents'
-var _storageRawDataContainerName = '${_storageContainerName}raw'
-var _storageImagesContainerName = '${_storageContainerName}images'
+var _storageRawDataContainerName = '${_storageContainerName}-raw'
+var _storageImagesContainerName = '${_storageContainerName}-images'
 
 @description('Storage Account Name. Use your own name convention or leave as it is to generate a random name.')
 param storageAccountName string = ''


### PR DESCRIPTION
This pull request includes changes to the documentation and infrastructure configuration to update the naming conventions for storage containers. The most important changes are as follows:

### Documentation Updates:
* [`docs/MANUAL_INSTALLATION.md`](diffhunk://#diff-b7798783d7a90c61bf5ace31bbaec90fef58158ee8551eea845c399e916cb6b7L242-R244): Updated the names of blob containers in the storage account section to `documents-images` and `documents-raw` instead of `images` and `raw_data`.

### Infrastructure Configuration:
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L402-R403): Modified the variables for storage container names to use hyphens (`-`) instead of concatenation without separators, changing from `${_storageContainerName}raw` and `${_storageContainerName}images` to `${_storageContainerName}-raw` and `${_storageContainerName}-images`.