### PR TITLE
chore: consume AI Landing Zone v2.0.14

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "infra"]
 	path = infra
 	url = https://github.com/Azure/bicep-ptn-aiml-landing-zone.git
-	branch = v2.0.13
+	branch = v2.0.14
 	ignore = dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Landing zone submodule bumped to `v2.0.14` and Dapr declared explicitly for GPT-RAG Container Apps.** `manifest.json` `ailz_tag`, `.gitmodules` `branch`, and the recorded `infra/` submodule gitlink now consume the upstream Dapr opt-in change from [Azure/bicep-ptn-aiml-landing-zone#86](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/86). Because GPT-RAG uses Dapr for inter-container service invocation, `main.parameters.json` now sets `dapr.enabled=true` for the orchestrator, frontend, and data ingestion Container Apps, preserving the current runtime behavior while allowing the landing zone default to remain Dapr-disabled for external apps.
+
 
 ## [v2.8.0] - 2026-06-02
 

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -249,6 +249,9 @@
           "min_replicas": 1,
           "max_replicas": 1,
           "canonical_name": "ORCHESTRATOR_APP",
+          "dapr": {
+            "enabled": true
+          },
           "roles": [
             "AppConfigurationDataReader",
             "CognitiveServicesUser",
@@ -267,7 +270,10 @@
           "profile_name": "main",
           "min_replicas": 1,
           "max_replicas": 1,
-          "canonical_name": "FRONTEND_APP",          
+          "canonical_name": "FRONTEND_APP",
+          "dapr": {
+            "enabled": true
+          },
           "roles": [
             "AppConfigurationDataReader",
             "AcrPull",
@@ -286,6 +292,9 @@
           "cpu": "1.0",
           "memory": "3.0Gi",
           "canonical_name": "DATA_INGEST_APP",
+          "dapr": {
+            "enabled": true
+          },
           "roles": [
             "AppConfigurationDataReader",
             "CognitiveServicesUser",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "tag": "v2.8.0",
   "repo": "https://github.com/azure/gpt-rag.git",  
-  "ailz_tag": "v2.0.13",
+  "ailz_tag": "v2.0.14",
   "components": [
     {
       "name": "gpt-rag-ui",


### PR DESCRIPTION
## Summary
- Bumps AI Landing Zone from v2.0.13 to v2.0.14 in manifest.json, .gitmodules, and the infra submodule gitlink.
- Explicitly enables Dapr for the orchestrator, frontend, and data ingestion Container Apps so GPT-RAG keeps inter-container service invocation behavior after the landing zone makes Dapr opt-in by default.
- Adds an Unreleased changelog entry for the bump and Dapr configuration.

## Validation
- python -m json.tool manifest.json
- python -m json.tool main.parameters.json
- az bicep build --file infra\\main.bicep
- azd provision --preview --no-prompt on env gptrag-0604261534
- Confirmed main.parameters.json sets dapr.enabled=true for orchestrator, frontend, and dataingest.

Related: Azure/bicep-ptn-aiml-landing-zone#86