### PR TITLE
Document Intelligence version fix

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -371,7 +371,7 @@ var _chatGptLlmMonitoring = chatGptLlmMonitoring != null ? chatGptLlmMonitoring 
 
 // Document intelligence settings
 
-var _docintApiVersion = (location == 'eastus' || location == 'westus2' || location == 'westeurope' || location == 'northcentralus') ? '2024-07-01-preview' : '2023-07-31'
+var _docintApiVersion = (location == 'eastus' || location == 'westus2' || location == 'westeurope' || location == 'northcentralus') ? '2024-07-31-preview' : '2023-07-31'
 
 // AI search settings
 


### PR DESCRIPTION
This pull request includes a minor change to the `infra/main.bicep` file. The change updates the API version for document intelligence settings based on the location.

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L374-R374): Updated the API version for document intelligence settings to `2024-07-31-preview` for specific locations.