### PR TITLE
Bug/bastion nsg

### DIFF
--- a/docs/CUSTOMIZATIONS_BYOR.md
+++ b/docs/CUSTOMIZATIONS_BYOR.md
@@ -160,7 +160,7 @@ For instance, if your AI subnet has a custom name, specify it using the `AZURE_A
 
 #### Networking resources
 
-When reusing an existing VNet, you must configure the network resources according to your standards **after deploying GPT-RAG**.
+When reusing an existing VNet, you must configure the network resources according to your standards **before deploying GPT-RAG**.
 
 These resources include Private Endpoints, Private DNS Links, and Search Private Links:
 

--- a/infra/core/network/vnet.bicep
+++ b/infra/core/network/vnet.bicep
@@ -68,42 +68,119 @@ resource bastionNsg 'Microsoft.Network/networkSecurityGroups@2020-11-01' = {
   properties: {
     securityRules: [
       {
-        name: 'AllowInternetInbound443'
+        name: 'AllowHttpsInbound'
         properties: {
           priority: 100
           protocol: 'Tcp'
           access: 'Allow'
           direction: 'Inbound'
-          sourceAddressPrefix: '*'
+          sourceAddressPrefix: 'Internet'
           sourcePortRange: '*'
           destinationAddressPrefix: '*'
           destinationPortRange: '443'
         }
       }
       {
-        name: 'AllowInternetOutbound443'
+        name: 'AllowGatewayManagerInbound'
         properties: {
-          priority: 200
+          priority: 120
           protocol: 'Tcp'
           access: 'Allow'
-          direction: 'Outbound'
-          sourceAddressPrefix: '*'
+          direction: 'Inbound'
+          sourceAddressPrefix: 'GatewayManager'
           sourcePortRange: '*'
           destinationAddressPrefix: '*'
           destinationPortRange: '443'
         }
       }
       {
-        name: 'AllowInternetOutbound3389'
+        name: 'AllowLoadBalancerInbound'
         properties: {
-          priority: 300
+          priority: 110
           protocol: 'Tcp'
           access: 'Allow'
-          direction: 'Outbound'
-          sourceAddressPrefix: '*'
+          direction: 'Inbound'
+          sourceAddressPrefix: 'AzureLoadBalancer'
           sourcePortRange: '*'
           destinationAddressPrefix: '*'
-          destinationPortRange: '3389'
+          destinationPortRange: '443'
+        }
+      }
+      {
+        name: 'AllowBastionHostCommunicationInBound'
+        properties: {
+          protocol: '*'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationPortRanges: [
+            '8080'
+            '5701'
+          ]
+          destinationAddressPrefix: 'VirtualNetwork'
+          access: 'Allow'
+          priority: 130
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'AllowSshRdpOutBound'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationPortRanges: [
+            '22'
+            '3389'
+          ]
+          destinationAddressPrefix: 'VirtualNetwork'
+          access: 'Allow'
+          priority: 100
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'AllowAzureCloudCommunicationOutBound'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationPortRange: '443'
+          destinationAddressPrefix: 'AzureCloud'
+          access: 'Allow'
+          priority: 110
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'AllowBastionHostCommunicationOutBound'
+        properties: {
+          protocol: '*'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationPortRanges: [
+            '8080'
+            '5701'
+          ]
+          destinationAddressPrefix: 'VirtualNetwork'
+          access: 'Allow'
+          priority: 120
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'AllowGetSessionInformationOutBound'
+        properties: {
+          protocol: '*'
+          sourcePortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'Internet'
+          destinationPortRanges: [
+            '80'
+            '443'
+          ]
+          access: 'Allow'
+          priority: 130
+          direction: 'Outbound'
         }
       }
     ]


### PR DESCRIPTION
Zero Trust provisioning Error: "Network security group bastion-nsg does not have necessary rules for Azure Bastion Subnet AzureBastionSubnet. (Code: NetworkSecurityGroupNotCompliantForAzureBastionSubnet)"

Troubleshooting - https://learn.microsoft.com/en-us/azure/bastion/troubleshoot#nsg
Documentation - https://learn.microsoft.com/en-us/azure/bastion/bastion-nsg#nsg

Solution: Add the required rules to the Bastion NSG. 
Template: https://github.com/Azure/azure-quickstart-templates/blob/master/quickstarts/microsoft.network/azure-bastion-nsg/main.bicep