### PR TITLE
docs(troubleshooting): link stale APP_CONFIG_ENDPOINT note to #491 and v2.9.1

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -97,6 +97,8 @@ To avoid this in the future:
 - Open a fresh terminal when switching between azd environments.
 - If you must set `APP_CONFIG_ENDPOINT` manually (for example, on a jumpbox or in CI), confirm it matches `azd env get-value APP_CONFIG_ENDPOINT` before deploying.
 
+The component deploy scripts also print a yellow warning when the shell `APP_CONFIG_ENDPOINT` and the active azd env disagree, starting with GPT-RAG [v2.9.1](https://github.com/Azure/GPT-RAG/releases/tag/v2.9.1) (orchestrator v2.8.3, ingestion v2.4.4, ui v2.3.11). See [#491](https://github.com/Azure/GPT-RAG/issues/491) for context.
+
 
 **Known Issues and Fixes**
 


### PR DESCRIPTION
Follow-up to #492. Adds a final paragraph linking the stale `APP_CONFIG_ENDPOINT` troubleshooting note to:

- Azure/GPT-RAG#491 (the originating issue)
- The [v2.9.1 release](https://github.com/Azure/GPT-RAG/releases/tag/v2.9.1) where the deploy-script warning shipped (orchestrator v2.8.3, ingestion v2.4.4, ui v2.3.11).