### PR TITLE
docs: rebuild gh-pages on releases

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,42 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - docs
+
+  # Rebuild when a new stable release or pre-release is published,
+  # since the home page shows release metadata baked at build time.
+  release:
+    types:
+      - published
+      - released
+      - prereleased
+
+  # Allow triggering a rebuild manually from the Actions UI.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: docs
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install MkDocs and dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force --clean --remote-branch gh-pages


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of project documentation. The workflow is triggered on pushes to the `docs` branch, new releases, and manual dispatches, and it builds and deploys documentation to GitHub Pages.

Documentation deployment automation:

* Added a `.github/workflows/deploy-docs.yml` workflow that checks out the repository, sets up Python, installs documentation dependencies, and deploys documentation to the `gh-pages` branch using MkDocs.
* Configured triggers for the workflow to run on pushes to the `docs` branch, new releases (including pre-releases), and manual workflow dispatches.
* Set permissions to allow the workflow to write to repository contents, required for deployment.