### PR TITLE
fix azd cdn

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install azd
-        uses: Azure/setup-azd@v1.0.0
+        uses: Azure/setup-azd@v2
 
       - name: Log in with Azure (Federated Credentials)
         run: |

--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -26,7 +26,7 @@ jobs:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     - name: Install azd
-      uses: Azure/setup-azd@v1.0.0
+      uses: Azure/setup-azd@v2
 
     - name: Login to Azure Developer CLI
       run: |


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to use the latest version of the Azure Developer CLI setup action.

* [`.github/workflows/deploy-template.yml`](diffhunk://#diff-de38019e0c78713420e4284838be9acc5cd7689af9483fb9b79fae047fe37612L30-R30): Updated the `Azure/setup-azd` action from version `v1.0.0` to `v2`.
* [`.github/workflows/loadtest.yaml`](diffhunk://#diff-5ed4c7bec737ccfb14393ede1186b0d17701f955727d4a07562e11b74882905fL29-R29): Updated the `Azure/setup-azd` action from version `v1.0.0` to `v2`.

Closes https://github.com/Azure/GPT-RAG/issues/273