### PR TITLE
chore: prepare release 2.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [v2.7.7] - 2026-05-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+
+
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 # Changelog
 
-## [Unreleased]
-
-
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
+
+## [v2.7.9] - 2026-05-28
+
+### Fixed
+- **Ingestion Managed Identity authentication in Azure Container Apps:** bumped `gpt-rag-ingestion` to [v2.4.1](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.4.1), updating `azure-identity` so `/ingest-documents` can authenticate sync Content Understanding, Blob Storage, and embedding paths with user-assigned Managed Identity.
+
+### Validation
+The following component versions were validated together for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.9 |
+| gpt-rag-orchestrator | v2.6.11 |
+| gpt-rag-ingestion | v2.4.1 |
+| gpt-rag-mcp | v0.3.8 |
+| infra (landing zone) | v2.0.2 |
 
 ## [v2.7.8] - 2026-05-28
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "tag": "v2.7.8",
+  "tag": "v2.7.9",
   "repo": "https://github.com/azure/gpt-rag.git",  
   "ailz_tag": "v2.0.2",
   "components": [
@@ -16,7 +16,7 @@
     {
       "name": "gpt-rag-ingestion",
       "repo": "https://github.com/azure/gpt-rag-ingestion.git",
-      "tag": "v2.4.0"
+      "tag": "v2.4.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- prepares GPT-RAG v2.7.9
- bumps gpt-rag-ingestion to v2.4.1 for Container Apps Managed Identity authentication in sync ingestion paths

## Validation
- manifest JSON validated locally
- fresh Azure Basic/no Network Isolation validation will run from the published tag