### PR TITLE
docs(whats-new): rewrite June 2026 entry to cover full release train

### DIFF
--- a/docs/whatisnew.md
+++ b/docs/whatisnew.md
@@ -2,11 +2,9 @@
 
 ### June 2026
 
-**[Release 2.8.2](https://github.com/Azure/GPT-RAG/tree/v2.8.2) - Authenticated uploads and Foundry Agent Service reuse**
+**[Release 2.9.1](https://github.com/Azure/GPT-RAG/tree/v2.9.1) - Authenticated uploads, Foundry Agent Service v2 stabilization, and Sweden Central unblocked**
 
-GPT-RAG now pins `gpt-rag-ui` v2.3.10, `gpt-rag-orchestrator` v2.8.1, `gpt-rag-ingestion` v2.4.3, and AI Landing Zone v2.0.14. Uploaded documents now work end-to-end in authenticated chat: the uploader identity is preserved during ingestion, the active conversation id is propagated during retrieval, and uploaded chunks are indexed with the correct ACL metadata so `single_agent_rag` can retrieve them in the same chat conversation.
-
-The June release train also moves the orchestrator to the Foundry Agent Service v2 create-once/reuse model and updates the landing zone for the Cosmos DB data-plane RBAC assignments required by declarative/versioned Foundry agents. GPT-RAG now explicitly enables Dapr for the orchestrator, frontend, and ingestion Container Apps after the landing zone made Dapr opt-in by default.
+The June release train makes per-conversation uploads work end-to-end in authenticated chat: the uploader identity is preserved during ingestion, the active conversation id flows through retrieval, and uploaded chunks are indexed with ACL metadata so `single_agent_rag` can return them inside the same conversation. The same train stabilizes the orchestrator on the Foundry Agent Service v2 create-once/reuse model, with the landing zone now provisioning the Cosmos DB data-plane RBAC assignments that declarative and versioned Foundry agents require, and Dapr explicitly enabled on the orchestrator, frontend, and ingestion Container Apps after the landing zone switched Dapr to opt-in. The late-June updates also unblock `swedencentral` deployments by fixing the Cosmos analytical storage preflight warning and scoping the Foundry Cosmos data-plane role assignment at the database level, expose the new `custom_metadata` field on RAG search results so retrieval can surface arbitrary blob metadata, and add a defensive warning to the deploy scripts when `APP_CONFIG_ENDPOINT` drifts from the active azd environment.
 
 ---
 


### PR DESCRIPTION
Rewrites the June 2026 `What's New` entry to match the May 2026 style: one cohesive paragraph, no inline pinned-version list, anchored on the latest tag of the month (v2.9.1).

The previous entry only covered v2.8.2 and listed pinned component versions inline, which is the wrong surface for that information per `.github/copilot-instructions.md` (component version tables belong in GitHub release notes, not the marketing/What's New page).

The new entry covers the full June train in a single paragraph:

- authenticated per-conversation uploads working end-to-end (uploader identity, conversation id, ACL metadata, `single_agent_rag` retrieval)
- Foundry Agent Service v2 create-once/reuse model stabilized, with landing zone Cosmos DB data-plane RBAC and Dapr re-enabled on the GPT-RAG Container Apps
- `swedencentral` unblocked via the Cosmos analytical storage preflight fix and Foundry Cosmos data-plane role assignment scoped at the database level
- new `custom_metadata` field exposed on RAG search results
- defensive warning in deploy scripts when `APP_CONFIG_ENDPOINT` drifts from the active azd environment