### PR TITLE
Added flask secret value for custom auth

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1090,7 +1090,9 @@ module frontEnd  'core/host/appservice.bicep' = {
     runtimeVersion: _appServiceRuntimeVersion
     scmDoBuildDuringDeployment: true
     basicPublishingCredentials: _networkIsolation?true:false
-    appSettings: [
+    keyVaultName: keyVault.outputs.name
+    flaskSecretName: 'flaskSecretKey'
+        appSettings: [
       {
         name: 'SPEECH_SYNTHESIS_VOICE_NAME'
         value: _speechSynthesisVoiceName
@@ -1184,6 +1186,14 @@ module appserviceAIAccess './core/security/aiservices-access.bicep' = {
   }
 } 
 
+module appserviceKeyVaultAccess './core/security/keyvault-access.bicep' =  {
+  name: 'appservice-keyvault-access'
+  scope: az.resourceGroup(_keyVaultResourceGroupName)
+  params: {
+    resourceName: keyVault.outputs.name
+    principalId: frontEnd.outputs.identityPrincipalId
+  }
+} 
 
 module dataIngestion './core/host/functions.bicep' = {
   name: 'dataIngestion'


### PR DESCRIPTION
This pull request introduces several changes to the `infra` directory to integrate KeyVault for managing secrets and to grant necessary access permissions. The most important changes include adding KeyVault parameters and resources, updating the `appservice.bicep` file to use these parameters, and modifying the `main.bicep` file to include the new KeyVault module.

KeyVault Integration:

* [`infra/core/host/appservice.bicep`](diffhunk://#diff-c49282ec82c441d0ca28744efdbdae6288715e320eb90772ac149c9096f7eeedR10-R13): Added parameters for `keyVaultName` and `flaskSecretName`, and defined a new KeyVault resource along with a secret for `flaskSecretKey`. [[1]](diffhunk://#diff-c49282ec82c441d0ca28744efdbdae6288715e320eb90772ac149c9096f7eeedR10-R13) [[2]](diffhunk://#diff-c49282ec82c441d0ca28744efdbdae6288715e320eb90772ac149c9096f7eeedR60-R81)

Access Permissions:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1093-R1094): Updated the `frontEnd` module to include `keyVaultName` and `flaskSecretName` parameters, and added a new module `appserviceKeyVaultAccess` to handle access permissions for KeyVault. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1093-R1094) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1189-R1196)