### PR TITLE
feat: warn about Azure AI Search transient regional capacity in preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Regional preflight: warn about Azure AI Search transient capacity.** `scripts/Invoke-GptRagRegionalPreflight.ps1` now adds a Warn next to the existing PASS for Azure AI Search, mirroring the Cosmos DB pattern. The PASS still confirms regional provider/SKU support, but operators are now explicitly told that pre-create capacity (`InsufficientResourcesAvailable`) is not exposed by a reliable quota API and provisioning may still fail on transient regional saturation. Closes [#470](https://github.com/Azure/GPT-RAG/issues/470).
+
 
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).

--- a/scripts/Invoke-GptRagRegionalPreflight.ps1
+++ b/scripts/Invoke-GptRagRegionalPreflight.ps1
@@ -244,7 +244,10 @@ $deployAiFoundry = Convert-ToBool (Resolve-ParameterValue $parameters.deployAiFo
 
 if ($location) {
     if ($deployVm -and $vmSize) { Test-VmSku -Location $location -VmSize $vmSize }
-    if ($deploySearch) { Test-ProviderLocation -ProviderNamespace 'Microsoft.Search' -ResourceType 'searchServices' -Location $location -DisplayName 'Azure AI Search' }
+    if ($deploySearch) {
+        Test-ProviderLocation -ProviderNamespace 'Microsoft.Search' -ResourceType 'searchServices' -Location $location -DisplayName 'Azure AI Search'
+        Add-Check Warn 'Azure AI Search capacity' "Azure AI Search transient regional capacity (for example InsufficientResourcesAvailable) is not exposed by a reliable pre-create quota API; this preflight validates provider/location support only."
+    }
     if ($deployCosmos) {
         Test-ProviderLocation -ProviderNamespace 'Microsoft.DocumentDB' -ResourceType 'databaseAccounts' -Location $cosmosLocation -DisplayName 'Azure Cosmos DB'
         Add-Check Warn 'Azure Cosmos DB capacity' "Cosmos DB transient regional capacity (for example high-demand ServiceUnavailable) is not exposed by a reliable pre-create quota API; this preflight validates provider/location support only."


### PR DESCRIPTION
Closes #470.

## Summary

Mirrors the Cosmos DB pattern in `scripts/Invoke-GptRagRegionalPreflight.ps1` so the operator is told that the Azure AI Search `[PASS]` only validates provider/location support, not pre-create capacity. Today operators see two `[PASS]` lines for Search/Cosmos with very different real-world reliability — provisioning can still fail with `InsufficientResourcesAvailable`. This aligns the messaging.

## Change

- `scripts/Invoke-GptRagRegionalPreflight.ps1`: after the Search `Test-ProviderLocation` PASS, add an `Add-Check Warn 'Azure AI Search capacity'` mirroring the existing Cosmos DB Warn.
- `CHANGELOG.md`: documented under `[Unreleased] > Changed`.

No functional change to provisioning — the trailing summary `GPT-RAG regional preflight completed with warnings. Provisioning can continue, but Azure may still fail on transient regional capacity.` already covers this case; it just wasn't being triggered for Search.

## Validation

- PowerShell parse check on the updated script: Syntax OK.
- This change only adds an additional `Add-Check Warn` call (same helper used elsewhere); no behavior change beyond the additional warning line and the corresponding non-zero `warnings.Count`.