### PR TITLE
v3.0.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "infra"]
 	path = infra
 	url = https://github.com/Azure/bicep-ptn-aiml-landing-zone.git
-	branch = v2.1.3
+	branch = v2.1.4
 	ignore = dirty
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v3.0.5] - 2026-06-27
+
+### User and operator impact
+
+Zero Trust deployments with Foundry IQ now work end to end. `v3.0.4` left ZT blocked on [bicep-ptn-aiml-landing-zone#110](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/110), where Foundry capability host creation failed during `azd provision` with `AmlRp BadRequest: "Invalid vnet resource ID provided"` because the capability host subnet delegation was emitted as `Microsoft.app` instead of `Microsoft.App`. AI Landing Zone [`v2.1.4`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.1.4) fixes the casing, and `v3.0.5` consumes that pin. ZT operators no longer need to opt down to `RETRIEVAL_BACKEND=ai_search`.
+
+### Changed
+
+- **AI Landing Zone Bicep module pin bumped to [`v2.1.4`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.1.4):** `manifest.json`, `.gitmodules`, and the `infra` submodule HEAD are all aligned on `v2.1.4`. Picks up the capability host subnet delegation casing fix that unblocks ZT + Foundry IQ.
+
+The following component versions are pinned for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.13 |
+| gpt-rag-orchestrator | v3.0.2 |
+| gpt-rag-ingestion | v2.4.13 |
+| bicep-ptn-aiml-landing-zone | v2.1.4 |
+
 ## [v3.0.4] - 2026-06-26
 
 ### User and operator impact

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "tag": "v3.0.4",
+  "tag": "v3.0.5",
   "repo": "https://github.com/azure/gpt-rag.git",
-  "ailz_tag": "v2.1.3",
+  "ailz_tag": "v2.1.4",
   "components": [
     {
       "name": "gpt-rag-ui",


### PR DESCRIPTION
Releases GPT-RAG v3.0.5.

## Summary

Bumps the AI Landing Zone pin to [2.1.4](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.1.4), which fixes capability host subnet delegation casing (Microsoft.app -> Microsoft.App). This unblocks Zero Trust deployments with Foundry IQ. v3.0.4 documented ZT as blocked on [bicep-ptn-aiml-landing-zone#110](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/110); that issue is fixed in AILZ v2.1.4 and consumed here.

## Changes

- `manifest.json`: `tag` -> `v3.0.5`, `ailz_tag` -> `v2.1.4`
- `.gitmodules`: infra submodule `branch` -> `v2.1.4`
- `infra` submodule pointer -> `v2.1.4`
- `CHANGELOG.md`: new `v3.0.5` entry

Other component pins unchanged: orchestrator `v3.0.2`, ingestion `v2.4.13`, ui `v2.3.13`.

## Validation

ZT `azd provision` green in ~65 min against AILZ fix branch. No AmlRp errors. Validation RG `rg-gptrag-zt-fix06270745`.