### PR TITLE
docs: add v2.7.0 + v2.6.7 entries to whatisnew, link AILZ parameterization in deploy

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,6 +4,8 @@ Choose your preferred deployment method based on project requirements and enviro
 
 > **Note:** You can change parameter values in `main.parameters.json` or set them with `azd env set` before running `azd provision`. This applies only to parameters that support environment variable substitution.
 
+> **Underlying infrastructure:** GPT-RAG provisions the **[Azure AI Landing Zone (AILZ) Bicep module](https://azure.github.io/AI-Landing-Zones/bicep/parameterization)** as its infrastructure foundation. For the full list of parameters, opt-in features (IP allow-lists, BYO Private DNS / Log Analytics, hub-and-spoke integration, etc.), and the v2 migration path, see the [AILZ parameterization reference](https://azure.github.io/AI-Landing-Zones/bicep/parameterization) and the [v2-migration guide](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/v2.0.0/docs/v2-migration.md).
+
 ## Prerequisites
 
 **Required Permissions:**

--- a/docs/whatisnew.md
+++ b/docs/whatisnew.md
@@ -1,5 +1,26 @@
 > 📌 [Check out what's coming next](https://github.com/orgs/Azure/projects/536/views/6)  (Azure org only)
 
+### May 2026
+
+**[Release 2.7.0](https://github.com/Azure/GPT-RAG/tree/v2.7.0) - AI Landing Zone v2.0 bump**
+
+The underlying Azure AI Landing Zone Bicep module has been upgraded from v1.0.7 to v2.0.2 — a major-version baseline update. Default behavior is unchanged for existing operators; all new capabilities are opt-in via `azd env set`.
+
+Highlights of what v2 brings to GPT-RAG operators:
+
+- **IP allow-listing** (`allowedIpRanges`): uniform CIDR allow-list applied across Storage, Key Vault, App Configuration, Container Registry, Cosmos DB, AI Search, and the AI Foundry storage account.
+- **BYO Private DNS zones / observability / hub-and-spoke** parameters for integration with an existing Azure Landing Zone hub.
+- **Pre-flight validation hook** that catches parameter contradictions before reaching ARM.
+- **Cosmos `enableAnalyticalStorage` fix** — the implicit `true` default that caused intermittent provisioning failures is gone; now an explicit opt-in via `enableCosmosAnalyticalStorage`.
+
+See the [v2-migration guide](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/v2.0.0/docs/v2-migration.md) and the [parameterization reference](https://azure.github.io/AI-Landing-Zones/bicep/parameterization) for the full v2 surface. No GPT-RAG component bumps in this release.
+
+**[Release 2.6.7](https://github.com/Azure/GPT-RAG/tree/v2.6.7) - Per-conversation file uploads**
+
+Users can now upload files directly through the chat interface. Documents are persisted to a per-conversation storage container, chunked and indexed into Azure AI Search with a `conversationId` field, and retrieved by the orchestrator with a filter that mixes conversation-private content with shared/global content. Implemented across coordinated component releases: `gpt-rag-ingestion` v2.3.4, `gpt-rag-orchestrator` v2.6.3, `gpt-rag-ui` v2.3.2.
+
+---
+
 ### April 2026
 
 **[Release 2.6.4](https://github.com/Azure/GPT-RAG/tree/v2.6.4) - Ingestion Enhancements, Ingestion Admin Dashboard, and Cost Optimization**


### PR DESCRIPTION
Adds entries to `whatisnew.md` for the two recent releases and adds a top-level note in `deploy.md` pointing to the AI Landing Zone (AILZ) parameterization reference so we do not duplicate the AILZ docs locally.

- `docs/whatisnew.md` — adds **May 2026** section with v2.7.0 (AILZ v2.0.2 bump) and v2.6.7 (per-conversation file uploads).
- `docs/deploy.md` — adds a callout linking to https://azure.github.io/AI-Landing-Zones/bicep/parameterization and to the v2-migration guide.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>