### PR TITLE
chore: release GPT-RAG v2.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [v2.7.7] - 2026-05-27
 
 ### Changed
 - **Grouped dependency refresh across GPT-RAG components:** bumped `requests` in the core configuration tooling to 2.33.0 and updated the service manifest to consume `gpt-rag-ui` [v2.3.8](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.3.8), `gpt-rag-orchestrator` [v2.6.10](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.6.10), and `gpt-rag-ingestion` [v2.3.8](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.3.8). `gpt-rag-mcp` [v0.3.7](https://github.com/Azure/gpt-rag-mcp/releases/tag/v0.3.7) was released in the same dependency refresh batch; the MCP server remains an optional component and is not listed in the default deployment manifest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- **Grouped dependency refresh across GPT-RAG components:** bumped `requests` in the core configuration tooling to 2.33.0 and updated the service manifest to consume `gpt-rag-ui` [v2.3.8](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.3.8), `gpt-rag-orchestrator` [v2.6.10](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.6.10), and `gpt-rag-ingestion` [v2.3.8](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.3.8). `gpt-rag-mcp` [v0.3.7](https://github.com/Azure/gpt-rag-mcp/releases/tag/v0.3.7) was released in the same dependency refresh batch; the MCP server remains an optional component and is not listed in the default deployment manifest.
+
+### Validation
+The following component versions were validated together for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.8 |
+| gpt-rag-orchestrator | v2.6.10 |
+| gpt-rag-ingestion | v2.3.8 |
+| gpt-rag-mcp | v0.3.7 |
+| infra (landing zone) | v2.0.2 |
+
 ## [v2.7.6] - 2026-05-27
 
 ### Changed

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -13,6 +13,6 @@ azure-mgmt-cognitiveservices==13.6.0
 
 # search
 
-requests==2.32.4
+requests==2.33.0
 azure-keyvault-secrets==4.9.0
 jinja2==3.1.6

--- a/manifest.json
+++ b/manifest.json
@@ -1,22 +1,22 @@
 {
-  "tag": "v2.7.6",
+  "tag": "v2.7.7",
   "repo": "https://github.com/azure/gpt-rag.git",  
   "ailz_tag": "v2.0.2",
   "components": [
     {
       "name": "gpt-rag-ui",
       "repo": "https://github.com/azure/gpt-rag-ui.git",
-      "tag": "v2.3.7"
+      "tag": "v2.3.8"
     },
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v2.6.9"
+      "tag": "v2.6.10"
     },
     {
       "name": "gpt-rag-ingestion",
       "repo": "https://github.com/azure/gpt-rag-ingestion.git",
-      "tag": "v2.3.7"
+      "tag": "v2.3.8"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Publishes GPT-RAG v2.7.7 with the grouped dependency refresh.
- Updates the default service manifest to consume gpt-rag-ui v2.3.8, gpt-rag-orchestrator v2.6.10, and gpt-rag-ingestion v2.3.8.
- Records gpt-rag-mcp v0.3.7 in the tested service versions table for the same dependency refresh batch.
- Bumps the core post-provision/config `requests` dependency to 2.33.0.

## Tested Service Versions
| Component | Version |
| --- | --- |
| gpt-rag-ui | v2.3.8 |
| gpt-rag-orchestrator | v2.6.10 |
| gpt-rag-ingestion | v2.3.8 |
| gpt-rag-mcp | v0.3.7 |
| infra (landing zone) | v2.0.2 |

## Validation
- `python -m json.tool manifest.json`
- clean install of `config/requirements.txt` and verified `requests==2.33.0`
- service release smoke validations were completed before publishing the component tags
- Azure basic deployment validation will be recorded after the umbrella release is published