### PR TITLE
Cosmos DB container updates for conversation history feature

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -2051,9 +2051,10 @@ module cosmosDBAccount 'br/public:avm/res/document-db/database-account:0.15.1' =
         containers: [
           for container in databaseContainersList: {
             name: container.name
-            paths: ['/id']
+            paths: [container.partitionKey]
             defaultTtl: -1
             throughput: 400
+            indexingPolicy: contains(container, 'indexingPolicy') ? container.indexingPolicy : null
           }
         ]
       }

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -143,19 +143,41 @@
       "value": [
         {
           "name": "conversations",
-          "canonical_name": "CONVERSATIONS_DATABASE_CONTAINER"
+          "canonical_name": "CONVERSATIONS_DATABASE_CONTAINER",
+          "partitionKey": "/principal_id",
+          "indexingPolicy": {
+            "compositeIndexes": [
+              [
+                { "path": "/isDeleted", "order": "Ascending" },
+                { "path": "/_ts", "order": "Descending" }
+              ],
+              [
+                { "path": "/isDeleted", "order": "Ascending" },
+                { "path": "/name", "order": "Ascending" },
+                { "path": "/_ts", "order": "Descending" }
+              ]
+            ]
+          }
         },
         {
           "name": "datasources",
-          "canonical_name": "DATASOURCES_DATABASE_CONTAINER"
+          "canonical_name": "DATASOURCES_DATABASE_CONTAINER",
+          "partitionKey": "/id"
         },
         {
           "name": "prompts",
-          "canonical_name": "PROMPTS_CONTAINER"
+          "canonical_name": "PROMPTS_CONTAINER",
+          "partitionKey": "/id"
         },
         {
           "name": "mcp",
-          "canonical_name": "MCP_CONTAINER"
+          "canonical_name": "MCP_CONTAINER",
+          "partitionKey": "/id"
+        },
+        {
+          "name": "chainlit_users",
+          "canonical_name": "USERS_DATABASE_CONTAINER",
+          "partitionKey": "/identifier"
         }
       ]
     },
@@ -192,6 +214,7 @@
           "roles": [
             "AppConfigurationDataReader",
             "AcrPull",
+            "CosmosDBBuiltInDataContributor",
             "StorageBlobDataReader",
             "StorageBlobDelegator",
             "KeyVaultSecretsUser"


### PR DESCRIPTION

This pull request updates the CosmosDB container configuration and parameters to support custom partition keys and indexing policies, improving data organization and query performance. The changes also add a new database container for users and enhance role assignments for resource access.

CosmosDB container configuration improvements:

* Updated the `cosmosDBAccount` module in `infra/main.bicep` to use custom partition keys from the container definitions, and to optionally apply custom indexing policies if provided.

Parameter enhancements for database containers:

* Modified `infra/main.parameters.json` to specify partition keys for each container, including new keys for `conversations`, `datasources`, `prompts`, `mcp`, and a new `chainlit_users` container.
* Added composite indexing policies for the `conversations` container to optimize queries by `isDeleted`, `_ts`, and `name` fields.

Access control updates:

* Added the `CosmosDBBuiltInDataContributor` role to resource role assignments, enabling enhanced access to CosmosDB data.