### PR TITLE
docs(grounding): add generic MCP server how-to (preview)

### DIFF
--- a/docs/howto_grounding_foundry_iq_prereqs.md
+++ b/docs/howto_grounding_foundry_iq_prereqs.md
@@ -110,6 +110,7 @@ sign in.
 | `indexedOneLake` | App-only. Foundry IQ managed identity reads the lakehouse. | No. |
 | `indexedSharePoint` | App-only. Microsoft Graph `Sites.Selected` or `Sites.Read.All` on a registered Entra app. No per-user ACL trimming in this preview. | No. |
 | `web` (Grounding with Bing) | App-only. No ACL. Billed per call. | No. |
+| `mcpServer` (generic MCP server) | App-only, managed-identity only in this release. No per-user ACL trimming. See [Generic MCP server](howto_grounding_mcp_server.md#authentication). | No. |
 | `workIq` | On-behalf-of (OBO). Orchestrator forwards the user's delegated token in `x-ms-query-source-authorization`. | Yes. |
 | `remoteSharePoint` | OBO through the Microsoft 365 Copilot Retrieval API. | Yes. |
 | `fabricOntology` | OBO to Microsoft Fabric. | Yes. |
@@ -139,6 +140,10 @@ this: at `retrievalReasoningEffort=minimal` (the current default) the
 Knowledge Base skips LLM planning entirely. Configure a planning model when:
 
 - You enable the `web` knowledge source. Web requires an LLM.
+- You enable one or more generic MCP server (`mcpServer`) sources. MCP
+  requires `low` or `medium` reasoning so the planner can select a tool
+  and generate its arguments; see
+  [Generic MCP server](howto_grounding_mcp_server.md#knowledge-base-planning-model).
 - You want `low` or `medium` reasoning effort so the Knowledge Base can
   select and blend across multiple sources.
 

--- a/docs/howto_grounding_foundry_iq_prereqs.md
+++ b/docs/howto_grounding_foundry_iq_prereqs.md
@@ -110,7 +110,7 @@ sign in.
 | `indexedOneLake` | App-only. Foundry IQ managed identity reads the lakehouse. | No. |
 | `indexedSharePoint` | App-only. Microsoft Graph `Sites.Selected` or `Sites.Read.All` on a registered Entra app. No per-user ACL trimming in this preview. | No. |
 | `web` (Grounding with Bing) | App-only. No ACL. Billed per call. | No. |
-| `mcpServer` (generic MCP server) | App-only, managed-identity only in this release. No per-user ACL trimming. See [Generic MCP server](howto_grounding_mcp_server.md#authentication). | No. |
+| `mcpServer` (generic MCP server) | Registration is app-only. Endpoint authentication is separate and requires a compatible runtime for query-time headers. App-only managed identity and per-user OBO are distinct runtime token-acquisition options. See [Generic MCP server](howto_grounding_mcp_server.md#authentication). | Only if you choose OBO for per-user endpoint authorization. |
 | `workIq` | On-behalf-of (OBO). Orchestrator forwards the user's delegated token in `x-ms-query-source-authorization`. | Yes. |
 | `remoteSharePoint` | OBO through the Microsoft 365 Copilot Retrieval API. | Yes. |
 | `fabricOntology` | OBO to Microsoft Fabric. | Yes. |
@@ -121,6 +121,13 @@ configured to forward a delegated token. This is the same plumbing that
 [Auth and Doc Security](howto_authentication.md) describes for GPT-RAG's own
 security-trimmed retrieval. Each per-source page lists the specific tenant
 consent, delegated permissions, and licensing you need.
+
+For `mcpServer`, do not confuse the orchestrator's managed identity with an
+OBO token. Managed identity is app-only and gives every user the same MCP
+authorization scope. OBO preserves the signed-in user's identity and only
+works when the MCP endpoint validates that delegated token. Neither mode is
+configured by the provisioning-only change described in
+[Generic MCP server](howto_grounding_mcp_server.md).
 
 ## Feature flags gated by Microsoft
 
@@ -142,7 +149,8 @@ Knowledge Base skips LLM planning entirely. Configure a planning model when:
 - You enable the `web` knowledge source. Web requires an LLM.
 - You enable one or more generic MCP server (`mcpServer`) sources. MCP
   requires `low` or `medium` reasoning so the planner can select a tool
-  and generate its arguments; see
+  and generate its arguments. A compatible orchestrator must also use a
+  `messages`-based retrieve request; see
   [Generic MCP server](howto_grounding_mcp_server.md#knowledge-base-planning-model).
 - You want `low` or `medium` reasoning effort so the Knowledge Base can
   select and blend across multiple sources.

--- a/docs/howto_grounding_mcp_server.md
+++ b/docs/howto_grounding_mcp_server.md
@@ -1,0 +1,413 @@
+# Foundry IQ: Generic MCP Server knowledge sources
+
+The `mcpServer` Foundry IQ knowledge source lets the Knowledge Base call
+tools exposed by a remote [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
+server you operate or trust, and blend the results with your other Foundry
+IQ sources (documents, Work IQ, Fabric, SharePoint, Web, and so on) in a
+single retrieve call. GPT-RAG's provisioning template is server-agnostic:
+it does not hard-code any particular MCP server. Azure Monitor MCP over
+workspace-scoped Application Insights / Log Analytics is used below as the
+worked reference scenario, but any MCP server that speaks the documented
+protocol and that you have added to the trusted host allowlist will work
+the same way.
+
+If you have not read the [Grounding sources overview](howto_grounding_overview.md),
+start there.
+
+!!! warning "Preview, remote code execution surface, read this before enabling"
+    MCP Server knowledge sources use a preview Foundry IQ knowledge-source
+    kind (`mcpServer`) on the `2026-05-01-preview` Azure AI Search API.
+    Behavior and configuration may change without notice; do not depend on
+    this for production workloads until it is generally available.
+
+    More importantly: an MCP server is a **remote, tool-invoking endpoint**.
+    Azure AI Search's knowledge-base planner decides which tool to call and
+    generates that tool's arguments from the user's question. Tool safety
+    does not guarantee semantic correctness of the generated arguments.
+    Only point this at MCP servers you trust, scope every tool to
+    read-only, bounded operations, and review the
+    [Security](#security-and-trust-boundary) section below before you
+    enable this in any environment that is not fully isolated.
+
+> Complete the [Foundry IQ prerequisites](howto_grounding_foundry_iq_prereqs.md)
+> first. The Prerequisites section below covers only what is specific to
+> this source.
+
+## How it works
+
+At retrieval time, the Knowledge Base -- not the GPT-RAG orchestrator --
+calls the configured MCP server directly over HTTPS:
+
+```mermaid
+flowchart LR
+  O[GPT-RAG orchestrator] --> KB[Foundry IQ Knowledge Base]
+  KB -- "plans + selects a tool" --> KB
+  KB -- "HTTPS, tool call" --> MCP[Remote MCP server]
+  MCP --> KB
+  KB --> O
+```
+
+1. The orchestrator sends a `messages`-based retrieve request to the
+   Knowledge Base with `low` or `medium` reasoning effort (never
+   `minimal`). Minimal reasoning skips query planning entirely, and MCP
+   tool selection and argument generation require the planner to run.
+2. The Knowledge Base's planning model (see
+   [Knowledge base planning model](#knowledge-base-planning-model) below)
+   decides whether to call the MCP source, which tool to invoke, and what
+   arguments to generate for it.
+3. Azure AI Search invokes the governed remote HTTPS MCP endpoint you
+   registered -- the exact `serverURL` from your configuration, never a
+   value supplied by the end user or by the orchestrator at query time.
+   Only the tools you explicitly allowlisted per source can be called.
+4. The tool's structured output is parsed according to the `outputParsing`
+   mode you configured, folded into the retrieve response, and normalized
+   into the standard reference contract alongside document and other
+   knowledge-source hits.
+
+GPT-RAG's provisioning template never sends request or response bodies
+through the orchestrator for this source; the call is entirely between
+Azure AI Search and the MCP server. Query-time credential forwarding (for
+MCP servers that need a caller-specific token) is orchestrator-side work
+tracked separately and is out of scope for this page.
+
+## When to use a generic MCP source
+
+Use an MCP Server knowledge source when:
+
+- You need live, tool-backed data (metrics, logs, a ticketing system, an
+  internal API) that cannot be pre-indexed, and an MCP server already
+  exposes it with a bounded, read-only tool surface.
+- You control or trust the MCP server's operator, its network exposure,
+  and the identity Azure AI Search uses to reach it.
+- You can accept that the knowledge base's planning model, not a human,
+  decides when to call the tool and what arguments to generate.
+
+Do not use it when:
+
+- The MCP server is untrusted, publicly writable, or you cannot audit the
+  arguments the planner generates.
+- The data is better served by an indexed knowledge source (Blob, AI
+  Search index, SharePoint indexed, OneLake). Indexed sources have a much
+  smaller trust surface than a live tool call.
+- You need static, long-lived credential (API key or bearer token)
+  authentication. This provisioning template does not support that yet;
+  see [Authentication](#authentication) below.
+
+## Prerequisites
+
+All of these are hard blockers. Work through them in order.
+
+1. **The MCP server must be reachable over HTTPS with a fixed, production
+   hostname.** No IP-literal endpoints, no `localhost`, no query strings
+   with embedded credentials. See [Trusted hosts](#trusted-hosts).
+2. **Managed-identity-only authentication.** Azure AI Search must be able
+   to reach the MCP server using its own identity (directly, or because
+   the MCP server sits behind something -- an API Management gateway, an
+   Azure Monitor-style RBAC-protected endpoint -- that recognizes that
+   identity). See [Authentication](#authentication).
+3. **Every tool you intend to call is explicitly allowlisted.** There is
+   no "allow all tools" option. Add each tool by name with its own
+   `inclusionMode`, `outputParsing`, and `maxOutputTokens`.
+4. **A knowledge base planning model.** MCP requires `low` or `medium`
+   `retrievalReasoningEffort`, which requires an Azure OpenAI chat model
+   on the knowledge base. See
+   [Knowledge base planning model](#knowledge-base-planning-model).
+5. **Network egress review.** Confirm with your network/security owner
+   that the Azure AI Search service is allowed to call the MCP server's
+   hostname, and that the MCP server's ingress is restricted to expected
+   callers. See [Network and gateway guidance](#network-and-gateway-guidance).
+
+## Configure a generic MCP source
+
+MCP support is opt-in and defaults to off. `azd provision` seeds five keys
+under the `gpt-rag` label with safe defaults (`FOUNDRY_IQ_MCP_ENABLED=false`,
+an empty source list, and conservative defaults for the rest). You do not
+have to create them by hand.
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `FOUNDRY_IQ_MCP_ENABLED` | `false` | `true` to enable, `false` to disable. |
+| `FOUNDRY_IQ_MCP_SOURCES_JSON` | `[]` | JSON array of MCP source objects. See schema below. |
+| `FOUNDRY_IQ_MCP_REASONING_EFFORT` | `low` | `low` or `medium`. Controls the knowledge base's `retrievalReasoningEffort` when MCP is enabled. |
+| `FOUNDRY_IQ_MCP_TRUSTED_HOSTS` | `` (empty) | Comma-separated allowlist of exact hostnames. Every `serverURL` host must match one of these exactly. |
+| `FOUNDRY_IQ_MCP_LOG_TOOL_ARGUMENTS` | `false` | Orchestrator-side flag reserved for verbose troubleshooting logging of generated tool arguments. Leave `false` outside a debugging session; generated arguments can echo back user question content. |
+
+### Source schema
+
+Each entry in `FOUNDRY_IQ_MCP_SOURCES_JSON` is a JSON object:
+
+```json
+{
+  "name": "monitor-mcp-ks",
+  "description": "Azure Monitor MCP over the platform Log Analytics workspace",
+  "serverURL": "https://monitor-mcp.contoso.com/mcp",
+  "tools": [
+    {
+      "name": "query_logs",
+      "outputParsing": "auto",
+      "inclusionMode": "reranked",
+      "maxOutputTokens": 4096
+    }
+  ]
+}
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `name` | Yes | Unique across all MCP sources. Becomes the knowledge-source name. |
+| `description` | No | Defaults to a generic description if omitted. |
+| `serverURL` | Yes | Must be `https://`, no userinfo, no fragment, no IP literal, and its host must exactly match an entry in `FOUNDRY_IQ_MCP_TRUSTED_HOSTS`. |
+| `tools` | Yes | Non-empty array. Every tool the planner is allowed to call. |
+| `auth` | No | Validation-only; see [Authentication](#authentication). Never forwarded into the registration payload. |
+
+Each tool object:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `name` | Yes | Unique within the source. |
+| `outputParsing` | Yes | One of `auto`, `json`, `split`, `none`. |
+| `documentsPath` | Only if `outputParsing` is `json` | JSON path into the tool's structured output. |
+| `inclusionMode` | Yes | `reranked` (only included when the reranker judges it relevant) or `always` (always passed to the model; budget accordingly). |
+| `maxOutputTokens` | Yes | Positive integer. Provisioning enforces a local cap of `8192` regardless of what the Search service would otherwise accept, to bound cost and prompt size. |
+
+`azd provision` parses and validates this JSON during setup and **fails the
+deployment closed** if it is invalid while `FOUNDRY_IQ_MCP_ENABLED=true`:
+malformed JSON, zero sources, zero tools, duplicate source or tool names,
+a non-`https` scheme, userinfo or a fragment in `serverURL`, an IP-literal
+or `localhost` host, a host outside `FOUNDRY_IQ_MCP_TRUSTED_HOSTS`, an
+unsupported `outputParsing` or `inclusionMode` value, a missing
+`documentsPath` when required, a non-positive or over-cap
+`maxOutputTokens`, or unsupported `auth` metadata all abort provisioning
+with an actionable error instead of silently registering a broken or
+insecure source.
+
+### Trusted hosts
+
+`FOUNDRY_IQ_MCP_TRUSTED_HOSTS` is a comma-separated allowlist of exact
+hostnames (not URLs, not wildcards, not CIDR ranges). Every `serverURL`
+you configure must have a host that matches one of these entries exactly
+(case-insensitive). This is defense in depth on top of the network-level
+egress control described in
+[Network and gateway guidance](#network-and-gateway-guidance): even if an
+operator fat-fingers a source's `serverURL`, provisioning refuses to
+register a knowledge source pointing anywhere the allowlist has not
+explicitly approved. IP literals are always rejected outright (this
+blocks loopback, link-local, and other reserved ranges by construction),
+so the allowlist is DNS-hostname-only.
+
+### Authentication
+
+The Azure AI Search REST schema for authenticating an `mcpServer`
+knowledge source is not yet publicly documented as of this preview. Rather
+than guess at an unverified field and silently no-op or fail at
+registration time, this provisioning template supports exactly one
+authentication mode:
+
+- **Implicit managed identity (supported).** The common case, and the one
+  used by the Azure Monitor MCP reference scenario below: grant the Azure
+  AI Search service's system-assigned managed identity the RBAC role it
+  needs on the target resource, and configure nothing else. No `auth`
+  field is required in the source JSON at all.
+
+If you add an `auth` object to a source, it is validated but never
+forwarded into the registration payload:
+
+- `{"kind": "managedIdentity"}` is accepted as an explicit (and
+  functionally redundant) no-op.
+- `{"kind": "foundryConnection"}` is always rejected. GPT-RAG calls the
+  knowledge base retrieve API directly; Foundry project connection
+  authentication does not apply to that path.
+- Anything containing API keys, tokens, secrets, passwords, or literal
+  header values is always rejected. **Do not put credential material in
+  `FOUNDRY_IQ_MCP_SOURCES_JSON` or anywhere in App Configuration.**
+- Any other `auth.kind` is rejected with a "not yet supported" error.
+
+Static long-lived header/token authentication for MCP servers, and
+dynamic per-query managed-identity/OBO credential forwarding, are tracked
+as orchestrator-side follow-up work once the Search team documents the
+real schema; they are not implemented by this provisioning template.
+
+### Knowledge base planning model
+
+When at least one MCP source is enabled, the knowledge base's `models`
+array is populated with the same Azure OpenAI model object GPT-RAG already
+renders for standard-mode Blob content extraction (reusing
+`FOUNDRY_IQ_AI_SERVICES_ENDPOINT`, `CHAT_DEPLOYMENT_NAME`'s deployment, and
+model name from `MODEL_DEPLOYMENTS`), and `retrievalReasoningEffort` is set
+to `FOUNDRY_IQ_MCP_REASONING_EFFORT` (`low` by default, or `medium`).
+Provisioning fails closed if no chat model or AI Services endpoint can be
+resolved, since the planner cannot select or call an MCP tool without one.
+When MCP is disabled, `models` stays `[]` and reasoning effort stays
+`minimal`, exactly as before this feature existed.
+
+## Reference scenario: Azure Monitor MCP
+
+Azure Monitor MCP over a workspace-scoped Log Analytics workspace is the
+motivating scenario for this feature, used here purely as a worked
+example -- the template has no Azure-Monitor-specific code path.
+
+1. Deploy or identify an Azure Monitor MCP server endpoint scoped to a
+   single Log Analytics workspace (or a small, explicit set of
+   workspaces). Do not point it at a broad, unscoped Log Analytics
+   surface.
+2. Grant the Azure AI Search service's system-assigned managed identity
+   **Log Analytics Data Reader** at the **workspace scope** (not subscription
+   or resource-group scope) for that workspace. Read-only, workspace-
+   scoped access is the floor: do not grant Contributor or a
+   subscription-wide role for this purpose.
+3. Configure the MCP server's own tool (for example `query_logs`) to
+   enforce, server-side:
+    - A bounded lookback window (for example, 24-72 hours), not
+      open-ended time ranges.
+    - A row/result cap per query.
+    - Read-only KQL only -- no management commands, no cross-workspace
+      joins beyond what you explicitly intend.
+    - Logging of the generated KQL so it is auditable after the fact.
+4. Add the source to `FOUNDRY_IQ_MCP_SOURCES_JSON`:
+
+   ```json
+   [
+     {
+       "name": "azure-monitor-mcp-ks",
+       "description": "Azure Monitor MCP over the platform observability workspace",
+       "serverURL": "https://azmon-mcp.contoso.com/mcp",
+       "tools": [
+         {
+           "name": "query_logs",
+           "outputParsing": "auto",
+           "inclusionMode": "reranked",
+           "maxOutputTokens": 4096
+         }
+       ]
+     }
+   ]
+   ```
+
+5. Add `azmon-mcp.contoso.com` to `FOUNDRY_IQ_MCP_TRUSTED_HOSTS`, set
+   `FOUNDRY_IQ_MCP_ENABLED=true`, re-run `azd hooks run postprovision` (or
+   `azd provision`), and `azd deploy`.
+6. Ask a bounded, time-scoped question (for example, "were there any
+   5xx spikes on the checkout service in the last 24 hours?") and review
+   the generated KQL in the MCP server's own logs before trusting the
+   answer in a shared environment.
+
+The bounded time range, row cap, read-only access, and auditable
+generated KQL in steps 3 and 6 are not optional hardening -- they are the
+minimum bar for exposing a natural-language-to-KQL tool to an LLM planner
+you do not fully control the prompting of.
+
+## Network and gateway guidance
+
+The trusted-host allowlist in this template is provisioning-time defense
+in depth, not a substitute for network-level control. Before enabling any
+MCP source outside a fully isolated test environment:
+
+- **Put the MCP server behind Azure API Management (or an equivalent
+  gateway)** so you get centralized authentication, rate limiting, and
+  request logging independent of what the MCP server itself implements.
+  See [Expose a REST API as an MCP server](https://learn.microsoft.com/azure/api-management/export-rest-mcp-server),
+  [About MCP servers in Azure API Management](https://learn.microsoft.com/azure/api-management/mcp-server-overview),
+  and [Monitor MCP server traffic in Azure API Management](https://learn.microsoft.com/azure/api-management/monitor-mcp-servers).
+- **Rate-limit the MCP endpoint.** The knowledge base planner can call a
+  tool on every retrieve request that selects it; an unbounded MCP server
+  behind a popular knowledge base is an unbounded cost and load surface.
+- **Restrict egress from Azure AI Search and ingress on the MCP server**
+  to each other where your network topology allows it (private endpoints,
+  IP allowlists, or an API Management instance with its own private
+  ingress). If the Azure AI Search service is deployed with network
+  isolation, confirm the MCP server's hostname is reachable through the
+  same private path other outbound Search traffic uses.
+- **Do not expose write-capable or destructive tools.** Every tool
+  allowlisted in `FOUNDRY_IQ_MCP_SOURCES_JSON` should be safe to call
+  automatically and repeatedly, with no meaningful side effect if the
+  planner calls it with unexpected arguments.
+
+## Security and trust boundary
+
+- The knowledge base planning model, not GPT-RAG code, decides when to
+  call an MCP tool and what arguments to pass. Treat every allowlisted
+  tool as something that **will** be called with LLM-generated arguments
+  during normal operation, not as a theoretical capability.
+- MCP tool safety (the server rejecting unsafe calls) does not guarantee
+  semantic correctness (the server accepting a syntactically valid but
+  wrong query and returning misleading results). Bound blast radius at the
+  MCP server itself, not just at the GPT-RAG configuration layer.
+- Nothing in this template accepts or forwards static credentials. If a
+  production MCP server absolutely requires header/token authentication
+  that this template does not yet support, do not work around that by
+  embedding a token in `FOUNDRY_IQ_MCP_SOURCES_JSON`, in an environment
+  variable, or anywhere else in App Configuration. Wait for a documented,
+  supported authentication field, or front the MCP server with a gateway
+  that performs the authentication on Search's behalf using the managed
+  identity it already presents.
+
+## Rollout, canary, and rollback
+
+- **Canary.** Enable one source with one low-risk, read-only tool in a
+  non-production environment first. Confirm the generated tool calls
+  (visible in the MCP server's own request logs, or Azure Monitor/App
+  Insights traces on the Search service) look reasonable before adding
+  more tools or sources.
+- **Rollout.** Add sources and tools incrementally. Each source is
+  independent; a problem with one MCP server does not require disabling
+  the others.
+- **Rollback.** Set `FOUNDRY_IQ_MCP_ENABLED=false` (the default) and
+  re-run `azd hooks run postprovision` and `azd deploy`. This is the same
+  disable gate used by every other opt-in Foundry IQ source in GPT-RAG:
+  flipping it back to `false` removes the MCP knowledge source references
+  from the knowledge base and restores `models=[]` and
+  `retrievalReasoningEffort=minimal` exactly as they were before MCP was
+  ever enabled. No data migration or re-provisioning of unrelated sources
+  is required.
+
+## Production blockers
+
+Do not promote an MCP source to a production environment until all of the
+following are true:
+
+- The `serverURL` is the actual production endpoint, not a development or
+  staging hostname left over from testing.
+- Every tool name in `FOUNDRY_IQ_MCP_SOURCES_JSON` matches the MCP
+  server's real, current tool names. A stale tool name fails at
+  registration or, worse, silently never gets selected by the planner.
+- The identity Azure AI Search authenticates as (its managed identity, or
+  the identity a fronting gateway presents on its behalf) has been
+  reviewed for the correct audience and the least-privilege role needed --
+  not a broader role granted for convenience during testing.
+- The network and gateway guidance above has been reviewed and signed off
+  by whoever owns egress/ingress policy for your environment.
+
+## Troubleshooting
+
+- **Deployment fails during Search setup with a message naming
+  `FOUNDRY_IQ_MCP_SOURCES_JSON`.** Provisioning validation rejected your
+  configuration. The error message names the exact field and rule that
+  failed (for example, an untrusted host, a duplicate name, or a missing
+  `documentsPath`). Fix the JSON and re-run `azd hooks run postprovision`.
+- **No MCP citations in responses.** Confirm `FOUNDRY_IQ_MCP_ENABLED=true`,
+  that `FOUNDRY_IQ_MCP_SOURCES_JSON` has at least one source, and that
+  `FOUNDRY_IQ_MCP_REASONING_EFFORT` is `low` or `medium`. Restart the
+  orchestrator so it picks up the App Configuration change.
+- **Planner never selects the MCP tool.** Reasoning effort, tool
+  description quality, and `inclusionMode` all affect selection. Try
+  `medium` reasoning, or `inclusionMode: "always"` while diagnosing (then
+  revert to `reranked` once you confirm the tool works, to control token
+  usage).
+- **Registration succeeds but calls fail at query time with an
+  authentication error.** Confirm the Azure AI Search service's
+  system-assigned managed identity has the RBAC role the MCP server (or
+  its fronting gateway) expects, at the correct scope.
+
+## Related reading
+
+- [Grounding sources overview](howto_grounding_overview.md)
+- [Foundry IQ prerequisites](howto_grounding_foundry_iq_prereqs.md)
+- [Foundry IQ: Web grounding](howto_grounding_web_bing.md)
+- Microsoft Learn: [What is a knowledge source?](https://learn.microsoft.com/azure/search/agentic-knowledge-source-overview)
+- Microsoft Learn: [Create a Knowledge Base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-create-knowledge-base)
+- Microsoft Learn: [Build agents using Model Context Protocol on Azure](https://learn.microsoft.com/azure/developer/ai/intro-agents-mcp)
+- Microsoft Learn: [Expose a REST API as an MCP server](https://learn.microsoft.com/azure/api-management/export-rest-mcp-server)
+- Microsoft Learn: [About MCP servers in Azure API Management](https://learn.microsoft.com/azure/api-management/mcp-server-overview)
+- Microsoft Learn: [Azure MCP Server tools for Azure Monitor and Workbooks](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-monitor)
+- Microsoft Learn: [Log Analytics Data Reader built-in role](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/monitor#log-analytics-data-reader)
+- [Microsoft preview terms](https://azure.microsoft.com/support/legal/preview-supplemental-terms/)

--- a/docs/howto_grounding_mcp_server.md
+++ b/docs/howto_grounding_mcp_server.md
@@ -1,4 +1,4 @@
-# Foundry IQ: Generic MCP Server knowledge sources
+# Foundry IQ: Generic MCP server knowledge sources
 
 The `mcpServer` Foundry IQ knowledge source lets the Knowledge Base call
 tools exposed by a remote [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
@@ -7,20 +7,27 @@ IQ sources (documents, Work IQ, Fabric, SharePoint, Web, and so on) in a
 single retrieve call. GPT-RAG's provisioning template is server-agnostic:
 it does not hard-code any particular MCP server. Azure Monitor MCP over
 workspace-scoped Application Insights / Log Analytics is used below as the
-worked reference scenario, but any MCP server that speaks the documented
-protocol and that you have added to the trusted host allowlist will work
-the same way.
+worked reference scenario.
 
 If you have not read the [Grounding sources overview](howto_grounding_overview.md),
 start there.
 
-!!! warning "Preview, remote code execution surface, read this before enabling"
+!!! warning "Preview configuration, not yet available end to end"
     MCP Server knowledge sources use a preview Foundry IQ knowledge-source
     kind (`mcpServer`) on the `2026-05-01-preview` Azure AI Search API.
     Behavior and configuration may change without notice; do not depend on
     this for production workloads until it is generally available.
 
-    More importantly: an MCP server is a **remote, tool-invoking endpoint**.
+    The `FOUNDRY_IQ_MCP_*` settings on this page match the proposed
+    provisioning implementation in
+    [GPT-RAG code PR #568](https://github.com/Azure/GPT-RAG/pull/568).
+    They are not available in a released GPT-RAG version yet. That PR
+    registers the source but does not update the orchestrator to send the
+    required `messages` request or query-time authentication headers. Keep
+    `FOUNDRY_IQ_MCP_ENABLED=false` until you deploy both the provisioning
+    change and a compatible orchestrator release.
+
+    An MCP server is a **remote, tool-invoking endpoint**.
     Azure AI Search's knowledge-base planner decides which tool to call and
     generates that tool's arguments from the user's question. Tool safety
     does not guarantee semantic correctness of the generated arguments.
@@ -35,8 +42,8 @@ start there.
 
 ## How it works
 
-At retrieval time, the Knowledge Base -- not the GPT-RAG orchestrator --
-calls the configured MCP server directly over HTTPS:
+When the provisioning and compatible runtime changes are both deployed,
+Azure AI Search calls the registered MCP server directly over HTTPS:
 
 ```mermaid
 flowchart LR
@@ -47,7 +54,7 @@ flowchart LR
   KB --> O
 ```
 
-1. The orchestrator sends a `messages`-based retrieve request to the
+1. A compatible orchestrator sends a `messages`-based retrieve request to the
    Knowledge Base with `low` or `medium` reasoning effort (never
    `minimal`). Minimal reasoning skips query planning entirely, and MCP
    tool selection and argument generation require the planner to run.
@@ -59,16 +66,21 @@ flowchart LR
    registered -- the exact `serverURL` from your configuration, never a
    value supplied by the end user or by the orchestrator at query time.
    Only the tools you explicitly allowlisted per source can be called.
-4. The tool's structured output is parsed according to the `outputParsing`
-   mode you configured, folded into the retrieve response, and normalized
-   into the standard reference contract alongside document and other
-   knowledge-source hits.
+4. The tool output is parsed according to the `outputParsing` mode and
+   returned in the normal retrieve response. Each MCP call appears in the
+   `activity` array. Each result appears in `references` and points back to
+   its activity entry through `activitySource`.
 
-GPT-RAG's provisioning template never sends request or response bodies
-through the orchestrator for this source; the call is entirely between
-Azure AI Search and the MCP server. Query-time credential forwarding (for
-MCP servers that need a caller-specific token) is orchestrator-side work
-tracked separately and is out of scope for this page.
+The MCP `references` entries do **not** contain the knowledge-source name.
+The name appears as `knowledgeSourceName` on the matching `activity` entry.
+Join `references[].activitySource` to `activity[].id` when you need to
+identify which source produced a citation.
+
+The user request and the retrieve response still pass through the
+orchestrator. Only the MCP tool call travels directly from Azure AI Search
+to the registered remote HTTPS endpoint. Query-time credential forwarding
+is also an orchestrator responsibility and is not implemented by code
+PR #568.
 
 ## When to use a generic MCP source
 
@@ -77,8 +89,8 @@ Use an MCP Server knowledge source when:
 - You need live, tool-backed data (metrics, logs, a ticketing system, an
   internal API) that cannot be pre-indexed, and an MCP server already
   exposes it with a bounded, read-only tool surface.
-- You control or trust the MCP server's operator, its network exposure,
-  and the identity Azure AI Search uses to reach it.
+- You control or trust the MCP server's operator and network exposure, and
+  you have a supported way to authenticate the Azure AI Search call to it.
 - You can accept that the knowledge base's planning model, not a human,
   decides when to call the tool and what arguments to generate.
 
@@ -90,7 +102,8 @@ Do not use it when:
   Search index, SharePoint indexed, OneLake). Indexed sources have a much
   smaller trust surface than a live tool call.
 - You need static, long-lived credential (API key or bearer token)
-  authentication. This provisioning template does not support that yet;
+  authentication. Azure AI Search supports stored headers upstream, but
+  GPT-RAG code PR #568 deliberately does not emit them;
   see [Authentication](#authentication) below.
 
 ## Prerequisites
@@ -100,11 +113,11 @@ All of these are hard blockers. Work through them in order.
 1. **The MCP server must be reachable over HTTPS with a fixed, production
    hostname.** No IP-literal endpoints, no `localhost`, no query strings
    with embedded credentials. See [Trusted hosts](#trusted-hosts).
-2. **Managed-identity-only authentication.** Azure AI Search must be able
-   to reach the MCP server using its own identity (directly, or because
-   the MCP server sits behind something -- an API Management gateway, an
-   Azure Monitor-style RBAC-protected endpoint -- that recognizes that
-   identity). See [Authentication](#authentication).
+2. **A supported endpoint authentication path.** Code PR #568 does not
+   configure credentials on the knowledge source and the current
+   orchestrator does not forward credentials at query time. Do not assume
+   Azure AI Search automatically presents its managed identity to the MCP
+   endpoint. See [Authentication](#authentication).
 3. **Every tool you intend to call is explicitly allowlisted.** There is
    no "allow all tools" option. Add each tool by name with its own
    `inclusionMode`, `outputParsing`, and `maxOutputTokens`.
@@ -119,10 +132,11 @@ All of these are hard blockers. Work through them in order.
 
 ## Configure a generic MCP source
 
-MCP support is opt-in and defaults to off. `azd provision` seeds five keys
-under the `gpt-rag` label with safe defaults (`FOUNDRY_IQ_MCP_ENABLED=false`,
-an empty source list, and conservative defaults for the rest). You do not
-have to create them by hand.
+The proposed MCP support is opt-in and defaults to off. After code PR #568
+is available, `azd provision` seeds five keys under the `gpt-rag` label
+with safe defaults (`FOUNDRY_IQ_MCP_ENABLED=false`, an empty source list,
+and conservative defaults for the rest). You do not have to create them by
+hand.
 
 | Key | Default | Purpose |
 | --- | --- | --- |
@@ -130,7 +144,7 @@ have to create them by hand.
 | `FOUNDRY_IQ_MCP_SOURCES_JSON` | `[]` | JSON array of MCP source objects. See schema below. |
 | `FOUNDRY_IQ_MCP_REASONING_EFFORT` | `low` | `low` or `medium`. Controls the knowledge base's `retrievalReasoningEffort` when MCP is enabled. |
 | `FOUNDRY_IQ_MCP_TRUSTED_HOSTS` | `` (empty) | Comma-separated allowlist of exact hostnames. Every `serverURL` host must match one of these exactly. |
-| `FOUNDRY_IQ_MCP_LOG_TOOL_ARGUMENTS` | `false` | Orchestrator-side flag reserved for verbose troubleshooting logging of generated tool arguments. Leave `false` outside a debugging session; generated arguments can echo back user question content. |
+| `FOUNDRY_IQ_MCP_LOG_TOOL_ARGUMENTS` | `false` | Reserved for a compatible orchestrator implementation. Code PR #568 only seeds this key; it does not log tool arguments. Leave it `false` because arguments can contain user or customer data. |
 
 ### Source schema
 
@@ -158,7 +172,7 @@ Each entry in `FOUNDRY_IQ_MCP_SOURCES_JSON` is a JSON object:
 | `description` | No | Defaults to a generic description if omitted. |
 | `serverURL` | Yes | Must be `https://`, no userinfo, no fragment, no IP literal, and its host must exactly match an entry in `FOUNDRY_IQ_MCP_TRUSTED_HOSTS`. |
 | `tools` | Yes | Non-empty array. Every tool the planner is allowed to call. |
-| `auth` | No | Validation-only; see [Authentication](#authentication). Never forwarded into the registration payload. |
+| `auth` | No | Validation-only in code PR #568. It is never forwarded and does not authenticate the endpoint. See [Authentication](#authentication). |
 
 Each tool object:
 
@@ -170,7 +184,8 @@ Each tool object:
 | `inclusionMode` | Yes | `reranked` (only included when the reranker judges it relevant) or `always` (always passed to the model; budget accordingly). |
 | `maxOutputTokens` | Yes | Positive integer. Provisioning enforces a local cap of `8192` regardless of what the Search service would otherwise accept, to bound cost and prompt size. |
 
-`azd provision` parses and validates this JSON during setup and **fails the
+After code PR #568 is available, `azd provision` parses and validates this
+JSON during setup and **fails the
 deployment closed** if it is invalid while `FOUNDRY_IQ_MCP_ENABLED=true`:
 malformed JSON, zero sources, zero tools, duplicate source or tool names,
 a non-`https` scheme, userinfo or a fragment in `serverURL`, an IP-literal
@@ -197,35 +212,47 @@ so the allowlist is DNS-hostname-only.
 
 ### Authentication
 
-The Azure AI Search REST schema for authenticating an `mcpServer`
-knowledge source is not yet publicly documented as of this preview. Rather
-than guess at an unverified field and silently no-op or fail at
-registration time, this provisioning template supports exactly one
-authentication mode:
+There are two separate authentication hops:
 
-- **Implicit managed identity (supported).** The common case, and the one
-  used by the Azure Monitor MCP reference scenario below: grant the Azure
-  AI Search service's system-assigned managed identity the RBAC role it
-  needs on the target resource, and configure nothing else. No `auth`
-  field is required in the source JSON at all.
+1. The orchestrator authenticates to Azure AI Search to call the Knowledge
+   Base.
+2. Azure AI Search calls the MCP endpoint and must satisfy that endpoint's
+   authentication requirements.
 
-If you add an `auth` object to a source, it is validated but never
-forwarded into the registration payload:
+Do not treat the trusted-host list, private DNS, an IP allowlist, TLS, or
+CORS as authentication. CORS is a browser control and does not protect this
+server-to-server call.
 
-- `{"kind": "managedIdentity"}` is accepted as an explicit (and
-  functionally redundant) no-op.
-- `{"kind": "foundryConnection"}` is always rejected. GPT-RAG calls the
-  knowledge base retrieve API directly; Foundry project connection
-  authentication does not apply to that path.
-- Anything containing API keys, tokens, secrets, passwords, or literal
-  header values is always rejected. **Do not put credential material in
-  `FOUNDRY_IQ_MCP_SOURCES_JSON` or anywhere in App Configuration.**
-- Any other `auth.kind` is rejected with a "not yet supported" error.
+Azure AI Search currently documents three endpoint-authentication patterns:
 
-Static long-lived header/token authentication for MCP servers, and
-dynamic per-query managed-identity/OBO credential forwarding, are tracked
-as orchestrator-side follow-up work once the Search team documents the
-real schema; they are not implemented by this provisioning template.
+- `foundryConnection`, only when Foundry Agent Service invokes the
+  Knowledge Base. It does not apply to GPT-RAG's direct retrieve call.
+- `storedHeaders`, for static credentials. GPT-RAG code PR #568 does not
+  render this option and rejects literal credentials.
+- Paired query-time control headers, prefixed with the knowledge-source
+  name. This is the appropriate upstream mechanism for rotating or
+  per-request credentials, but it requires orchestrator support that is
+  not included in code PR #568.
+
+Managed identity and OBO describe how a compatible orchestrator can obtain
+the token placed in a paired query-time header:
+
+- **Managed identity** obtains an app-only token. Every user sees the same
+  MCP authorization scope.
+- **On-behalf-of (OBO)** exchanges the signed-in user's delegated token.
+  Use it only when the MCP server enforces per-user authorization.
+
+Neither mode is enabled by writing `{"kind": "managedIdentity"}` in
+`FOUNDRY_IQ_MCP_SOURCES_JSON`. Code PR #568 accepts that value only as a
+validation no-op and does not emit an `authentication` block. Any `auth`
+object containing API keys, tokens, secrets, passwords, or headers is
+rejected. **Never put credential material in
+`FOUNDRY_IQ_MCP_SOURCES_JSON` or App Configuration.**
+
+Until a compatible orchestrator forwards the documented paired headers,
+use this feature only with an isolated test endpoint that does not require
+credentials. Do not expose an unauthenticated MCP endpoint to the public
+internet.
 
 ### Knowledge base planning model
 
@@ -244,26 +271,36 @@ When MCP is disabled, `models` stays `[]` and reasoning effort stays
 
 Azure Monitor MCP over a workspace-scoped Log Analytics workspace is the
 motivating scenario for this feature, used here purely as a worked
-example -- the template has no Azure-Monitor-specific code path.
+example. The template has no Azure Monitor-specific code path.
 
-1. Deploy or identify an Azure Monitor MCP server endpoint scoped to a
-   single Log Analytics workspace (or a small, explicit set of
-   workspaces). Do not point it at a broad, unscoped Log Analytics
-   surface.
-2. Grant the Azure AI Search service's system-assigned managed identity
-   **Log Analytics Data Reader** at the **workspace scope** (not subscription
-   or resource-group scope) for that workspace. Read-only, workspace-
-   scoped access is the floor: do not grant Contributor or a
-   subscription-wide role for this purpose.
-3. Configure the MCP server's own tool (for example `query_logs`) to
-   enforce, server-side:
-    - A bounded lookback window (for example, 24-72 hours), not
-      open-ended time ranges.
-    - A row/result cap per query.
-    - Read-only KQL only -- no management commands, no cross-workspace
-      joins beyond what you explicitly intend.
-    - Logging of the generated KQL so it is auditable after the fact.
-4. Add the source to `FOUNDRY_IQ_MCP_SOURCES_JSON`:
+1. Deploy or identify an Azure Monitor MCP endpoint. Put it behind API
+   Management or an equivalent gateway, and restrict the backend to one
+   Log Analytics workspace or a small, explicit set of workspaces.
+2. Identify the principal that actually queries Log Analytics:
+    - If the hosted MCP server uses its own managed identity, grant that
+      identity access.
+    - If a compatible orchestrator forwards an app-only or OBO token, grant
+      the principal represented by that token access.
+
+   Do **not** grant the Azure AI Search service identity Log Analytics
+   access unless your endpoint has a separately verified design that
+   authenticates and uses that identity.
+3. Assign **Log Analytics Data Reader** at the **workspace scope**, not at
+   subscription or resource-group scope. Do not grant Contributor.
+4. Expose only the Azure Monitor MCP workspace-log query tool. Get its
+   exact name from the endpoint's `tools/list` response because tool names
+   can change between Azure MCP Server versions. Enforce these controls in
+   the MCP server or gateway, not only in the prompt:
+    - A bounded lookback, such as 24 hours.
+    - A row cap, such as 100 rows.
+    - Read-only KQL, with no management commands or unapproved
+      cross-workspace queries.
+    - Auditable tool arguments and generated KQL. Payloads can contain
+      customer data, so log them only in a controlled environment and
+      apply retention and access controls.
+5. Add the source to `FOUNDRY_IQ_MCP_SOURCES_JSON`. Replace
+   `<workspace-log-query-tool>` with the exact name returned by
+   `tools/list`:
 
    ```json
    [
@@ -273,7 +310,7 @@ example -- the template has no Azure-Monitor-specific code path.
        "serverURL": "https://azmon-mcp.contoso.com/mcp",
        "tools": [
          {
-           "name": "query_logs",
+           "name": "<workspace-log-query-tool>",
            "outputParsing": "auto",
            "inclusionMode": "reranked",
            "maxOutputTokens": 4096
@@ -283,18 +320,26 @@ example -- the template has no Azure-Monitor-specific code path.
    ]
    ```
 
-5. Add `azmon-mcp.contoso.com` to `FOUNDRY_IQ_MCP_TRUSTED_HOSTS`, set
-   `FOUNDRY_IQ_MCP_ENABLED=true`, re-run `azd hooks run postprovision` (or
-   `azd provision`), and `azd deploy`.
-6. Ask a bounded, time-scoped question (for example, "were there any
-   5xx spikes on the checkout service in the last 24 hours?") and review
-   the generated KQL in the MCP server's own logs before trusting the
-   answer in a shared environment.
+6. Add `azmon-mcp.contoso.com` to `FOUNDRY_IQ_MCP_TRUSTED_HOSTS`. In an
+   isolated test environment with compatible provisioning and
+   orchestrator builds, set `FOUNDRY_IQ_MCP_ENABLED=true` and run
+   `azd hooks run postprovision` or `azd provision`.
+7. Ask a bounded question, such as "Were there any 5xx spikes on the
+   checkout service in the last 24 hours? Limit the result to 100 rows."
+   Review the generated KQL before trusting the answer. A safe query should
+   contain both a time predicate and a result cap, for example:
 
-The bounded time range, row cap, read-only access, and auditable
-generated KQL in steps 3 and 6 are not optional hardening -- they are the
-minimum bar for exposing a natural-language-to-KQL tool to an LLM planner
-you do not fully control the prompting of.
+   ```kusto
+   AppRequests
+   | where TimeGenerated >= ago(24h)
+   | where ResultCode startswith "5"
+   | summarize failures = count() by bin(TimeGenerated, 15m)
+   | top 100 by TimeGenerated desc
+   ```
+
+The bounded time range, row cap, read-only role, and auditable KQL are the
+minimum controls for exposing a natural-language-to-KQL tool to an LLM
+planner.
 
 ## Network and gateway guidance
 
@@ -302,10 +347,13 @@ The trusted-host allowlist in this template is provisioning-time defense
 in depth, not a substitute for network-level control. Before enabling any
 MCP source outside a fully isolated test environment:
 
-- **Put the MCP server behind Azure API Management (or an equivalent
-  gateway)** so you get centralized authentication, rate limiting, and
-  request logging independent of what the MCP server itself implements.
-  See [Expose a REST API as an MCP server](https://learn.microsoft.com/azure/api-management/export-rest-mcp-server),
+- **Put the MCP server behind Azure API Management or an equivalent
+  gateway** so authentication, authorization, rate limiting, and
+  request logging do not depend only on the MCP implementation. Point
+  `serverURL` at the gateway endpoint, then add the gateway hostname to
+  `FOUNDRY_IQ_MCP_TRUSTED_HOSTS`. See
+  [Expose and govern an existing MCP server](https://learn.microsoft.com/azure/api-management/expose-existing-mcp-server),
+  [Secure access to MCP servers](https://learn.microsoft.com/azure/api-management/secure-mcp-servers),
   [About MCP servers in Azure API Management](https://learn.microsoft.com/azure/api-management/mcp-server-overview),
   and [Monitor MCP server traffic in Azure API Management](https://learn.microsoft.com/azure/api-management/monitor-mcp-servers).
 - **Rate-limit the MCP endpoint.** The knowledge base planner can call a
@@ -317,6 +365,10 @@ MCP source outside a fully isolated test environment:
   ingress). If the Azure AI Search service is deployed with network
   isolation, confirm the MCP server's hostname is reachable through the
   same private path other outbound Search traffic uses.
+- **Treat network controls and CORS as defense in depth.** Private
+  connectivity and IP rules reduce exposure but do not identify the
+  caller. CORS controls browser JavaScript and does not authenticate Azure
+  AI Search. Require endpoint authentication as well.
 - **Do not expose write-capable or destructive tools.** Every tool
   allowlisted in `FOUNDRY_IQ_MCP_SOURCES_JSON` should be safe to call
   automatically and repeatedly, with no meaningful side effect if the
@@ -332,33 +384,33 @@ MCP source outside a fully isolated test environment:
   semantic correctness (the server accepting a syntactically valid but
   wrong query and returning misleading results). Bound blast radius at the
   MCP server itself, not just at the GPT-RAG configuration layer.
-- Nothing in this template accepts or forwards static credentials. If a
-  production MCP server absolutely requires header/token authentication
-  that this template does not yet support, do not work around that by
+- Nothing in code PR #568 accepts or forwards static credentials. Azure AI
+  Search supports stored headers, but GPT-RAG intentionally does not expose
+  that option because it would place long-lived secrets in configuration.
+  If an MCP server requires header or token authentication, do not work
+  around the missing runtime support by
   embedding a token in `FOUNDRY_IQ_MCP_SOURCES_JSON`, in an environment
-  variable, or anywhere else in App Configuration. Wait for a documented,
-  supported authentication field, or front the MCP server with a gateway
-  that performs the authentication on Search's behalf using the managed
-  identity it already presents.
+  variable, or anywhere else in App Configuration. Use a gateway and a
+  compatible orchestrator that forwards a short-lived token through the
+  documented paired query-time headers.
 
 ## Rollout, canary, and rollback
 
-- **Canary.** Enable one source with one low-risk, read-only tool in a
-  non-production environment first. Confirm the generated tool calls
-  (visible in the MCP server's own request logs, or Azure Monitor/App
-  Insights traces on the Search service) look reasonable before adding
-  more tools or sources.
+- **Canary.** First deploy compatible provisioning and orchestrator builds
+  in a non-production environment. Enable one source with one low-risk,
+  read-only tool. Confirm the endpoint receives authenticated calls and
+  review the generated arguments before adding tools or sources.
 - **Rollout.** Add sources and tools incrementally. Each source is
   independent; a problem with one MCP server does not require disabling
   the others.
-- **Rollback.** Set `FOUNDRY_IQ_MCP_ENABLED=false` (the default) and
-  re-run `azd hooks run postprovision` and `azd deploy`. This is the same
-  disable gate used by every other opt-in Foundry IQ source in GPT-RAG:
-  flipping it back to `false` removes the MCP knowledge source references
-  from the knowledge base and restores `models=[]` and
-  `retrievalReasoningEffort=minimal` exactly as they were before MCP was
-  ever enabled. No data migration or re-provisioning of unrelated sources
-  is required.
+- **Rollback.** Set `FOUNDRY_IQ_MCP_ENABLED=false` and run
+  `azd hooks run postprovision` or `azd provision`. This removes the MCP
+  references from the Knowledge Base and restores `models=[]` and
+  `retrievalReasoningEffort=minimal`. The top-level MCP knowledge-source
+  object can remain registered in Azure AI Search because provisioning
+  does not delete objects that disappear from the template. It is unused
+  after the Knowledge Base reference is removed. Delete it separately only
+  after you verify that no Knowledge Base references it.
 
 ## Production blockers
 
@@ -367,13 +419,15 @@ following are true:
 
 - The `serverURL` is the actual production endpoint, not a development or
   staging hostname left over from testing.
+- A compatible orchestrator sends `messages`-based retrieval and the
+  endpoint authentication has been tested. Code PR #568 alone is not
+  sufficient.
 - Every tool name in `FOUNDRY_IQ_MCP_SOURCES_JSON` matches the MCP
   server's real, current tool names. A stale tool name fails at
   registration or, worse, silently never gets selected by the planner.
-- The identity Azure AI Search authenticates as (its managed identity, or
-  the identity a fronting gateway presents on its behalf) has been
-  reviewed for the correct audience and the least-privilege role needed --
-  not a broader role granted for convenience during testing.
+- The identity used for the MCP endpoint and the identity used by the MCP
+  tool against its backend have both been reviewed for the correct token
+  audience and least-privilege role.
 - The network and gateway guidance above has been reviewed and signed off
   by whoever owns egress/ingress policy for your environment.
 
@@ -386,17 +440,20 @@ following are true:
   `documentsPath`). Fix the JSON and re-run `azd hooks run postprovision`.
 - **No MCP citations in responses.** Confirm `FOUNDRY_IQ_MCP_ENABLED=true`,
   that `FOUNDRY_IQ_MCP_SOURCES_JSON` has at least one source, and that
-  `FOUNDRY_IQ_MCP_REASONING_EFFORT` is `low` or `medium`. Restart the
-  orchestrator so it picks up the App Configuration change.
+  `FOUNDRY_IQ_MCP_REASONING_EFFORT` is `low` or `medium`. Also confirm
+  that your orchestrator build supports `messages`-based MCP retrieval.
+  To identify the source for a citation, join its `activitySource` to the
+  matching activity record; the reference itself has no source name.
 - **Planner never selects the MCP tool.** Reasoning effort, tool
   description quality, and `inclusionMode` all affect selection. Try
   `medium` reasoning, or `inclusionMode: "always"` while diagnosing (then
   revert to `reranked` once you confirm the tool works, to control token
   usage).
 - **Registration succeeds but calls fail at query time with an
-  authentication error.** Confirm the Azure AI Search service's
-  system-assigned managed identity has the RBAC role the MCP server (or
-  its fronting gateway) expects, at the correct scope.
+  authentication error.** Registration does not prove endpoint
+  authentication works. Confirm the compatible orchestrator sends the
+  paired query-time headers, the token audience matches the MCP gateway,
+  and the gateway accepts the app-only or OBO identity you selected.
 
 ## Related reading
 
@@ -404,9 +461,12 @@ following are true:
 - [Foundry IQ prerequisites](howto_grounding_foundry_iq_prereqs.md)
 - [Foundry IQ: Web grounding](howto_grounding_web_bing.md)
 - Microsoft Learn: [What is a knowledge source?](https://learn.microsoft.com/azure/search/agentic-knowledge-source-overview)
+- Microsoft Learn: [Create an MCP Server knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-mcp-server)
 - Microsoft Learn: [Create a Knowledge Base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-create-knowledge-base)
+- Microsoft Learn: [Query a Knowledge Base and review activity and references](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-retrieve)
 - Microsoft Learn: [Build agents using Model Context Protocol on Azure](https://learn.microsoft.com/azure/developer/ai/intro-agents-mcp)
-- Microsoft Learn: [Expose a REST API as an MCP server](https://learn.microsoft.com/azure/api-management/export-rest-mcp-server)
+- Microsoft Learn: [Expose and govern an existing MCP server](https://learn.microsoft.com/azure/api-management/expose-existing-mcp-server)
+- Microsoft Learn: [Secure access to MCP servers](https://learn.microsoft.com/azure/api-management/secure-mcp-servers)
 - Microsoft Learn: [About MCP servers in Azure API Management](https://learn.microsoft.com/azure/api-management/mcp-server-overview)
 - Microsoft Learn: [Azure MCP Server tools for Azure Monitor and Workbooks](https://learn.microsoft.com/azure/developer/azure-mcp-server/tools/azure-monitor)
 - Microsoft Learn: [Log Analytics Data Reader built-in role](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/monitor#log-analytics-data-reader)

--- a/docs/howto_grounding_overview.md
+++ b/docs/howto_grounding_overview.md
@@ -13,7 +13,7 @@ set of pages you are reading.
 | --- | --- | --- |
 | Orchestrator talks to | A single Knowledge Base endpoint that fans out to one or more Knowledge Sources | An Azure AI Search index |
 | `RETRIEVAL_BACKEND` | `foundry_iq` (default in v3.0.2+) | `ai_search` |
-| Sources it can blend | Blob, existing Search index, Work IQ, Fabric ontology, Fabric Data Agent, SharePoint (remote and indexed), OneLake, Web | One AI Search index |
+| Sources it can blend | Blob, existing Search index, Work IQ, Fabric ontology, Fabric Data Agent, SharePoint (remote and indexed), OneLake, Web, generic MCP servers | One AI Search index |
 | Multi-source, permission trimming, agentic retrieval | Yes, out of the box | No, you build it |
 | Custom ingestion pipeline | Optional (`searchIndex` source) | Required (GPT-RAG ingestion into the index) |
 | Status | Default, recommended | Fully supported, rollback and compatibility path |
@@ -79,6 +79,7 @@ flowchart LR
   KB --> KS7[OneLake indexed - indexedOneLake - Preview]
   KB --> KS8[SharePoint indexed - indexedSharePoint - Preview]
   KB --> KS9[Web grounding - web - Preview]
+  KB --> KS10[Generic MCP server - mcpServer - Preview]
 ```
 
 Two things matter for operators.
@@ -113,6 +114,7 @@ Two things matter for operators.
 | OneLake | `indexedOneLake` | Preview, requires workspace RBAC | [OneLake](howto_grounding_onelake.md) |
 | SharePoint indexed | `indexedSharePoint` | Preview, app-only auth | [SharePoint indexed](howto_grounding_sharepoint_indexed.md) |
 | Web grounding | `web` | Preview, billed per Bing call | [Web grounding](howto_grounding_web_bing.md) |
+| Generic MCP server | `mcpServer` | Preview, tool-backed, managed-identity auth only | [Generic MCP server](howto_grounding_mcp_server.md) |
 
 ### Pick a source
 
@@ -139,6 +141,11 @@ Knowledge Base.
   queries lakehouse content natively.
 - **Public web, scoped by allow / block lists.** Add `web`. No ACL, no
   OBO, billed per Bing call.
+- **Live, tool-backed data from a trusted remote MCP server** (metrics,
+  logs, or another system that cannot be pre-indexed). Add `mcpServer`.
+  Requires an explicit tool allowlist, a trusted-host allowlist, and a
+  knowledge base planning model. See
+  [Generic MCP server](howto_grounding_mcp_server.md).
 
 ## Approach B: Azure AI Search direct
 

--- a/docs/howto_grounding_overview.md
+++ b/docs/howto_grounding_overview.md
@@ -114,7 +114,7 @@ Two things matter for operators.
 | OneLake | `indexedOneLake` | Preview, requires workspace RBAC | [OneLake](howto_grounding_onelake.md) |
 | SharePoint indexed | `indexedSharePoint` | Preview, app-only auth | [SharePoint indexed](howto_grounding_sharepoint_indexed.md) |
 | Web grounding | `web` | Preview, billed per Bing call | [Web grounding](howto_grounding_web_bing.md) |
-| Generic MCP server | `mcpServer` | Preview, tool-backed, managed-identity auth only | [Generic MCP server](howto_grounding_mcp_server.md) |
+| Generic MCP server | `mcpServer` | Configuration preview, compatible runtime required | [Generic MCP server](howto_grounding_mcp_server.md) |
 
 ### Pick a source
 
@@ -144,7 +144,9 @@ Knowledge Base.
 - **Live, tool-backed data from a trusted remote MCP server** (metrics,
   logs, or another system that cannot be pre-indexed). Add `mcpServer`.
   Requires an explicit tool allowlist, a trusted-host allowlist, and a
-  knowledge base planning model. See
+  knowledge base planning model. The proposed provisioning settings are
+  not yet available in a released GPT-RAG version, and a compatible
+  orchestrator is also required. See
   [Generic MCP server](howto_grounding_mcp_server.md).
 
 ## Approach B: Azure AI Search direct

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
         - SharePoint indexed: howto_grounding_sharepoint_indexed.md
         - OneLake: howto_grounding_onelake.md
         - Web grounding: howto_grounding_web_bing.md
+        - Generic MCP server: howto_grounding_mcp_server.md
       - 'Approach B: AI Search direct':
         - Overview: howto_grounding_ai_search_direct.md
         - SharePoint connector: howto_sharepoint_connector.md


### PR DESCRIPTION
## Purpose

Documentation portion of Azure/gpt-rag#567 (companion to code PR #568,
`feature/foundry-iq-mcp-server` -> `develop`). Adds the how-to page for
the new opt-in, preview `mcpServer` Foundry IQ knowledge source and wires
it into the existing grounding-sources navigation.

## What changed

- `docs/howto_grounding_mcp_server.md` (new): preview banner and trust-
  boundary warning, how it works at retrieval time, when to use / not use
  it, prerequisites, full `FOUNDRY_IQ_MCP_*` configuration and source
  JSON schema reference, the trusted-host allowlist model, the
  managed-identity-only authentication boundary (why `foundryConnection`
  and literal secrets are rejected), the knowledge-base planning-model
  reuse, a worked Azure Monitor MCP reference scenario (workspace-scoped
  Log Analytics Data Reader, bounded time range and row caps, auditable
  KQL), API Management / gateway and rate-limiting guidance, rollout /
  canary / rollback via the existing disable gate, production blockers,
  and troubleshooting.
- `docs/howto_grounding_overview.md`: added the `mcpServer` source to
  the approach comparison table, the source diagram, the ""knowledge
  sources at a glance"" table, and the ""pick a source"" list.
- `docs/howto_grounding_foundry_iq_prereqs.md`: added `mcpServer` to
  the authorization-model-per-source table and to the query-planning-LLM
  section (MCP requires `low`/`medium` reasoning, same as Web).
- `mkdocs.yml`: registered the new page under **Approach A: Foundry
  IQ**, after Web grounding.

## Related Backlog Item or Issue

Related to Azure/gpt-rag#567 (docs portion). Companion code PR: #568.

## Is this change disruptive or does it break existing applications?

- [x] No. Documentation only.

## Cross-Repository Dependencies

- [ ] gpt-rag-orchestrator
- [ ] gpt-rag-ingestion
- [ ] gpt-rag-ui
- [ ] gpt-rag-mcp

## Does this require changes to project documentation?

- [x] Yes -- this is the documentation change.

## Validation

- `python -m mkdocs build --strict` from the `docs` branch worktree
  completes with no errors and no new warnings (only two pre-existing
  orphan-page notices unrelated to this change).
- Citations verified against Microsoft Learn search (Azure MCP Server /
  Azure Monitor tools, Azure API Management MCP server governance and
  monitoring docs, Azure built-in roles for Monitor -- corrected to the
  more precise **Log Analytics Data Reader** role rather than the broader
  Log Analytics Reader role) before inclusion.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I have tested the new functionality and ensured existing features still work
- [x] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request