### PR TITLE
release: v2.9.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [v2.9.16] - 2026-06-19
+
+### User and operator impact
+
+Patch release that bumps the orchestrator pin from [`v2.8.11`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.8.11) to [`v2.8.12`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.8.12). No other component changed: UI, ingestion, and AI Landing Zone pins are identical to v2.9.15. The orchestrator update is a P1 follow-up on the operator dashboard's Overview and Conversations tabs: the Custom range date inputs now cap at today and clamp any stored future date on load; the `to=YYYY-MM-DD` query parameter is now inclusive of the entire end day instead of stopping at midnight UTC; Overview tooltips render on an opaque background so they are readable over the cards behind them; the Conversations dialog reconstructs user turns from the persisted prompts (with a friendly note pointing to the Azure AI Foundry agent thread for the full transcript) instead of showing empty cards; and the Configuration tab's *Reload settings cache* button is renamed to *Refresh from App Configuration* with sentence-case info tooltips on both footer buttons explaining what each one does. See [Azure/gpt-rag-orchestrator#246](https://github.com/Azure/gpt-rag-orchestrator/pull/246).
+
+### Changed
+
+- **Orchestrator pin bumped to [`v2.8.12`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.8.12):** Operator-reported follow-up on the dashboard Overview and Conversations tabs. Caps Custom range date inputs at today (UTC), makes the `to` parameter end-of-day inclusive, rejects future ranges with HTTP 400, gives tooltips an opaque background, reconstructs conversation detail from persisted prompts with a Foundry deep-link note, and clarifies the Configuration tab button labels and tooltips.
+
+- **UI pin unchanged:** [`v2.3.13`](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.3.13).
+- **Ingestion pin unchanged:** [`v2.4.13`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.4.13).
+- **Infra (AI Landing Zone) pin unchanged:** [`v2.0.20`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.20).
+
+### Validation
+
+The following component versions are pinned for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.13 |
+| gpt-rag-orchestrator | v2.8.12 |
+| gpt-rag-ingestion | v2.4.13 |
+| AI Landing Zone | v2.0.20 |
+
 ## [v2.9.15] - 2026-06-19
 
 ### User and operator impact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [v2.9.15] - 2026-06-19
+
+### User and operator impact
+
+Patch release that bumps the ingestion pin from [`v2.4.12`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.4.12) to [`v2.4.13`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.4.13). No other component changed: UI, orchestrator, and AI Landing Zone pins are identical to v2.9.14. The ingestion update is a P2 follow-up on the operator dashboard Jobs tab: the *Run now* button strip and the *Queue and schedule* table have moved off the Jobs tab into a new dedicated **Schedules** tab (tab order is now *Jobs | Schedules | Files | Configuration*), and the "Started <job>" success toast now auto-dismisses after 4 seconds and gets a manual close button so it no longer sits on screen forever. See [Azure/gpt-rag-ingestion#254](https://github.com/Azure/gpt-rag-ingestion/pull/254).
+
+### Changed
+
+- **Ingestion pin bumped to [`v2.4.13`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.4.13):** Operator-reported follow-up on the Jobs tab. Relocates the *Run now* strip and *Queue and schedule* table to a new *Schedules* tab so the Jobs tab stays focused on the recent-runs history; makes the *Run now* success toast auto-dismiss after 4 seconds with a manual close button so it no longer stays on screen forever.
+
+- **UI pin unchanged:** [`v2.3.13`](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.3.13).
+- **Orchestrator pin unchanged:** [`v2.8.11`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.8.11).
+- **Infra (AI Landing Zone) pin unchanged:** [`v2.0.20`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.20).
+
+### Validation
+
+The following component versions are pinned for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.13 |
+| gpt-rag-orchestrator | v2.8.11 |
+| gpt-rag-ingestion | v2.4.13 |
+| bicep-ptn-aiml-landing-zone | v2.0.20 |
 ## [v2.9.14] - 2026-06-19
 
 ### User and operator impact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [v2.9.14] - 2026-06-19
+
+### User and operator impact
+
+Patch release that bumps the orchestrator pin from [`v2.8.10`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.8.10) to [`v2.8.11`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.8.11). No other component changed: UI, ingestion, and AI Landing Zone pins are identical to v2.9.13. The orchestrator update is a P2 follow-up against the Overview tab dashboard shipped in v2.8.10: it stops the info tooltips from rendering in ALL CAPS, fixes the Active users metric so anonymous traffic counts as a single bucket instead of one user per conversation, and makes the Custom range chip immediately reveal the From/To date inputs without zeroing the chart. See [Azure/gpt-rag-orchestrator#241](https://github.com/Azure/gpt-rag-orchestrator/issues/241) for the operator report.
+
+### Changed
+
+- **Orchestrator pin bumped to [`v2.8.11`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v2.8.11):** Operator-reported follow-up to v2.8.10. Three Overview tab fixes: tooltip sentence case, anonymous user bucketing in the Active users metric, and a visible Custom range editor that keeps the chart populated.
+
+- **UI pin unchanged:** [`v2.3.13`](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.3.13).
+- **Ingestion pin unchanged:** [`v2.4.12`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.4.12).
+- **Infra (AI Landing Zone) pin unchanged:** [`v2.0.20`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.20).
+
+### Validation
+
+The following component versions are pinned for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.13 |
+| gpt-rag-orchestrator | v2.8.11 |
+| gpt-rag-ingestion | v2.4.12 |
+| bicep-ptn-aiml-landing-zone | v2.0.20 |
 ## [v2.9.13] - 2026-06-19
 
 ### User and operator impact

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "tag": "v2.9.14",
+  "tag": "v2.9.15",
   "repo": "https://github.com/azure/gpt-rag.git",
   "ailz_tag": "v2.0.20",
   "components": [
@@ -16,7 +16,7 @@
     {
       "name": "gpt-rag-ingestion",
       "repo": "https://github.com/azure/gpt-rag-ingestion.git",
-      "tag": "v2.4.12"
+      "tag": "v2.4.13"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "tag": "v2.9.15",
+  "tag": "v2.9.16",
   "repo": "https://github.com/azure/gpt-rag.git",
   "ailz_tag": "v2.0.20",
   "components": [
@@ -11,7 +11,7 @@
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v2.8.11"
+      "tag": "v2.8.12"
     },
     {
       "name": "gpt-rag-ingestion",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "tag": "v2.9.13",
+  "tag": "v2.9.14",
   "repo": "https://github.com/azure/gpt-rag.git",
   "ailz_tag": "v2.0.20",
   "components": [
@@ -11,7 +11,7 @@
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v2.8.10"
+      "tag": "v2.8.11"
     },
     {
       "name": "gpt-rag-ingestion",


### PR DESCRIPTION
Bump orchestrator pin from v2.8.11 to v2.8.12 (dashboard Overview and Conversations fixes). Other pins unchanged. See CHANGELOG.