### PR TITLE
fix(post-provision): seed WORK_IQ_* and FABRIC_IQ_* App Config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@
 
 ### Fixed
 
+- **`scripts/postProvision.ps1` now seeds `WORK_IQ_*` and `FABRIC_IQ_*` App Configuration keys.**
+  The post-provision hook previously stamped every `FOUNDRY_IQ_*` key
+  explicitly but relied on `config/search/setup.py` rendering
+  `search.settings.j2` to populate the Work IQ and Fabric IQ keys as a
+  side-effect. `Set-GptRagAppConfiguration` now seeds `WORK_IQ_ENABLED`,
+  `WORK_IQ_KNOWLEDGE_SOURCE_NAME`, `FABRIC_IQ_ENABLED`,
+  `FABRIC_IQ_KNOWLEDGE_SOURCE_NAME`, `FABRIC_IQ_WORKSPACE_ID`, and
+  `FABRIC_IQ_ONTOLOGY_ID` with the same defaults as the Jinja template
+  (`enabled=false`, everything else `""`). Operators can now flip Work IQ
+  or Fabric IQ on from the App Configuration blade without having to
+  discover key names first. See
+  [`Azure/gpt-rag#551`](https://github.com/Azure/gpt-rag/issues/551).
+
 ## [v3.3.0] - 2026-07-10
 
 ### User and operator impact

--- a/scripts/postProvision.ps1
+++ b/scripts/postProvision.ps1
@@ -394,6 +394,18 @@ function Set-GptRagAppConfiguration {
         FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS = (Get-OptionalEnvValue 'FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS')
         FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED = (Get-OptionalEnvValue 'FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED' 'false')
         FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME = $foundryIqConversationKnowledgeSourceName
+        # Work IQ and Fabric IQ knowledge-source passthrough keys. Defaults
+        # match config/search/search.settings.j2 (opt-in via `*_ENABLED=true`
+        # plus the required identifiers). Seeding them here so a fresh
+        # provision registers the keys with default values under the
+        # gpt-rag label, and operators can flip the flags from the App
+        # Configuration blade without having to know the exact key names.
+        WORK_IQ_ENABLED = (Get-OptionalEnvValue 'WORK_IQ_ENABLED' 'false')
+        WORK_IQ_KNOWLEDGE_SOURCE_NAME = (Get-OptionalEnvValue 'WORK_IQ_KNOWLEDGE_SOURCE_NAME' '')
+        FABRIC_IQ_ENABLED = (Get-OptionalEnvValue 'FABRIC_IQ_ENABLED' 'false')
+        FABRIC_IQ_KNOWLEDGE_SOURCE_NAME = (Get-OptionalEnvValue 'FABRIC_IQ_KNOWLEDGE_SOURCE_NAME' '')
+        FABRIC_IQ_WORKSPACE_ID = (Get-OptionalEnvValue 'FABRIC_IQ_WORKSPACE_ID' '')
+        FABRIC_IQ_ONTOLOGY_ID = (Get-OptionalEnvValue 'FABRIC_IQ_ONTOLOGY_ID' '')
         NETWORK_ISOLATION = (Get-OptionalEnvValue 'NETWORK_ISOLATION' 'false')
         USE_UAI = (Get-OptionalEnvValue 'USE_UAI' 'false')
         USE_CAPP_API_KEY = (Get-OptionalEnvValue 'USE_CAPP_API_KEY' 'false')


### PR DESCRIPTION
## Summary

`scripts/postProvision.ps1::Set-GptRagAppConfiguration` seeded every
`FOUNDRY_IQ_*` App Configuration key but left `WORK_IQ_*` and
`FABRIC_IQ_*` (added in `v3.3.0` and `v3.4.0` respectively) to be
populated as a side-effect of `config/search/setup.py` rendering
`config/search/search.settings.j2`. That meant operators enabling
Work IQ or Fabric IQ after the fact had to know the exact key names, run
`az appconfig kv set` for each key, and then re-run the search setup
script.

This extends the seeding block with the matching `Get-OptionalEnvValue`
calls and the same defaults as the Jinja template (`enabled=false`,
everything else `""`), so a fresh provision registers the keys with
their defaults and operators can flip them from the App Configuration
blade without having to discover key names first.

Fixes #551

## Changes

- `scripts/postProvision.ps1`: seed `WORK_IQ_ENABLED`,
  `WORK_IQ_KNOWLEDGE_SOURCE_NAME`, `FABRIC_IQ_ENABLED`,
  `FABRIC_IQ_KNOWLEDGE_SOURCE_NAME`, `FABRIC_IQ_WORKSPACE_ID`, and
  `FABRIC_IQ_ONTOLOGY_ID` alongside the existing `FOUNDRY_IQ_*` block.
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Validation

- Local PowerShell parser: `Parser.ParseFile` reports no errors.
- Azure validation: fresh Standard provision on a throwaway resource
  group in `swedencentral`; will report the App Config listing (all six
  keys present with the seeded defaults) plus idempotency on re-run in
  the release notes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>