### PR TITLE
chore: prepare release 2.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [v2.7.7] - 2026-05-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,21 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [v2.7.8] - 2026-05-28
+
+### Changed
+- **Grouped dependency refresh across GPT-RAG components:** updated the service manifest to consume `gpt-rag-ui` [v2.3.9](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.3.9), `gpt-rag-orchestrator` [v2.6.11](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.6.11), and `gpt-rag-ingestion` [v2.4.0](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.4.0). `gpt-rag-mcp` [v0.3.8](https://github.com/Azure/gpt-rag-mcp/releases/tag/v0.3.8) was released in the same dependency refresh batch; the MCP server remains an optional component and is not listed in the default deployment manifest.
+
+### Validation
+The following component versions were validated together for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.9 |
+| gpt-rag-orchestrator | v2.6.11 |
+| gpt-rag-ingestion | v2.4.0 |
+| gpt-rag-mcp | v0.3.8 |
+| infra (landing zone) | v2.0.2 |
 
 ## [v2.7.7] - 2026-05-27
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,22 +1,22 @@
 {
-  "tag": "v2.7.7",
+  "tag": "v2.7.8",
   "repo": "https://github.com/azure/gpt-rag.git",  
   "ailz_tag": "v2.0.2",
   "components": [
     {
       "name": "gpt-rag-ui",
       "repo": "https://github.com/azure/gpt-rag-ui.git",
-      "tag": "v2.3.8"
+      "tag": "v2.3.9"
     },
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v2.6.10"
+      "tag": "v2.6.11"
     },
     {
       "name": "gpt-rag-ingestion",
       "repo": "https://github.com/azure/gpt-rag-ingestion.git",
-      "tag": "v2.3.8"
+      "tag": "v2.4.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Prepare GPT-RAG v2.7.8.
- Bump manifest to gpt-rag-ui v2.3.9, gpt-rag-orchestrator v2.6.11, and gpt-rag-ingestion v2.4.0.
- Document the companion optional gpt-rag-mcp v0.3.8 dependency refresh.

## Validation
- Service dependency changes were validated locally before release; ingestion included targeted PDF/page-splitting and chunking smokes for pypdf 6.10.2 and langchain-text-splitters 1.1.2.
- Fresh Azure Basic validation will be performed on v2.7.8 after the release is published.