### PR TITLE
update search api

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -371,10 +371,10 @@ var _searchServiceSkuName = _networkIsolation?'standard2':'standard'
 param searchIndex string = ''
 var _searchIndex = !empty(searchIndex) ? searchIndex : 'ragindex'
 
-// @allowed([ '2023-11-01', '2023-10-01-Preview', '2024-05-01-preview' ])
+// @allowed([ '2024-07-01', '2023-11-01', '2023-10-01-Preview', '2024-05-01-preview' ])
 // Requires version 2023-10-01-Preview or higher for indexProjections and MIS authResourceId.
 param searchApiVersion string = ''
-var _searchApiVersion = !empty(searchApiVersion) ? searchApiVersion : '2024-05-01-preview'
+var _searchApiVersion = !empty(searchApiVersion) ? searchApiVersion : '2024-07-01'
 
 @description('Frequency of search reindexing. PT5M (5 min), PT1H (1 hour), P1D (1 day).')
 // @allowed(['PT5M', 'PT1H', 'P1D'])


### PR DESCRIPTION
This pull request includes a small change to the `infra/main.bicep` file. The change updates the allowed API versions and the default search API version.

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L374-R377): Added `2024-07-01` to the allowed API versions and set it as the default search API version.