### PR TITLE
Subnet range and storage key access fix

### DIFF
--- a/infra/core/host/functions.bicep
+++ b/infra/core/host/functions.bicep
@@ -23,6 +23,8 @@ param networkIsolation bool
 param vnetName string
 param subnetId string
 
+param allowSharedKeyAccess bool = true
+
 param functionAppReuse bool
 param deployFunctionApp bool = true
 param existingFunctionAppResourceGroupName string
@@ -66,6 +68,7 @@ resource newStorageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = if (
   properties: {
     allowBlobPublicAccess: false // Disable anonymous access 
     supportsHttpsTrafficOnly: true
+    allowSharedKeyAccess: allowSharedKeyAccess    
     defaultToOAuthAuthentication: true
   }
 }

--- a/infra/core/network/vnet.bicep
+++ b/infra/core/network/vnet.bicep
@@ -1,16 +1,16 @@
 param vnetName string
 param location string
-param vnetAddress string = '10.0.0.0/16'
 param aiSubnetName string
 param appIntSubnetName string
 param appServicesSubnetName string
 param databaseSubnetName string
 param bastionSubnetName string
-param aiSubnetPrefix string = '10.0.1.0/24'
-param appIntSubnetPrefix string = '10.0.2.0/24'
-param appServicesSubnetPrefix string = '10.0.3.0/24'
-param databaseSubnetPrefix string = '10.0.4.0/24'
-param bastionSubnetPrefix string = '10.0.5.0/24'
+param vnetAddress string = '10.0.0.0/23'
+param aiSubnetPrefix string = '10.0.0.0/26'
+param appIntSubnetPrefix string = '10.0.0.128/26'
+param appServicesSubnetPrefix string = '10.0.0.192/26'
+param databaseSubnetPrefix string = '10.0.1.0/26'
+param bastionSubnetPrefix string = '10.0.0.64/26'
 param appServicePlanId string
 param appServicePlanName string
 param tags object = {}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -187,7 +187,7 @@ var _vnetName = _azureReuseConfig.vnetReuse ? _azureReuseConfig.existingVnetName
 
 @description('Address space for the virtual network')
 param vnetAddress string = ''
-var _vnetAddress = !empty(vnetAddress) ? vnetAddress : '10.0.0.0/24'
+var _vnetAddress = !empty(vnetAddress) ? vnetAddress : '10.0.0.0/23'
 
 @description('Name of the AI services subnet')
 param aiSubnetName string = ''
@@ -195,7 +195,7 @@ var _aiSubnetName = !empty(aiSubnetName) ? aiSubnetName : 'ai-subnet'
 
 @description('Address prefix for the AI services subnet')
 param aiSubnetPrefix string = ''
-var _aiSubnetPrefix = !empty(aiSubnetPrefix) ? aiSubnetPrefix : '10.0.0.0/28'
+var _aiSubnetPrefix = !empty(aiSubnetPrefix) ? aiSubnetPrefix : '10.0.0.0/26'
 
 @description('Name of the Bastion subnet')
 param bastionSubnetName string = ''
@@ -211,7 +211,7 @@ var _appIntSubnetName = !empty(appIntSubnetName) ? appIntSubnetName : 'app-int-s
 
 @description('Address prefix for the App Integration subnet')
 param appIntSubnetPrefix string = ''
-var _appIntSubnetPrefix = !empty(appIntSubnetPrefix) ? appIntSubnetPrefix : '10.0.0.48/28'
+var _appIntSubnetPrefix = !empty(appIntSubnetPrefix) ? appIntSubnetPrefix : '10.0.0.128/26'
 
 @description('Name of the App Services subnet')
 param appServicesSubnetName string = ''
@@ -219,7 +219,7 @@ var _appServicesSubnetName = !empty(appServicesSubnetName) ? appServicesSubnetNa
 
 @description('Address prefix for the App Services subnet')
 param appServicesSubnetPrefix string = ''
-var _appServicesSubnetPrefix = !empty(appServicesSubnetPrefix) ? appServicesSubnetPrefix : '10.0.0.16/28'
+var _appServicesSubnetPrefix = !empty(appServicesSubnetPrefix) ? appServicesSubnetPrefix : '10.0.0.192/26'
 
 @description('Name of the Database subnet')
 param databaseSubnetName string = ''
@@ -227,7 +227,7 @@ var _databaseSubnetName = !empty(databaseSubnetName) ? databaseSubnetName : 'dat
 
 @description('Address prefix for the Database subnet')
 param databaseSubnetPrefix string = ''
-var _databaseSubnetPrefix = !empty(databaseSubnetPrefix) ? databaseSubnetPrefix : '10.0.0.32/28'
+var _databaseSubnetPrefix = !empty(databaseSubnetPrefix) ? databaseSubnetPrefix : '10.0.1.0/26'
 
 // flag that indicates if we're reusing a vnet
 var _vnetReuse = _azureReuseConfig.vnetReuse


### PR DESCRIPTION
This pull request includes several important changes to the network configuration and function app deployment parameters in the Bicep files. The changes primarily focus on updating subnet address prefixes and adding a new parameter for shared key access in storage accounts.

Fixes:
https://github.com/Azure/GPT-RAG/issues/226
https://github.com/Azure/GPT-RAG/issues/225

### Network Configuration Updates:

* [`infra/core/network/vnet.bicep`](diffhunk://#diff-0bec7c211a8cb281a61bc2046ddf753c52604125ad2af9678301861c172bb8e1L3-R13): Updated the virtual network and subnet address prefixes to accommodate a larger address space.
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L190-R198): Adjusted the default values for virtual network and subnet address prefixes to align with the new address space configuration. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L190-R198) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L214-R230)

### Function App Deployment Parameters:

* [`infra/core/host/functions.bicep`](diffhunk://#diff-fdfa3d588bb37778e24108dda63c3cf8e68d29ed74974ceecd88c1b019014241R26-R27): Added a new parameter `allowSharedKeyAccess` to control access to storage accounts using shared keys.
* [`infra/core/host/functions.bicep`](diffhunk://#diff-fdfa3d588bb37778e24108dda63c3cf8e68d29ed74974ceecd88c1b019014241R71): Modified the storage account resource properties to include the new `allowSharedKeyAccess` parameter.