### PR TITLE
Azure Direct Models and SharePoint Lists

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -2414,6 +2414,26 @@ module assignAIFoundryCogServOAIUserExecutor 'modules/security/resource-role-ass
   }
 }
 
+// AI Foundry Account - Cognitive Services  User -> Executor
+module assignAIFoundryCogServUserExecutor 'modules/security/resource-role-assignment.bicep' = if (deployAiFoundry) {
+  name: 'assignAIFoundryCogServUserExecutor'
+  params: {
+    name: 'assignAIFoundryCogServUserExecutor'
+    roleAssignments: [
+      {
+        principalId: principalId
+        roleDefinitionId: subscriptionResourceId(
+          'Microsoft.Authorization/roleDefinitions',
+          const.roles.CognitiveServicesUser.guid
+        )
+        #disable-next-line BCP318
+        resourceId: aiFoundryAccountResourceId
+        principalType: principalType
+      }
+    ]
+  }
+}
+
 // App Configuration Settings Service - App Configuration Data Reader -> ContainerApp
 module assignAppConfigAppConfigurationDataReaderContainerApps 'modules/security/resource-role-assignment.bicep' = [
   for (app, i) in containerAppsList: if (deployAppConfig && contains(

--- a/infra/manifest.json
+++ b/infra/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.2.6",
-  "release": "release/2.2.6",
+  "tag": "v2.3.0",
+  "release": "release/2.3.0",
   "repo": "https://github.com/azure/gpt-rag.git",
   "components": [
     {
@@ -12,19 +12,20 @@
     {
       "name": "gpt-rag-mcp",
       "repo": "https://github.com/azure/gpt-rag-mcp.git",
-      "tag": "v0.2.3",
-      "release": "release/0.2.3"
+      "tag": "v0.3.4",
+      "release": "release/0.3.4"
     },
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v2.2.1",
-      "release": "release/2.2.1"
+      "tag": "v2.3.0",
+      "release": "release/2.3.0"
     },
     {
       "name": "gpt-rag-ingestion",
       "repo": "https://github.com/azure/gpt-rag-ingestion.git",
-      "tag": "v2.0.6"
+      "tag": "v2.1.0",
+      "release": "release/2.1.0"
     }
   ]
 }


### PR DESCRIPTION
This pull request introduces an access control update to enable working with non–Azure OpenAI models in Azure AI Foundry and updates component versions to align the solution with the latest supported capabilities across ingestion and orchestration. The main changes are grouped below:

**AI Foundry access enablement (non–Azure OpenAI models):**

* Added a new module (`assignAIFoundryCogServUserExecutor`) in `infra/main.bicep` to assign the **Cognitive Services User** role to a principal on the AI Foundry account.
  This role assignment is required to allow users and workloads to run inference using **Azure AI Foundry models beyond Azure OpenAI**, enabling scenarios such as Azure direct models in the orchestration layer.

**Deployment manifest and component updates (solution alignment with latest features):**

* Updated the overall deployment version to `v2.3.0` in `infra/manifest.json`.
* Updated component versions in `infra/manifest.json` to incorporate recent platform and feature updates:

  * `gpt-rag-mcp` to `v0.3.4`
  * `gpt-rag-orchestrator` to `v2.3.0` (including support for Azure direct models)
  * `gpt-rag-ingestion` to `v2.1.0`, with the release field added (including **SharePoint Lists support**)

These updates collectively ensure the solution is compatible with the latest AI Foundry capabilities, particularly non–Azure OpenAI model usage in orchestration and enhanced ingestion scenarios.