### PR TITLE
release: v2.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,23 @@
 
 ## [Unreleased]
 
+
+## [v2.7.11] - 2026-05-29
+
 ### Changed
 - **Regional preflight: warn about Azure AI Search transient capacity.** `scripts/Invoke-GptRagRegionalPreflight.ps1` now adds a Warn next to the existing PASS for Azure AI Search, mirroring the Cosmos DB pattern. The PASS still confirms regional provider/SKU support, but operators are now explicitly told that pre-create capacity (`InsufficientResourcesAvailable`) is not exposed by a reliable quota API and provisioning may still fail on transient regional saturation. Closes [#470](https://github.com/Azure/GPT-RAG/issues/470).
+
+### Validation
+The following component versions were validated together for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.9 |
+| gpt-rag-orchestrator | v2.6.11 |
+| gpt-rag-ingestion | v2.4.2 |
+| gpt-rag-mcp | v0.3.8 |
+| infra (landing zone) | v2.0.2 |
+
 
 
 All notable changes to this project will be documented in this file.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [v2.7.7] - 2026-05-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+
+
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Regional preflight: warn about Azure AI Search transient capacity.** `scripts/Invoke-GptRagRegionalPreflight.ps1` now adds a Warn next to the existing PASS for Azure AI Search, mirroring the Cosmos DB pattern. The PASS still confirms regional provider/SKU support, but operators are now explicitly told that pre-create capacity (`InsufficientResourcesAvailable`) is not exposed by a reliable quota API and provisioning may still fail on transient regional saturation. Closes [#470](https://github.com/Azure/GPT-RAG/issues/470).
+
 
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "tag": "v2.7.10",
+  "tag": "v2.7.11",
   "repo": "https://github.com/azure/gpt-rag.git",  
   "ailz_tag": "v2.0.2",
   "components": [

--- a/scripts/Invoke-GptRagRegionalPreflight.ps1
+++ b/scripts/Invoke-GptRagRegionalPreflight.ps1
@@ -244,7 +244,10 @@ $deployAiFoundry = Convert-ToBool (Resolve-ParameterValue $parameters.deployAiFo
 
 if ($location) {
     if ($deployVm -and $vmSize) { Test-VmSku -Location $location -VmSize $vmSize }
-    if ($deploySearch) { Test-ProviderLocation -ProviderNamespace 'Microsoft.Search' -ResourceType 'searchServices' -Location $location -DisplayName 'Azure AI Search' }
+    if ($deploySearch) {
+        Test-ProviderLocation -ProviderNamespace 'Microsoft.Search' -ResourceType 'searchServices' -Location $location -DisplayName 'Azure AI Search'
+        Add-Check Warn 'Azure AI Search capacity' "Azure AI Search transient regional capacity (for example InsufficientResourcesAvailable) is not exposed by a reliable pre-create quota API; this preflight validates provider/location support only."
+    }
     if ($deployCosmos) {
         Test-ProviderLocation -ProviderNamespace 'Microsoft.DocumentDB' -ResourceType 'databaseAccounts' -Location $cosmosLocation -DisplayName 'Azure Cosmos DB'
         Add-Check Warn 'Azure Cosmos DB capacity' "Cosmos DB transient regional capacity (for example high-demand ServiceUnavailable) is not exposed by a reliable pre-create quota API; this preflight validates provider/location support only."


### PR DESCRIPTION
Release v2.7.11.

Includes:
- #470 / #471: regional preflight Warn for Azure AI Search transient capacity.

Component pins (unchanged from v2.7.10):
- gpt-rag-ui v2.3.9
- gpt-rag-orchestrator v2.6.11
- gpt-rag-ingestion v2.4.2
- gpt-rag-mcp v0.3.8
- landing zone v2.0.2