### PR TITLE
fix: make postProvision.sh venv cleanup non-fatal — closes #426

### DIFF
--- a/scripts/postProvision.sh
+++ b/scripts/postProvision.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Ensure the temporary venv is always cleaned up, even on early exits.
+# Cleanup failures must never cause the post-provision hook to report failure.
+cleanup() {
+  deactivate 2>/dev/null || true
+  rm -rf config/.venv_temp 2>/dev/null || true
+}
+trap cleanup EXIT
+
 echo "🔧 Running post-provision steps..."
 echo
 
@@ -140,8 +149,12 @@ echo "🔍 AI Search setup…"
 ###############################################################################
 echo
 echo "🧹 Cleaning Python environment up…"
-deactivate
-rm -rf config/.venv_temp
+# `deactivate` only restores shell variables (PATH, PS1) — it deletes nothing.
+# Since the script is ending, there is nothing to restore. We skip it and
+# go straight to removing the venv directory.
+# python3's shutil.rmtree handles locked files and open __pycache__ handles
+# (common on macOS with Python 3.12+) without raising, unlike `rm -rf`.
+python3 -c "import shutil; shutil.rmtree('config/.venv_temp', ignore_errors=True)"
 
 echo
 echo "✅ postProvisioning completed."


### PR DESCRIPTION
The cleanup block at the end of postProvision.sh fails under set -euo pipefail when rm -rf cannot remove the Python 3.14 venv directory on macOS (file handles still held by recently completed python -m invocations).

- Add trap EXIT handler to ensure cleanup runs even on early script exits
- Replace rm -rf with python3 shutil.rmtree (handles locked files gracefully)
- Skip deactivate at script end (no shell state to restore)

Brings postProvision.sh to parity with the care already applied in postProvision.ps1, which has its cleanup commented out for the same reason.

## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

## Contributing guidelines

Please see [Contributing Guidelines](https://azure.github.io/GPT-RAG/contributing) before creating your Pull Request.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Related Backlog Item or Issue

If applicable, provide a link to the relevant backlog item or issue.

## Is this change disruptive or does it break existing applications?

If deploying this change could impact existing applications, please specify.

- [ ] Yes
- [ ] No

## Cross-Repository Dependencies

If this change depends on pull requests in other repositories within the solution, provide the links below.

- [ ] [gpt-rag-orchestrator](https://github.com/azure/gpt-rag-orchestrator)
- [ ] [gpt-rag-ingestion](https://github.com/azure/gpt-rag-ingestion)
- [ ] [gpt-rag-ui](https://github.com/azure/gpt-rag-ui)
- [ ] [gpt-rag-mcp](https://github.com/azure/gpt-rag-mcp)

## Does this require changes to project documentation?

If the changes add new functionality, update the documentation accordingly.

- [ ] Yes
- [ ] No

## Documentation Link

If this change adds a new functionality, provide a link to its documentation.

## Code quality checklist

- [ ] I verified the changes locally to ensure they work as expected
- [ ] I have tested the new functionality and ensured existing features still work
- [ ] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request