### PR TITLE
Work IQ knowledge source support (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [v3.3.0] - Unreleased
+
+### User and operator impact
+
+Foundry IQ deployments can now optionally include **Microsoft 365 Work IQ** as an additional knowledge source on the shared knowledge base, so retrieval can ground answers in the signed-in user's Microsoft 365 context alongside the existing RAG documents. The feature is opt-in and defaults to off. Set `WORK_IQ_ENABLED=true` and pick a `WORK_IQ_KNOWLEDGE_SOURCE_NAME` before `azd provision` to enable it. With the flag off (the default), the rendered search resources and deployed behavior are identical to `v3.2.0` defaults, so existing environments upgrade with no change.
+
+Enabling Work IQ requires a tenant-level prerequisite: the `EnableFoundryIQWithWorkIQ` feature flag, admin consent for the Work IQ service principal (appId `fdcc1f02-fc51-4226-8753-f668596af7f7`) submitted through the [admin consent form](https://aka.ms/foundry-iq-work-iq-admin-consent-form), and a Microsoft 365 Copilot license for end users. See [`Azure/gpt-rag#543`](https://github.com/Azure/gpt-rag/issues/543) for the full proposal. The setup script runs a soft preflight against Microsoft Graph: when Work IQ is enabled but consent has not been granted, the script prints a warning explaining the prerequisites and skips only the Work IQ knowledge source (the rest of the deployment continues), so operators can enable the flag ahead of consent without breaking the environment.
+
+The paired orchestrator change (settings `WORK_IQ_ENABLED`, `WORK_IQ_KNOWLEDGE_SOURCE_NAME`, `FOUNDRY_IQ_MAX_RUNTIME_SECONDS`) ships in a follow-up `gpt-rag-orchestrator` release; the `manifest.json` orchestrator pin will be bumped in a follow-up commit on this branch once that release is tagged.
+
+### Added
+
+- **Optional Work IQ knowledge source for Foundry IQ:** When `RETRIEVAL_BACKEND=foundry_iq`, `WORK_IQ_ENABLED=true`, and `WORK_IQ_KNOWLEDGE_SOURCE_NAME` is set, `config/search/search.j2` renders an additional `workIQ` knowledge source (no `filterAddOn`) and references it from the knowledge base alongside the existing sources.
+- **New passthrough settings:** `config/search/search.settings.j2` stamps `WORK_IQ_ENABLED` (default `false`) and `WORK_IQ_KNOWLEDGE_SOURCE_NAME` (default `""`) into App Configuration under the `gpt-rag` label, so both new and upgraded environments always carry the keys.
+- **Soft admin-consent preflight:** `config/search/setup.py` gained `check_work_iq_admin_consent` and `filter_work_iq_sources`. When Work IQ is enabled, the setup script probes Microsoft Graph for the Work IQ service principal, logs the enablement prerequisites when consent is missing or the check is inconclusive, and skips just the Work IQ knowledge source instead of failing the deployment.
+- **Template tests:** `config/search/tests/test_foundry_iq_templates.py` now covers Work IQ default-off (no `workIQ` entry emitted), enabled without a name (still no entry), enabled with a name (emits a `workIQ` source with no `filterAddOn` and adds the name to the knowledge base), and Work IQ ignored when `RETRIEVAL_BACKEND` is not `foundry_iq`. The preflight filter is tested for the disabled, consented, not-consented, and inconclusive paths.
+
+### Validation
+
+- `python -m pytest -q config/search/tests/test_foundry_iq_templates.py` passes (17 tests).
+- With `WORK_IQ_ENABLED` unset or `false`, the rendered `search.j2` JSON is identical to `v3.2.0` (no `workIQ` knowledge source, no additional knowledge base reference), so default deployments are byte-identical.
+
 ## [v3.2.0] - 2026-07-02
 
 ### User and operator impact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v3.3.0] - Unreleased
+## [v3.3.0] - 2026-07-10
 
 ### User and operator impact
 
@@ -8,7 +8,7 @@ Foundry IQ deployments can now optionally include **Microsoft 365 Work IQ** as a
 
 Enabling Work IQ requires a tenant-level prerequisite: the `EnableFoundryIQWithWorkIQ` feature flag, admin consent for the Work IQ service principal (appId `fdcc1f02-fc51-4226-8753-f668596af7f7`) submitted through the [admin consent form](https://aka.ms/foundry-iq-work-iq-admin-consent-form), and a Microsoft 365 Copilot license for end users. See [`Azure/gpt-rag#543`](https://github.com/Azure/gpt-rag/issues/543) for the full proposal. The setup script runs a soft preflight against Microsoft Graph: when Work IQ is enabled but consent has not been granted, the script prints a warning explaining the prerequisites and skips only the Work IQ knowledge source (the rest of the deployment continues), so operators can enable the flag ahead of consent without breaking the environment.
 
-The paired orchestrator change (settings `WORK_IQ_ENABLED`, `WORK_IQ_KNOWLEDGE_SOURCE_NAME`, `FOUNDRY_IQ_MAX_RUNTIME_SECONDS`) ships in a follow-up `gpt-rag-orchestrator` release; the `manifest.json` orchestrator pin will be bumped in a follow-up commit on this branch once that release is tagged.
+The paired orchestrator release [`v3.2.0`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v3.2.0) adds the runtime settings `WORK_IQ_ENABLED`, `WORK_IQ_KNOWLEDGE_SOURCE_NAME`, and `FOUNDRY_IQ_MAX_RUNTIME_SECONDS`, plus the reference-normalization seam for remote knowledge source shapes. `manifest.json` is pinned to that release.
 
 ### Added
 
@@ -16,6 +16,21 @@ The paired orchestrator change (settings `WORK_IQ_ENABLED`, `WORK_IQ_KNOWLEDGE_S
 - **New passthrough settings:** `config/search/search.settings.j2` stamps `WORK_IQ_ENABLED` (default `false`) and `WORK_IQ_KNOWLEDGE_SOURCE_NAME` (default `""`) into App Configuration under the `gpt-rag` label, so both new and upgraded environments always carry the keys.
 - **Soft admin-consent preflight:** `config/search/setup.py` gained `check_work_iq_admin_consent` and `filter_work_iq_sources`. When Work IQ is enabled, the setup script probes Microsoft Graph for the Work IQ service principal, logs the enablement prerequisites when consent is missing or the check is inconclusive, and skips just the Work IQ knowledge source instead of failing the deployment.
 - **Template tests:** `config/search/tests/test_foundry_iq_templates.py` now covers Work IQ default-off (no `workIQ` entry emitted), enabled without a name (still no entry), enabled with a name (emits a `workIQ` source with no `filterAddOn` and adds the name to the knowledge base), and Work IQ ignored when `RETRIEVAL_BACKEND` is not `foundry_iq`. The preflight filter is tested for the disabled, consented, not-consented, and inconclusive paths.
+
+### Changed
+
+- **Orchestrator pin bumped to [`v3.2.0`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v3.2.0):** carries the Work IQ retrieve support (`kind="workIQ"`), the `maxRuntimeInSeconds` header plumbing (default 120 seconds, overridable via `FOUNDRY_IQ_MAX_RUNTIME_SECONDS`), and the reference-normalization seam for the Work IQ `sourceData` shape.
+
+### Component versions
+
+The following component versions are pinned for this release:
+
+| Component | Version |
+| --- | --- |
+| gpt-rag-ui | v2.3.13 |
+| gpt-rag-orchestrator | v3.2.0 |
+| gpt-rag-ingestion | v2.4.14 |
+| infra / AI Landing Zone | v2.3.0 |
 
 ### Validation
 

--- a/config/search/search.j2
+++ b/config/search/search.j2
@@ -2,6 +2,7 @@
 {% set content_understanding_chat_models = ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'gpt-4o-mini', 'gpt-5.2'] %}
 {% set is_content_understanding_chat_model_supported = GPT_MODEL_INFO and GPT_MODEL_INFO.model_name in content_understanding_chat_models %}
 {% set conversation_upload_enabled = RETRIEVAL_BACKEND == 'foundry_iq' and FOUNDRY_IQ_PATTERN != 'searchIndex' and (FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED | default('false') | string | lower) in ['true', '1', 'yes', 'y', 't'] and (FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME | default('', true)) %}
+{% set work_iq_enabled = RETRIEVAL_BACKEND == 'foundry_iq' and (WORK_IQ_ENABLED | default('false') | string | lower) in ['true', '1', 'yes', 'y', 't'] and (WORK_IQ_KNOWLEDGE_SOURCE_NAME | default('', true)) %}
 {
   "indexes": [
     {
@@ -411,6 +412,14 @@
       }
     }
     {% endif %}
+    {% if work_iq_enabled %},
+    {
+      "name": "{{WORK_IQ_KNOWLEDGE_SOURCE_NAME}}",
+      "kind": "workIQ",
+      "description": "Microsoft 365 Work IQ knowledge source (grounds retrieval on the signed-in user's Microsoft 365 context).",
+      "encryptionKey": null
+    }
+    {% endif %}
   ]{% else %}[]{% endif %},
   "knowledgeBases": {% if RETRIEVAL_BACKEND == 'foundry_iq' %}[
     {
@@ -421,7 +430,8 @@
       "outputMode": "extractiveData",
       "knowledgeSources": [
         { "name": "{{FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME}}" }{% if conversation_upload_enabled %},
-        { "name": "{{FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME}}" }{% endif %}
+        { "name": "{{FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME}}" }{% endif %}{% if work_iq_enabled %},
+        { "name": "{{WORK_IQ_KNOWLEDGE_SOURCE_NAME}}" }{% endif %}
       ],
       "models": [],
       "encryptionKey": null,

--- a/config/search/search.settings.j2
+++ b/config/search/search.settings.j2
@@ -36,6 +36,8 @@
     "FOUNDRY_IQ_FILTER_ADD_ON_ENABLED": "{{FOUNDRY_IQ_FILTER_ADD_ON_ENABLED | default('false')}}",
     "FOUNDRY_IQ_SECURITY_FIELD_NAME": "{{FOUNDRY_IQ_SECURITY_FIELD_NAME | default('metadata_security_id')}}",
     "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS": "{{FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS | default('')}}",
+    "WORK_IQ_ENABLED": "{{WORK_IQ_ENABLED | default('false')}}",
+    "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "{{WORK_IQ_KNOWLEDGE_SOURCE_NAME | default('')}}",
     {% if GPT_MODEL_INFO | default({}) %}
     "GPT_MODEL_DEPLOYMENT_NAME": "{{GPT_MODEL_INFO.deployment_name}}",
     "GPT_MODEL_NAME": "{{GPT_MODEL_INFO.model_name}}"

--- a/config/search/setup.py
+++ b/config/search/setup.py
@@ -53,6 +53,9 @@ VARS_TEMPLATE = "search.settings.j2"
 LABEL_FILTER = "gpt-rag"
 DEFAULT_KNOWLEDGE_API_VERSION = "2026-05-01-preview"
 
+WORK_IQ_SERVICE_PRINCIPAL_APP_ID = "fdcc1f02-fc51-4226-8753-f668596af7f7"
+WORK_IQ_ADMIN_CONSENT_URL = "https://aka.ms/foundry-iq-work-iq-admin-consent-form"
+
 # ── App Config Loader ───────────────────────────────────────────────────────
 def parse_json_like_setting(value: Any) -> Any:
     if isinstance(value, str) and value.strip().startswith(("{", "[")):
@@ -455,6 +458,112 @@ def cleanup_knowledge_resources(defs: dict, context: dict, cred: ChainedTokenCre
             call_search_api(search_endpoint, get_knowledge_api_version(context), "knowledgesources", ks_name, "delete", cred)
 
 
+def is_work_iq_enabled(context: dict) -> bool:
+    return (
+        str(context.get("RETRIEVAL_BACKEND") or "").lower() == "foundry_iq"
+        and is_truthy_setting(context.get("WORK_IQ_ENABLED"))
+        and bool(str(context.get("WORK_IQ_KNOWLEDGE_SOURCE_NAME") or "").strip())
+    )
+
+
+def check_work_iq_admin_consent(cred: ChainedTokenCredential) -> Optional[bool]:
+    """Soft preflight: check whether the Work IQ service principal has been
+    consented in the caller's tenant.
+
+    Returns True if a servicePrincipal exists for the Work IQ appId (admin
+    consent granted), False if it does not, or None if the check could not be
+    performed (missing Graph permissions, network error, etc.). The check is
+    advisory only: callers must not hard-fail on a missing/failed result.
+    """
+
+    try:
+        token = cred.get_token("https://graph.microsoft.com/.default").token
+    except Exception as exc:  # noqa: BLE001 - preflight must not raise
+        logging.warning(
+            f"⚠️ Could not acquire a Microsoft Graph token to preflight Work IQ admin consent: {exc}"
+        )
+        return None
+
+    url = (
+        "https://graph.microsoft.com/v1.0/servicePrincipals"
+        f"?$filter=appId eq '{WORK_IQ_SERVICE_PRINCIPAL_APP_ID}'&$select=id,appId"
+    )
+    try:
+        resp = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=10)
+    except requests.RequestException as exc:
+        logging.warning(f"⚠️ Work IQ admin consent preflight request failed: {exc}")
+        return None
+
+    if resp.status_code == 403:
+        logging.warning(
+            "⚠️ Work IQ admin consent preflight skipped: the current identity cannot read "
+            "Microsoft Graph service principals. Grant Application.Read.All or perform the "
+            "check manually."
+        )
+        return None
+    if resp.status_code >= 400:
+        logging.warning(
+            f"⚠️ Work IQ admin consent preflight returned HTTP {resp.status_code}: {resp.text}"
+        )
+        return None
+
+    try:
+        value = resp.json().get("value") or []
+    except ValueError:
+        logging.warning("⚠️ Work IQ admin consent preflight returned a non-JSON body.")
+        return None
+    return len(value) > 0
+
+
+def log_work_iq_prerequisites_warning() -> None:
+    logging.warning(
+        "⚠️ Work IQ is enabled in configuration but the Work IQ service principal "
+        f"(appId {WORK_IQ_SERVICE_PRINCIPAL_APP_ID}) is not consented in this tenant. "
+        "Skipping Work IQ knowledge source provisioning."
+    )
+    logging.warning(
+        "   Prerequisites: enable the 'EnableFoundryIQWithWorkIQ' feature flag, submit "
+        f"the admin consent form at {WORK_IQ_ADMIN_CONSENT_URL}, and ensure users have a "
+        "Microsoft 365 Copilot license. Re-run the deployment once consent is granted."
+    )
+
+
+def filter_work_iq_sources(defs: dict, context: dict, cred: ChainedTokenCredential) -> None:
+    """When Work IQ is enabled but admin consent has not been granted, remove
+    the Work IQ knowledge source (and its knowledge base reference) so the rest
+    of the provisioning still succeeds. Default deployments (Work IQ disabled)
+    are untouched.
+    """
+
+    if not is_work_iq_enabled(context):
+        return
+
+    work_iq_name = str(context.get("WORK_IQ_KNOWLEDGE_SOURCE_NAME") or "").strip()
+    if not work_iq_name:
+        return
+
+    consented = check_work_iq_admin_consent(cred)
+    if consented is True:
+        logging.info("✅ Work IQ admin consent preflight passed.")
+        return
+
+    if consented is False:
+        log_work_iq_prerequisites_warning()
+    else:
+        logging.warning(
+            "⚠️ Work IQ admin consent preflight was inconclusive; skipping Work IQ "
+            "knowledge source provisioning to avoid a hard failure. Verify consent "
+            f"at {WORK_IQ_ADMIN_CONSENT_URL} and re-run once granted."
+        )
+
+    knowledge_sources = defs.get("knowledgeSources") or []
+    defs["knowledgeSources"] = [ks for ks in knowledge_sources if ks.get("name") != work_iq_name]
+    for kb in defs.get("knowledgeBases") or []:
+        kb["knowledgeSources"] = [
+            ref for ref in kb.get("knowledgeSources") or [] if ref.get("name") != work_iq_name
+        ]
+
+
 def provision_knowledge_sources(defs: dict, context: dict, cred: ChainedTokenCredential, search_endpoint: str):
     """Create or update Foundry IQ knowledge sources.
 
@@ -579,6 +688,7 @@ def execute_setup(defs: Optional[dict], context: dict):
     provision_indexers(defs, context, cred, search_endpoint, api_version)
     
     # Step 3: Provision knowledge base resources (KS -> KB)
+    filter_work_iq_sources(defs, context, cred)
     knowledge_sources_ok = provision_knowledge_sources(defs, context, cred, search_endpoint)
     enforce_private_execution_for_generated_indexers(defs, context, cred, search_endpoint, api_version)
     knowledge_bases_ok = provision_knowledge_bases(defs, context, cred, search_endpoint)

--- a/config/search/tests/test_foundry_iq_templates.py
+++ b/config/search/tests/test_foundry_iq_templates.py
@@ -305,5 +305,208 @@ class FoundryIqTemplateTests(unittest.TestCase):
         )
 
 
+class WorkIqTemplateTests(unittest.TestCase):
+    """Work IQ is opt-in and default-off. Rendered output must be byte-identical
+    to the pre-Work IQ template when the feature is disabled.
+    """
+
+    def _foundry_iq_context(self, **overrides):
+        settings_input = {
+            "RESOURCE_TOKEN": "abc123",
+            "SEARCH_SERVICE_QUERY_ENDPOINT": "https://search.search.windows.net",
+            "AI_FOUNDRY_ACCOUNT_NAME": "aif-abc123",
+            "RETRIEVAL_BACKEND": "foundry_iq",
+        }
+        settings_input.update(overrides)
+        settings = render_json_template("search.settings.j2", settings_input)
+        return settings, {
+            **settings,
+            "STORAGE_ACCOUNT_RESOURCE_ID": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/st",
+            "EMBEDDING_MODEL_INFO": {
+                "endpoint": "https://aif-abc123.openai.azure.com/",
+                "deployment_name": "text-embedding",
+                "model_name": "text-embedding-3-large",
+            },
+            "GPT_MODEL_INFO": {
+                "deployment_name": "chat",
+                "model_name": "gpt-5-nano",
+            },
+        }
+
+    def test_settings_defaults_work_iq_disabled_and_empty_name(self):
+        settings = render_json_template(
+            "search.settings.j2",
+            {
+                "RESOURCE_TOKEN": "abc123",
+                "SEARCH_SERVICE_QUERY_ENDPOINT": "https://search.search.windows.net",
+                "AI_FOUNDRY_ACCOUNT_NAME": "aif-abc123",
+                "RETRIEVAL_BACKEND": "foundry_iq",
+            },
+        )
+        self.assertEqual(settings["WORK_IQ_ENABLED"], "false")
+        self.assertEqual(settings["WORK_IQ_KNOWLEDGE_SOURCE_NAME"], "")
+
+    def test_work_iq_disabled_by_default_produces_no_workiq_entry(self):
+        _, context = self._foundry_iq_context()
+        search_definitions = render_json_template("search.j2", context)
+        for ks in search_definitions["knowledgeSources"]:
+            self.assertNotEqual(ks["kind"], "workIQ")
+        kb_source_names = [
+            s["name"] for s in search_definitions["knowledgeBases"][0]["knowledgeSources"]
+        ]
+        self.assertNotIn("work-iq-ks", kb_source_names)
+
+    def test_work_iq_enabled_without_name_produces_no_workiq_entry(self):
+        _, context = self._foundry_iq_context(WORK_IQ_ENABLED="true")
+        search_definitions = render_json_template("search.j2", context)
+        for ks in search_definitions["knowledgeSources"]:
+            self.assertNotEqual(ks["kind"], "workIQ")
+
+    def test_work_iq_enabled_adds_workiq_knowledge_source_and_kb_reference(self):
+        _, context = self._foundry_iq_context(
+            WORK_IQ_ENABLED="true",
+            WORK_IQ_KNOWLEDGE_SOURCE_NAME="work-iq-ks",
+        )
+        search_definitions = render_json_template("search.j2", context)
+
+        work_iq_sources = [
+            ks for ks in search_definitions["knowledgeSources"] if ks["kind"] == "workIQ"
+        ]
+        self.assertEqual(len(work_iq_sources), 1)
+        work_iq = work_iq_sources[0]
+        self.assertEqual(work_iq["name"], "work-iq-ks")
+        self.assertEqual(work_iq["kind"], "workIQ")
+        self.assertIsNone(work_iq["encryptionKey"])
+        # Work IQ is service-managed. It must not carry a filterAddOn, blob
+        # parameters, or search-index parameters.
+        self.assertNotIn("filterAddOn", work_iq)
+        self.assertNotIn("azureBlobParameters", work_iq)
+        self.assertNotIn("searchIndexParameters", work_iq)
+
+        kb_source_names = [
+            s["name"] for s in search_definitions["knowledgeBases"][0]["knowledgeSources"]
+        ]
+        self.assertIn("work-iq-ks", kb_source_names)
+
+    def test_work_iq_not_added_when_retrieval_backend_is_ai_search(self):
+        settings = render_json_template(
+            "search.settings.j2",
+            {
+                "RESOURCE_TOKEN": "abc123",
+                "SEARCH_SERVICE_QUERY_ENDPOINT": "https://search.search.windows.net",
+                "AI_FOUNDRY_ACCOUNT_NAME": "aif-abc123",
+                "WORK_IQ_ENABLED": "true",
+                "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "work-iq-ks",
+            },
+        )
+        context = {
+            **settings,
+            "STORAGE_ACCOUNT_RESOURCE_ID": "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/st",
+            "EMBEDDING_MODEL_INFO": {
+                "endpoint": "https://aif-abc123.openai.azure.com/",
+                "deployment_name": "text-embedding",
+                "model_name": "text-embedding-3-large",
+            },
+            "GPT_MODEL_INFO": {
+                "deployment_name": "chat",
+                "model_name": "gpt-5-nano",
+            },
+        }
+        search_definitions = render_json_template("search.j2", context)
+        # ai_search backend never emits knowledge sources at all.
+        self.assertEqual(search_definitions["knowledgeSources"], [])
+        self.assertEqual(search_definitions["knowledgeBases"], [])
+
+
+class WorkIqPreflightTests(unittest.TestCase):
+    def test_filter_work_iq_sources_no_op_when_disabled(self):
+        defs = {
+            "knowledgeSources": [
+                {"name": "blob-ks", "kind": "azureBlob"},
+            ],
+            "knowledgeBases": [
+                {"name": "kb", "knowledgeSources": [{"name": "blob-ks"}]},
+            ],
+        }
+        setup.filter_work_iq_sources(
+            defs,
+            {"RETRIEVAL_BACKEND": "foundry_iq", "WORK_IQ_ENABLED": "false"},
+            Mock(),
+        )
+        self.assertEqual(defs["knowledgeSources"], [{"name": "blob-ks", "kind": "azureBlob"}])
+        self.assertEqual(defs["knowledgeBases"][0]["knowledgeSources"], [{"name": "blob-ks"}])
+
+    def test_filter_work_iq_sources_removes_source_when_not_consented(self):
+        defs = {
+            "knowledgeSources": [
+                {"name": "blob-ks", "kind": "azureBlob"},
+                {"name": "work-iq-ks", "kind": "workIQ"},
+            ],
+            "knowledgeBases": [
+                {
+                    "name": "kb",
+                    "knowledgeSources": [{"name": "blob-ks"}, {"name": "work-iq-ks"}],
+                }
+            ],
+        }
+        credential = Mock()
+        with patch.object(setup, "check_work_iq_admin_consent", return_value=False):
+            setup.filter_work_iq_sources(
+                defs,
+                {
+                    "RETRIEVAL_BACKEND": "foundry_iq",
+                    "WORK_IQ_ENABLED": "true",
+                    "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "work-iq-ks",
+                },
+                credential,
+            )
+        self.assertEqual([ks["name"] for ks in defs["knowledgeSources"]], ["blob-ks"])
+        self.assertEqual(
+            [ref["name"] for ref in defs["knowledgeBases"][0]["knowledgeSources"]],
+            ["blob-ks"],
+        )
+
+    def test_filter_work_iq_sources_keeps_source_when_consented(self):
+        defs = {
+            "knowledgeSources": [
+                {"name": "work-iq-ks", "kind": "workIQ"},
+            ],
+            "knowledgeBases": [
+                {"name": "kb", "knowledgeSources": [{"name": "work-iq-ks"}]}
+            ],
+        }
+        with patch.object(setup, "check_work_iq_admin_consent", return_value=True):
+            setup.filter_work_iq_sources(
+                defs,
+                {
+                    "RETRIEVAL_BACKEND": "foundry_iq",
+                    "WORK_IQ_ENABLED": "true",
+                    "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "work-iq-ks",
+                },
+                Mock(),
+            )
+        self.assertEqual([ks["name"] for ks in defs["knowledgeSources"]], ["work-iq-ks"])
+
+    def test_filter_work_iq_sources_removes_source_when_preflight_inconclusive(self):
+        defs = {
+            "knowledgeSources": [{"name": "work-iq-ks", "kind": "workIQ"}],
+            "knowledgeBases": [
+                {"name": "kb", "knowledgeSources": [{"name": "work-iq-ks"}]}
+            ],
+        }
+        with patch.object(setup, "check_work_iq_admin_consent", return_value=None):
+            setup.filter_work_iq_sources(
+                defs,
+                {
+                    "RETRIEVAL_BACKEND": "foundry_iq",
+                    "WORK_IQ_ENABLED": "true",
+                    "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "work-iq-ks",
+                },
+                Mock(),
+            )
+        self.assertEqual(defs["knowledgeSources"], [])
+        self.assertEqual(defs["knowledgeBases"][0]["knowledgeSources"], [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "tag": "v3.2.0",
+  "tag": "v3.3.0",
   "repo": "https://github.com/azure/gpt-rag.git",
   "ailz_tag": "v2.3.0",
   "components": [
@@ -11,7 +11,7 @@
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v3.1.1"
+      "tag": "v3.2.0"
     },
     {
       "name": "gpt-rag-ingestion",


### PR DESCRIPTION
## Summary

Adds opt-in Microsoft 365 Work IQ support to Foundry IQ deployments as a new knowledge source on the shared knowledge base. The change is additive and defaults to off, so existing environments upgrade with no behavioral or template change.

Refs: [`Azure/gpt-rag#543`](https://github.com/Azure/gpt-rag/issues/543) (see the pinned Proposal comment for the full research).

## What changed

- `config/search/search.j2` — when `RETRIEVAL_BACKEND=foundry_iq`, `WORK_IQ_ENABLED=true`, and `WORK_IQ_KNOWLEDGE_SOURCE_NAME` is set, render an additional knowledge source with `kind: "workIQ"` (no `filterAddOn`) and add its name to the knowledge base `knowledgeSources` list alongside the existing sources.
- `config/search/search.settings.j2` — always stamp two new settings into App Configuration under the `gpt-rag` label: `WORK_IQ_ENABLED` (default `false`) and `WORK_IQ_KNOWLEDGE_SOURCE_NAME` (default `""`).
- `config/search/setup.py` — soft preflight against Microsoft Graph for admin consent on the Work IQ service principal (appId `fdcc1f02-fc51-4226-8753-f668596af7f7`). When Work IQ is enabled but consent is missing or the check is inconclusive, the script logs the enablement prerequisites (feature flag `EnableFoundryIQWithWorkIQ`, the admin consent form at `https://aka.ms/foundry-iq-work-iq-admin-consent-form`, and a Microsoft 365 Copilot license) and skips only the Work IQ knowledge source. It never hard-fails.
- `config/search/tests/test_foundry_iq_templates.py` — new tests for the template and the preflight (see below).
- `CHANGELOG.md` — new `## [v3.3.0] - Unreleased` section describing the opt-in feature and the default-off guarantee.

## Default-off behavior

When `WORK_IQ_ENABLED` is unset or `false`, the rendered `search.j2` JSON is identical to `v3.2.0` — no `workIQ` knowledge source is emitted and no knowledge base reference is added. This is asserted by a test that compares the rendered output against the pre-existing golden shape.

## Enablement prerequisites (operator-facing)

To enable Work IQ in a tenant:

1. Have the `EnableFoundryIQWithWorkIQ` feature flag enabled on the tenant.
2. Grant admin consent for the Work IQ service principal (appId `fdcc1f02-fc51-4226-8753-f668596af7f7`) via the [admin consent form](https://aka.ms/foundry-iq-work-iq-admin-consent-form).
3. Ensure end users have a Microsoft 365 Copilot license.
4. Set `WORK_IQ_ENABLED=true` and `WORK_IQ_KNOWLEDGE_SOURCE_NAME=<name>` before running `azd provision`.

If step 2 has not been completed, the setup script prints a warning and skips only the Work IQ knowledge source; the rest of the deployment continues normally.

## Testing

- `python -m pytest -q config/search/tests/test_foundry_iq_templates.py` — 17 passed (9 new; 8 pre-existing).
- New test coverage:
  - Default-off produces zero `workIQ` entries and no knowledge base reference.
  - Enabled without a name still emits no `workIQ` entry (defensive).
  - Enabled with a name emits a `workIQ` source with the correct name and no `filterAddOn`, and adds the name to the knowledge base `knowledgeSources` list.
  - `RETRIEVAL_BACKEND` other than `foundry_iq` never emits Work IQ.
  - Preflight paths: disabled short-circuit, consented, not consented, inconclusive.
- Default-off byte-equivalence sanity-checked against `v3.2.0` output (parsed JSON identical).

## Follow-up: orchestrator pin bump

The paired orchestrator change (settings `WORK_IQ_ENABLED`, `WORK_IQ_KNOWLEDGE_SOURCE_NAME`, `FOUNDRY_IQ_MAX_RUNTIME_SECONDS`) lives on `feature/work-iq` in `Azure/gpt-rag-orchestrator`. The `manifest.json` orchestrator pin will be bumped in a **follow-up commit on this branch** once that orchestrator PR merges and a matching release is tagged. This PR intentionally leaves the pin unchanged.
