### PR TITLE
feat(foundry-iq): serve UI file uploads in Pattern A (v3.2.0)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "infra"]
 	path = infra
 	url = https://github.com/Azure/bicep-ptn-aiml-landing-zone.git
-	branch = v2.2.0
+	branch = v2.3.0
 	ignore = dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [v3.2.0] - 2026-07-02
+
+### User and operator impact
+
+Foundry IQ deployments using Pattern A (`FOUNDRY_IQ_PATTERN=azureBlob`) can now also serve documents that users upload through the chat UI, in the same conversation, without switching retrieval backends. When you turn the feature on, the search setup provisions a second, conversational knowledge source over the existing RAG index (`ragindex-<token>`) and adds it to the Foundry IQ knowledge base. Uploaded files are indexed with a `conversationId`, and the orchestrator (pinned here to [`v3.1.0`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v3.1.0)) scopes that conversational source per conversation at query time, so one user's upload never leaks into another conversation.
+
+The feature is opt-in and defaults to off. Set `FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED=true` before `azd provision` to enable it. With the flag off (the default), the rendered search resources and deployed behavior are identical to `v3.1.0`, so existing environments upgrade with no change. The feature only applies to Pattern A; the `searchIndex` pattern (Pattern B) never adds the conversational source because file upload already works there.
+
+Fresh deployments also consume [AI Landing Zone `v2.3.0`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.3.0), which adds a generic App Configuration passthrough so accelerators can push their own settings into App Config without the landing zone needing to know about them.
+
+### Added
+
+- **Conversational file upload knowledge source for Foundry IQ Pattern A:** When `RETRIEVAL_BACKEND=foundry_iq`, the pattern is not `searchIndex`, and `FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED=true`, `config/search/search.j2` renders a second `searchIndex` knowledge source over `SEARCH_RAG_INDEX_NAME` (semantic config `semantic-config`) and references it from the knowledge base alongside the primary `azureBlob` source. The conversational source name defaults to `<ragIndexName>-conv-ks` and can be overridden with `FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME`.
+- **New passthrough settings:** `scripts/postProvision.ps1` and `config/search/search.settings.j2` stamp `FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED` (default `false`) and `FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME` (default `<ragIndexName>-conv-ks`) into App Configuration under the `gpt-rag` label, so both new and upgraded environments always carry the keys.
+- **Template tests:** `config/search/tests/test_foundry_iq_templates.py` covers the feature off (single source), on (blob plus conversational source, knowledge base references both), and the `searchIndex` pattern guard (no conversational source added).
+
+### Changed
+
+- **AI Landing Zone Bicep module pin bumped to [`v2.3.0`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.3.0):** `manifest.json`, `.gitmodules`, and the `infra` submodule HEAD are aligned on the landing-zone release that adds the generic App Configuration passthrough.
+- **Orchestrator pin bumped to [`v3.1.0`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v3.1.0):** carries the hybrid multi-source retrieval that reads the conversational knowledge source and applies the per-`conversationId` filter add-on at query time. Required for conversational file upload to work end to end.
+
+### Validation
+
+- `pytest config/search/tests/test_foundry_iq_templates.py` passes (8 tests), covering the conversational source on/off behavior, the knowledge base references, and the `searchIndex` pattern guard.
+- With `FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED` unset or `false`, the rendered `search.j2` output is unchanged from `v3.1.0` (single knowledge source, single knowledge base reference), so the default deployment is byte-identical.
+
+The following component versions are pinned for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.13 |
+| gpt-rag-orchestrator | v3.1.0 |
+| gpt-rag-ingestion | v2.4.14 |
+| bicep-ptn-aiml-landing-zone | v2.3.0 |
+
 ## [v3.1.0] - 2026-07-01
 
 ### User and operator impact

--- a/config/search/search.j2
+++ b/config/search/search.j2
@@ -1,6 +1,7 @@
 {% set is_foundry_iq_standard_blob = RETRIEVAL_BACKEND == 'foundry_iq' and FOUNDRY_IQ_PATTERN != 'searchIndex' and FOUNDRY_IQ_CONTENT_EXTRACTION_MODE == 'standard' %}
 {% set content_understanding_chat_models = ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'gpt-4o-mini', 'gpt-5.2'] %}
 {% set is_content_understanding_chat_model_supported = GPT_MODEL_INFO and GPT_MODEL_INFO.model_name in content_understanding_chat_models %}
+{% set conversation_upload_enabled = RETRIEVAL_BACKEND == 'foundry_iq' and FOUNDRY_IQ_PATTERN != 'searchIndex' and (FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED | default('false') | string | lower) in ['true', '1', 'yes', 'y', 't'] and (FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME | default('', true)) %}
 {
   "indexes": [
     {
@@ -386,6 +387,30 @@
       }
     }
     {% endif %}
+    {% if conversation_upload_enabled %},
+    {
+      "name": "{{FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME}}",
+      "kind": "searchIndex",
+      "description": "Conversational file upload knowledge source (searchIndex over RAG index, scoped per conversation at query time)",
+      "encryptionKey": null,
+      "searchIndexParameters": {
+        "searchIndexName": "{{SEARCH_RAG_INDEX_NAME}}",
+        "semanticConfigurationName": "semantic-config",
+        "sourceDataFields": [
+          { "name": "metadata_storage_name" },
+          { "name": "metadata_storage_path" },
+          { "name": "filepath" },
+          { "name": "page" },
+          { "name": "title" },
+          { "name": "category" },
+          { "name": "url" }
+        ],
+        "searchFields": [
+          { "name": "*" }
+        ]
+      }
+    }
+    {% endif %}
   ]{% else %}[]{% endif %},
   "knowledgeBases": {% if RETRIEVAL_BACKEND == 'foundry_iq' %}[
     {
@@ -395,7 +420,8 @@
       "answerInstructions": null,
       "outputMode": "extractiveData",
       "knowledgeSources": [
-        { "name": "{{FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME}}" }
+        { "name": "{{FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME}}" }{% if conversation_upload_enabled %},
+        { "name": "{{FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME}}" }{% endif %}
       ],
       "models": [],
       "encryptionKey": null,

--- a/config/search/search.settings.j2
+++ b/config/search/search.settings.j2
@@ -25,6 +25,8 @@
     "FOUNDRY_IQ_KNOWLEDGE_RETRIEVAL_BILLING_PLAN": "{{FOUNDRY_IQ_KNOWLEDGE_RETRIEVAL_BILLING_PLAN | default('free')}}",
     "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "{{FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME | default(search_rag_index_name ~ ('-rag-ks' if foundry_iq_pattern == 'searchIndex' else '-blob-ks'), true)}}",
     "FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND": "{{FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND | default('searchIndex' if foundry_iq_pattern == 'searchIndex' else 'azureBlob', true)}}",
+    "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED": "{{FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED | default('false')}}",
+    "FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME": "{{FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME | default(search_rag_index_name ~ '-conv-ks', true)}}",
     "FOUNDRY_IQ_STORAGE_CONTAINER_NAME": "{{FOUNDRY_IQ_STORAGE_CONTAINER_NAME | default('documents')}}",
     "FOUNDRY_IQ_STORAGE_FOLDER_PATH": "{{FOUNDRY_IQ_STORAGE_FOLDER_PATH | default('')}}",
     "FOUNDRY_IQ_IS_ADLS_GEN2": "{{FOUNDRY_IQ_IS_ADLS_GEN2 | default('false')}}",

--- a/config/search/setup.py
+++ b/config/search/setup.py
@@ -442,8 +442,9 @@ def cleanup_knowledge_resources(defs: dict, context: dict, cred: ChainedTokenCre
     knowledge_sources = list(defs.get("knowledgeSources", []))
     search_index_ks_name = f"{context.get('SEARCH_RAG_INDEX_NAME')}-rag-ks"
     blob_ks_name = f"{context.get('SEARCH_RAG_INDEX_NAME')}-blob-ks"
+    conversation_ks_name = context.get("FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME") or f"{context.get('SEARCH_RAG_INDEX_NAME')}-conv-ks"
     existing_ks_names = {ks["name"] for ks in knowledge_sources if ks.get("name")}
-    for name in (search_index_ks_name, blob_ks_name):
+    for name in (search_index_ks_name, blob_ks_name, conversation_ks_name):
         if name and name not in existing_ks_names:
             knowledge_sources.append({"name": name})
             existing_ks_names.add(name)

--- a/config/search/tests/test_foundry_iq_templates.py
+++ b/config/search/tests/test_foundry_iq_templates.py
@@ -179,5 +179,131 @@ class FoundryIqTemplateTests(unittest.TestCase):
         get.assert_not_called()
 
 
+    def test_conversation_upload_disabled_by_default_keeps_single_knowledge_source(self):
+        settings = render_json_template(
+            "search.settings.j2",
+            {
+                "RESOURCE_TOKEN": "abc123",
+                "SEARCH_SERVICE_QUERY_ENDPOINT": "https://search.search.windows.net",
+                "AI_FOUNDRY_ACCOUNT_NAME": "aif-abc123",
+                "RETRIEVAL_BACKEND": "foundry_iq",
+            },
+        )
+        self.assertEqual(settings["FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED"], "false")
+        self.assertEqual(
+            settings["FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME"],
+            "ragindex-abc123-conv-ks",
+        )
+
+        context = {
+            **settings,
+            "STORAGE_ACCOUNT_RESOURCE_ID": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/st",
+            "EMBEDDING_MODEL_INFO": {
+                "endpoint": "https://aif-abc123.openai.azure.com/",
+                "deployment_name": "text-embedding",
+                "model_name": "text-embedding-3-large",
+            },
+            "GPT_MODEL_INFO": {
+                "deployment_name": "chat",
+                "model_name": "gpt-5-nano",
+            },
+        }
+
+        search_definitions = render_json_template("search.j2", context)
+        self.assertEqual(len(search_definitions["knowledgeSources"]), 1)
+        self.assertEqual(
+            search_definitions["knowledgeSources"][0]["kind"], "azureBlob"
+        )
+        self.assertEqual(
+            len(search_definitions["knowledgeBases"][0]["knowledgeSources"]), 1
+        )
+
+    def test_conversation_upload_enabled_adds_conversational_search_index_source(self):
+        settings = render_json_template(
+            "search.settings.j2",
+            {
+                "RESOURCE_TOKEN": "abc123",
+                "SEARCH_SERVICE_QUERY_ENDPOINT": "https://search.search.windows.net",
+                "AI_FOUNDRY_ACCOUNT_NAME": "aif-abc123",
+                "RETRIEVAL_BACKEND": "foundry_iq",
+                "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED": "true",
+            },
+        )
+        self.assertEqual(settings["FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED"], "true")
+
+        context = {
+            **settings,
+            "STORAGE_ACCOUNT_RESOURCE_ID": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/st",
+            "EMBEDDING_MODEL_INFO": {
+                "endpoint": "https://aif-abc123.openai.azure.com/",
+                "deployment_name": "text-embedding",
+                "model_name": "text-embedding-3-large",
+            },
+            "GPT_MODEL_INFO": {
+                "deployment_name": "chat",
+                "model_name": "gpt-5-nano",
+            },
+        }
+
+        search_definitions = render_json_template("search.j2", context)
+        knowledge_sources = search_definitions["knowledgeSources"]
+        self.assertEqual(len(knowledge_sources), 2)
+        self.assertEqual(knowledge_sources[0]["kind"], "azureBlob")
+
+        conv_source = knowledge_sources[1]
+        self.assertEqual(conv_source["name"], "ragindex-abc123-conv-ks")
+        self.assertEqual(conv_source["kind"], "searchIndex")
+        self.assertEqual(
+            conv_source["searchIndexParameters"]["searchIndexName"],
+            "ragindex-abc123",
+        )
+        self.assertEqual(
+            conv_source["searchIndexParameters"]["semanticConfigurationName"],
+            "semantic-config",
+        )
+
+        kb_sources = search_definitions["knowledgeBases"][0]["knowledgeSources"]
+        self.assertEqual(
+            [s["name"] for s in kb_sources],
+            ["ragindex-abc123-blob-ks", "ragindex-abc123-conv-ks"],
+        )
+
+    def test_conversation_upload_not_added_for_search_index_pattern(self):
+        settings = render_json_template(
+            "search.settings.j2",
+            {
+                "RESOURCE_TOKEN": "abc123",
+                "SEARCH_SERVICE_QUERY_ENDPOINT": "https://search.search.windows.net",
+                "AI_FOUNDRY_ACCOUNT_NAME": "aif-abc123",
+                "RETRIEVAL_BACKEND": "foundry_iq",
+                "FOUNDRY_IQ_PATTERN": "searchIndex",
+                "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED": "true",
+            },
+        )
+
+        context = {
+            **settings,
+            "STORAGE_ACCOUNT_RESOURCE_ID": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/st",
+            "EMBEDDING_MODEL_INFO": {
+                "endpoint": "https://aif-abc123.openai.azure.com/",
+                "deployment_name": "text-embedding",
+                "model_name": "text-embedding-3-large",
+            },
+            "GPT_MODEL_INFO": {
+                "deployment_name": "chat",
+                "model_name": "gpt-5-nano",
+            },
+        }
+
+        search_definitions = render_json_template("search.j2", context)
+        self.assertEqual(len(search_definitions["knowledgeSources"]), 1)
+        self.assertEqual(
+            search_definitions["knowledgeSources"][0]["kind"], "searchIndex"
+        )
+        self.assertEqual(
+            len(search_definitions["knowledgeBases"][0]["knowledgeSources"]), 1
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "tag": "v3.1.0",
+  "tag": "v3.2.0",
   "repo": "https://github.com/azure/gpt-rag.git",
-  "ailz_tag": "v2.2.0",
+  "ailz_tag": "v2.3.0",
   "components": [
     {
       "name": "gpt-rag-ui",
@@ -11,7 +11,7 @@
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v3.0.4"
+      "tag": "v3.1.0"
     },
     {
       "name": "gpt-rag-ingestion",

--- a/scripts/postProvision.ps1
+++ b/scripts/postProvision.ps1
@@ -358,6 +358,13 @@ function Set-GptRagAppConfiguration {
     }
     $effectiveKnowledgeBaseName = if ($retrievalBackend -eq 'foundry_iq') { $knowledgeBaseName } else { '' }
 
+    $foundryIqConversationKnowledgeSourceName = if ($retrievalBackend -eq 'foundry_iq') {
+        Get-OptionalEnvValue 'FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME' "$ragIndexName-conv-ks"
+    }
+    else {
+        ''
+    }
+
     $settings = [ordered]@{
         AZURE_TENANT_ID = $tenantId
         SUBSCRIPTION_ID = $subscriptionId
@@ -385,6 +392,8 @@ function Set-GptRagAppConfiguration {
         FOUNDRY_IQ_FILTER_ADD_ON_ENABLED = (Get-OptionalEnvValue 'FOUNDRY_IQ_FILTER_ADD_ON_ENABLED' 'false')
         FOUNDRY_IQ_SECURITY_FIELD_NAME = (Get-OptionalEnvValue 'FOUNDRY_IQ_SECURITY_FIELD_NAME' 'metadata_security_id')
         FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS = (Get-OptionalEnvValue 'FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS')
+        FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED = (Get-OptionalEnvValue 'FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED' 'false')
+        FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME = $foundryIqConversationKnowledgeSourceName
         NETWORK_ISOLATION = (Get-OptionalEnvValue 'NETWORK_ISOLATION' 'false')
         USE_UAI = (Get-OptionalEnvValue 'USE_UAI' 'false')
         USE_CAPP_API_KEY = (Get-OptionalEnvValue 'USE_CAPP_API_KEY' 'false')


### PR DESCRIPTION
## Summary

Adds an opt-in **conversational knowledge source** so Foundry IQ **Pattern A** (`azureBlob`) deployments can also serve documents that users upload through the chat UI, in the same conversation, without switching retrieval backends.

When enabled, `config/search/setup.py` provisions a second `searchIndex` knowledge source over the existing RAG index (`ragindex-<token>`) and adds it to the Foundry IQ knowledge base. Uploaded files are indexed with a `conversationId`, and the orchestrator (pinned to `v3.1.0`) scopes that source per conversation at query time via the filter add-on, so one user's upload never leaks into another conversation.

## Opt-in and backward compatible

- Off by default. Set `FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED=true` before `azd provision` to enable.
- With the flag off (default), the rendered search resources and deployed behavior are **byte-identical to `v3.1.0`**. Existing environments upgrade with no change.
- Only applies to Pattern A. The `searchIndex` pattern (Pattern B) never adds the conversational source (file upload already works there).

## Changes

- **`config/search/search.j2`**: render the conversational `searchIndex` knowledge source over `SEARCH_RAG_INDEX_NAME` and reference it from the knowledge base when the feature is enabled and the pattern is not `searchIndex`.
- **`config/search/search.settings.j2`** and **`scripts/postProvision.ps1`**: stamp `FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED` (default `false`) and `FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME` (default `<ragIndex>-conv-ks`) into App Configuration under the `gpt-rag` label. (`postProvision.sh` untouched.)
- **`config/search/setup.py`**: include the conversational source name in cleanup so toggling the feature off removes the orphaned knowledge source.
- **`config/search/tests/test_foundry_iq_templates.py`**: cover feature on/off and the `searchIndex` pattern guard.
- **`manifest.json` / `.gitmodules` / `infra` submodule**: bump AI Landing Zone pin `v2.2.0` -> `v2.3.0` (generic App Configuration passthrough) and orchestrator pin `v3.0.4` -> `v3.1.0` (hybrid multi-source retrieval).
- **`CHANGELOG.md`**: `v3.2.0` entry.

## Validation

- `pytest config/search/tests/test_foundry_iq_templates.py` passes (8 tests): conversational source on/off, knowledge base references, and the `searchIndex` pattern guard.
- With the flag unset/`false`, `search.j2` output is unchanged from `v3.1.0` (single knowledge source, single KB reference).

## Component versions

| Component | Version |
| --- | --- |
| gpt-rag-ui | v2.3.13 |
| gpt-rag-orchestrator | v3.1.0 |
| gpt-rag-ingestion | v2.4.14 |
| bicep-ptn-aiml-landing-zone | v2.3.0 |
