### PR TITLE
Fix #422: Improve Architecture Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,25 @@ GPT-RAG is built on a Zero-Trust architecture to ensure that all components oper
 ## Architecture
 
 ![Zero Trust Architecture](media/architecture_zero_trust.png)
-*Zero-Trust Architecture*
+*Zero-Trust Architecture — full deployment with all optional modules enabled*
+
+### Required vs. Optional Modules
+
+The diagram above shows a complete deployment. In practice, many components are optional. The table below clarifies what is needed for a minimal deployment versus what can be added incrementally.
+
+| Component | Required | Notes |
+|-----------|----------|-------|
+| **Azure OpenAI** | ✅ Required | Core LLM for generation |
+| **Azure AI Search** | ✅ Required | Retrieval index |
+| **gpt-rag-orchestrator** | ✅ Required | Query orchestration and agent logic |
+| **gpt-rag-ingestion** | ✅ Required | Document chunking and indexing pipeline |
+| **gpt-rag-ui** | ⬜ Optional | Reference chat UI — bring your own front-end instead |
+| **Zero-Trust / AI Landing Zone** | ⬜ Optional | Recommended for production; not needed for PoC/dev |
+| **Document-level security (ACL/RBAC)** | ⬜ Optional | Enable when per-user data trimming is required |
+| **SharePoint / Lists connector** | ⬜ Optional | Add when SharePoint is a data source |
+| **NL2SQL / MCP strategies** | ⬜ Optional | Advanced agent strategies; enable per use case |
+
+> **Start small.** A working RAG solution requires only the four core components. Add optional modules as your requirements evolve.
 
 ## AI Agent Capabilities
 


### PR DESCRIPTION
Closes #422

Adds a "Required vs. Optional Modules" section to `README.md` (after line 29) to address confusion caused by the all-modules architecture diagram. The existing `architecture_zero_trust.png` caption is updated to explicitly label it as a full deployment, and a new table maps each component (`Azure OpenAI`, `Azure AI Search`, `gpt-rag-orchestrator`, `gpt-rag-ingestion`, `gpt-rag-ui`, Zero-Trust/AI LZA, document-level security, SharePoint connector, NL2SQL/MCP strategies) to a Required/Optional status with brief rationale. A callout block reinforces the minimal four-component starting point.

- `README.md` — caption update at the `Zero-Trust Architecture` image reference; new table and blockquote inserted in the `## Architecture` section.

Verified by rendering the Markdown locally and confirming the table displays correctly, all checkmarks render as intended, and the section flows logically between the architecture diagram and the `## AI Agent Capabilities` heading.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*