### PR TITLE
feat: add custom_metadata field to RAG index schema (issue #487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`custom_metadata` field on the RAG search index (issue [#487](https://github.com/Azure/GPT-RAG/issues/487)):** Adds a `Collection(Edm.ComplexType)` `custom_metadata` field with `{key, value}` subfields to the RAG index schema in `config/search/search.j2`. The field is filterable and facetable so retrievers can target documents by user-defined blob tags (for example, `$filter=custom_metadata/any(m: m/key eq 'department' and m/value eq 'finance')`). Not included in the semantic configuration's `prioritizedKeywordsFields` to avoid biasing ranking. Pairs with the matching extraction in `gpt-rag-ingestion` (issue [#487](https://github.com/Azure/GPT-RAG/issues/487)); operators must reapply the index schema and reingest existing documents to populate the field.
+
 ## [v2.8.3] - 2026-06-10
 
 ### Fixed

--- a/config/search/search.j2
+++ b/config/search/search.j2
@@ -14,6 +14,14 @@
         { "name": "metadata_security_group_ids",    "type": "Collection(Edm.String)",   "searchable": false, "retrievable": true, "filterable": true, "permissionFilter": "groupIds" },
         { "name": "metadata_security_user_ids",     "type": "Collection(Edm.String)",   "searchable": false, "retrievable": true, "filterable": true, "permissionFilter": "userIds" },
         { "name": "metadata_security_rbac_scope",   "type": "Edm.String",               "searchable": false, "retrievable": true, "filterable": true, "permissionFilter": "rbacScope" },
+        {
+          "name": "custom_metadata",
+          "type": "Collection(Edm.ComplexType)",
+          "fields": [
+            { "name": "key",   "type": "Edm.String", "searchable": false, "retrievable": true, "filterable": true, "facetable": true },
+            { "name": "value", "type": "Edm.String", "searchable": true,  "retrievable": true, "filterable": true, "facetable": true }
+          ]
+        },
         { "name": "chunk_id",                       "type": "Edm.Int32",                "searchable": false, "retrievable": true },
         { "name": "content",                        "type": "Edm.String",               "searchable": true,  "retrievable": true, "analyzer": "{{SEARCH_ANALYZER_NAME}}" },
         { "name": "imageCaptions",                  "type": "Edm.String",               "searchable": true,  "retrievable": true, "analyzer": "{{SEARCH_ANALYZER_NAME}}" },


### PR DESCRIPTION
## Summary

Implements [Azure/GPT-RAG#487](https://github.com/Azure/GPT-RAG/issues/487) on the platform side: adds a single, always-on `custom_metadata` field to the RAG index schema so user-defined blob tags surface in AI Search results.

## What changes

- `config/search/search.j2`: adds a `Collection(Edm.ComplexType)` `custom_metadata` field on the RAG index with `{key, value}` subfields. Both subfields are `retrievable` and `filterable`; `value` is also `searchable` (analyzer-aware) and `facetable`. Inserted after `metadata_security_rbac_scope`, before `chunk_id`.
- The field is intentionally **not** included in `semantic.prioritizedFields.prioritizedKeywordsFields` to avoid biasing semantic ranking by operational tags.
- `CHANGELOG.md`: entry added under a new `[Unreleased]` section on `develop`.

## Architectural decision

A single, always-on field on the index schema. No App Configuration key, no feature flag, no per-deployment toggle. Validated with Martin and approved by the maintainer. The matching ingestion-side extraction lives in `Azure/gpt-rag-ingestion` (companion PR on the same issue, also targeting `develop`).

## Required ingestion version

Requires the matching `gpt-rag-ingestion` PR (issue #487) to actually populate the field. Until both ship together, the field stays empty for newly indexed documents.

## Example query

```
$filter=custom_metadata/any(m: m/key eq 'department' and m/value eq 'finance')
```

The field is also `facetable`, so it can drive faceted navigation.

## Operator note

After upgrading, operators must:

1. Reapply the search index schema (the deploy flow already does this through `config/search/search.j2`).
2. Reingest existing documents to populate `custom_metadata` for back-catalogue blobs. New uploads pick it up automatically.

## Validation

- Template parses to valid JSON after Jinja substitution.
- End-to-end Azure validation (schema reapply + sample upload + filter query) is performed against the maintainer's Standard validation environment as part of the cross-repo rollout.

## Documentation

User-facing documentation will be updated by Steve in a separate PR on the `docs` branch (MkDocs site). Not touched here.

## Target branch

`develop`.
