### PR TITLE
sharepoint ingestion fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v2.1.2] – 2025-10-02
+### Changed
+- Fixed a bug in daa ingestion component where the SharePoint ingestion process was unnecessarily re-indexing unchanged files.
+
 ## [v2.1.1] – 2025-09-22
 ### Changed
 - Limit `azd` environment variables to the script process (no longer persisted to the user profile) to reduce secret exposure. Resolves [#378](https://github.com/Azure/GPT-RAG/issues/378).

--- a/infra/manifest.json
+++ b/infra/manifest.json
@@ -1,5 +1,5 @@
 {
-  "release": "v2.1.1",
+  "release": "v2.1.2",
   "repo": "https://github.com/azure/gpt-rag.git",
   "components": [
     {
@@ -20,7 +20,7 @@
     {
       "name": "gpt-rag-ingestion",
       "repo": "https://github.com/azure/gpt-rag-ingestion.git",
-      "tag": "v2.0.4"
+      "tag": "v2.0.5"
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the project to version `v2.1.2` and addresses a bug in the SharePoint ingestion process that caused unnecessary re-indexing of unchanged files. It also updates the release and component tags to reflect the new version.

Version and release updates:

* Updated the project version to `v2.1.2` in both `CHANGELOG.md` and `infra/manifest.json`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R9) [[2]](diffhunk://#diff-e345c74ed3e9bf4a7a75ae54fbd3413b6b1a51df466ca1d6ead77457d956f68dL2-R2)

Bug fix:

* Fixed a bug in the daa ingestion component to prevent the SharePoint ingestion process from re-indexing unchanged files.

Dependency/component updates:

* Updated the `gpt-rag-ingestion` component tag from `v2.0.4` to `v2.0.5` in `infra/manifest.json`.