### PR TITLE
feat(search): register Fabric IQ (fabricOntology) knowledge source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Added
 
+- **Fabric IQ (Microsoft Fabric ontology) knowledge source support (opt-in, default off).**
+  Foundry IQ deployments can now optionally include a Microsoft Fabric
+  ontology as an additional knowledge source on the shared knowledge base,
+  so retrieval can ground answers in a Fabric semantic model, lakehouse,
+  warehouse, or KQL database exposed through the ontology, alongside
+  existing RAG documents and Work IQ. Feature is opt-in via the App
+  Configuration keys `FABRIC_IQ_ENABLED`, `FABRIC_IQ_KNOWLEDGE_SOURCE_NAME`,
+  `FABRIC_IQ_WORKSPACE_ID`, and `FABRIC_IQ_ONTOLOGY_ID`. With the flag off
+  (the default), the rendered search resources and deployed behavior are
+  identical to the `v3.3.0` defaults, so existing environments upgrade with
+  no change. Requires a Microsoft Fabric workspace with an ontology item,
+  tenant-level Fabric ontology enablement, Fabric-licensed end users, and
+  the same Entra tenant as the Foundry / Search resource. See
+  [`Azure/gpt-rag#543`](https://github.com/Azure/gpt-rag/issues/543).
+
 ### Changed
 
 ### Fixed

--- a/config/search/search.j2
+++ b/config/search/search.j2
@@ -3,6 +3,7 @@
 {% set is_content_understanding_chat_model_supported = GPT_MODEL_INFO and GPT_MODEL_INFO.model_name in content_understanding_chat_models %}
 {% set conversation_upload_enabled = RETRIEVAL_BACKEND == 'foundry_iq' and FOUNDRY_IQ_PATTERN != 'searchIndex' and (FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED | default('false') | string | lower) in ['true', '1', 'yes', 'y', 't'] and (FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME | default('', true)) %}
 {% set work_iq_enabled = RETRIEVAL_BACKEND == 'foundry_iq' and (WORK_IQ_ENABLED | default('false') | string | lower) in ['true', '1', 'yes', 'y', 't'] and (WORK_IQ_KNOWLEDGE_SOURCE_NAME | default('', true)) %}
+{% set fabric_iq_enabled = RETRIEVAL_BACKEND == 'foundry_iq' and (FABRIC_IQ_ENABLED | default('false') | string | lower) in ['true', '1', 'yes', 'y', 't'] and (FABRIC_IQ_KNOWLEDGE_SOURCE_NAME | default('', true)) and (FABRIC_IQ_WORKSPACE_ID | default('', true)) and (FABRIC_IQ_ONTOLOGY_ID | default('', true)) %}
 {
   "indexes": [
     {
@@ -420,6 +421,18 @@
       "encryptionKey": null
     }
     {% endif %}
+    {% if fabric_iq_enabled %},
+    {
+      "name": "{{FABRIC_IQ_KNOWLEDGE_SOURCE_NAME}}",
+      "kind": "fabricOntology",
+      "description": "Microsoft Fabric IQ knowledge source (grounds retrieval on a Fabric ontology in the caller's workspace).",
+      "fabricOntologyParameters": {
+        "workspaceId": "{{FABRIC_IQ_WORKSPACE_ID}}",
+        "ontologyId": "{{FABRIC_IQ_ONTOLOGY_ID}}"
+      },
+      "encryptionKey": null
+    }
+    {% endif %}
   ]{% else %}[]{% endif %},
   "knowledgeBases": {% if RETRIEVAL_BACKEND == 'foundry_iq' %}[
     {
@@ -431,7 +444,8 @@
       "knowledgeSources": [
         { "name": "{{FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME}}" }{% if conversation_upload_enabled %},
         { "name": "{{FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME}}" }{% endif %}{% if work_iq_enabled %},
-        { "name": "{{WORK_IQ_KNOWLEDGE_SOURCE_NAME}}" }{% endif %}
+        { "name": "{{WORK_IQ_KNOWLEDGE_SOURCE_NAME}}" }{% endif %}{% if fabric_iq_enabled %},
+        { "name": "{{FABRIC_IQ_KNOWLEDGE_SOURCE_NAME}}" }{% endif %}
       ],
       "models": [],
       "encryptionKey": null,

--- a/config/search/search.settings.j2
+++ b/config/search/search.settings.j2
@@ -38,6 +38,10 @@
     "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS": "{{FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS | default('')}}",
     "WORK_IQ_ENABLED": "{{WORK_IQ_ENABLED | default('false')}}",
     "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "{{WORK_IQ_KNOWLEDGE_SOURCE_NAME | default('')}}",
+    "FABRIC_IQ_ENABLED": "{{FABRIC_IQ_ENABLED | default('false')}}",
+    "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "{{FABRIC_IQ_KNOWLEDGE_SOURCE_NAME | default('')}}",
+    "FABRIC_IQ_WORKSPACE_ID": "{{FABRIC_IQ_WORKSPACE_ID | default('')}}",
+    "FABRIC_IQ_ONTOLOGY_ID": "{{FABRIC_IQ_ONTOLOGY_ID | default('')}}",
     {% if GPT_MODEL_INFO | default({}) %}
     "GPT_MODEL_DEPLOYMENT_NAME": "{{GPT_MODEL_INFO.deployment_name}}",
     "GPT_MODEL_NAME": "{{GPT_MODEL_INFO.model_name}}"

--- a/config/search/setup.py
+++ b/config/search/setup.py
@@ -466,6 +466,23 @@ def is_work_iq_enabled(context: dict) -> bool:
     )
 
 
+def is_fabric_iq_enabled(context: dict) -> bool:
+    """Return True when Fabric IQ should be registered as a knowledge source.
+
+    Requires the retrieval backend to be Foundry IQ, the FABRIC_IQ_ENABLED
+    switch to be truthy, and all three binding fields (knowledge source name,
+    Fabric workspace id, Fabric ontology id) to be set. Fabric IQ has no
+    shared service principal, so there is no admin-consent preflight.
+    """
+    return (
+        str(context.get("RETRIEVAL_BACKEND") or "").lower() == "foundry_iq"
+        and is_truthy_setting(context.get("FABRIC_IQ_ENABLED"))
+        and bool(str(context.get("FABRIC_IQ_KNOWLEDGE_SOURCE_NAME") or "").strip())
+        and bool(str(context.get("FABRIC_IQ_WORKSPACE_ID") or "").strip())
+        and bool(str(context.get("FABRIC_IQ_ONTOLOGY_ID") or "").strip())
+    )
+
+
 def check_work_iq_admin_consent(cred: ChainedTokenCredential) -> Optional[bool]:
     """Soft preflight: check whether the Work IQ service principal has been
     consented in the caller's tenant.

--- a/config/search/tests/test_foundry_iq_templates.py
+++ b/config/search/tests/test_foundry_iq_templates.py
@@ -417,6 +417,72 @@ class WorkIqTemplateTests(unittest.TestCase):
         self.assertEqual(search_definitions["knowledgeSources"], [])
         self.assertEqual(search_definitions["knowledgeBases"], [])
 
+    def test_settings_defaults_fabric_iq_disabled_and_empty(self):
+        settings = render_json_template(
+            "search.settings.j2",
+            {
+                "RESOURCE_TOKEN": "abc123",
+                "SEARCH_SERVICE_QUERY_ENDPOINT": "https://search.search.windows.net",
+                "AI_FOUNDRY_ACCOUNT_NAME": "aif-abc123",
+                "RETRIEVAL_BACKEND": "foundry_iq",
+            },
+        )
+        self.assertEqual(settings["FABRIC_IQ_ENABLED"], "false")
+        self.assertEqual(settings["FABRIC_IQ_KNOWLEDGE_SOURCE_NAME"], "")
+        self.assertEqual(settings["FABRIC_IQ_WORKSPACE_ID"], "")
+        self.assertEqual(settings["FABRIC_IQ_ONTOLOGY_ID"], "")
+
+    def test_fabric_iq_disabled_by_default_produces_no_fabric_entry(self):
+        _, context = self._foundry_iq_context()
+        search_definitions = render_json_template("search.j2", context)
+        for ks in search_definitions["knowledgeSources"]:
+            self.assertNotEqual(ks["kind"], "fabricOntology")
+        kb_source_names = [
+            s["name"] for s in search_definitions["knowledgeBases"][0]["knowledgeSources"]
+        ]
+        self.assertNotIn("fabric-iq-ks", kb_source_names)
+
+    def test_fabric_iq_enabled_without_binding_fields_produces_no_entry(self):
+        # Enabled + name but missing workspace and ontology ids must not emit.
+        _, context = self._foundry_iq_context(
+            FABRIC_IQ_ENABLED="true",
+            FABRIC_IQ_KNOWLEDGE_SOURCE_NAME="fabric-iq-ks",
+        )
+        search_definitions = render_json_template("search.j2", context)
+        for ks in search_definitions["knowledgeSources"]:
+            self.assertNotEqual(ks["kind"], "fabricOntology")
+
+    def test_fabric_iq_enabled_adds_fabric_knowledge_source_and_kb_reference(self):
+        _, context = self._foundry_iq_context(
+            FABRIC_IQ_ENABLED="true",
+            FABRIC_IQ_KNOWLEDGE_SOURCE_NAME="fabric-iq-ks",
+            FABRIC_IQ_WORKSPACE_ID="ws-guid-1",
+            FABRIC_IQ_ONTOLOGY_ID="ont-guid-1",
+        )
+        search_definitions = render_json_template("search.j2", context)
+
+        fabric_sources = [
+            ks
+            for ks in search_definitions["knowledgeSources"]
+            if ks["kind"] == "fabricOntology"
+        ]
+        self.assertEqual(len(fabric_sources), 1)
+        fabric = fabric_sources[0]
+        self.assertEqual(fabric["name"], "fabric-iq-ks")
+        self.assertEqual(fabric["kind"], "fabricOntology")
+        self.assertIsNone(fabric["encryptionKey"])
+        # Fabric IQ is service-managed. It must not carry a filterAddOn.
+        self.assertNotIn("filterAddOn", fabric)
+        self.assertEqual(
+            fabric["fabricOntologyParameters"],
+            {"workspaceId": "ws-guid-1", "ontologyId": "ont-guid-1"},
+        )
+
+        kb_source_names = [
+            s["name"] for s in search_definitions["knowledgeBases"][0]["knowledgeSources"]
+        ]
+        self.assertIn("fabric-iq-ks", kb_source_names)
+
 
 class WorkIqPreflightTests(unittest.TestCase):
     def test_filter_work_iq_sources_no_op_when_disabled(self):


### PR DESCRIPTION
Registers a Fabric IQ (`fabricOntology`) knowledge source on the shared Foundry IQ knowledge base, so retrieval can ground answers on a Microsoft Fabric ontology alongside the existing RAG documents and Work IQ. Pairs with orchestrator PR https://github.com/Azure/gpt-rag-orchestrator/pull/263.

## What

- `config/search/search.j2` emits a `kind="fabricOntology"` KS with `fabricOntologyParameters` (`workspaceId`, `ontologyId`) and adds it to the KB `knowledgeSources` array. Feature is gated on `RETRIEVAL_BACKEND=foundry_iq` and all four keys being truthy: `FABRIC_IQ_ENABLED`, `FABRIC_IQ_KNOWLEDGE_SOURCE_NAME`, `FABRIC_IQ_WORKSPACE_ID`, `FABRIC_IQ_ONTOLOGY_ID`.
- `config/search/search.settings.j2` passes the four keys through with safe defaults so the settings render is stable when Fabric IQ is off.
- `config/search/setup.py` adds `is_fabric_iq_enabled(context)`. Fabric IQ has no shared service principal so there is no admin-consent preflight (unlike Work IQ).
- 4 new template tests in `config/search/tests/test_foundry_iq_templates.py` mirroring the Work IQ suite (defaults, absent binding fields, full happy path, KB reference).

## Tests

`pytest config/search/tests/test_foundry_iq_templates.py`: 21 passed, no regressions.

## Prerequisites (must be surfaced in release notes and docs)

- Microsoft Fabric workspace with an ontology item the caller has access to.
- Tenant-level Fabric ontology enablement.
- End users with Fabric licenses and ontology access.
- Same Entra tenant as the Foundry / Search resource.
- **Data-egress caveat:** Fabric IQ may route data outside the Azure compliance boundary. Operators must review.

## Refs

Azure/GPT-RAG#543 (umbrella issue: Work IQ + Fabric IQ)
