### PR TITLE
docs(governance): add audit trail baseline

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,8 +43,8 @@ Use the table below for the deployment parameters behind each layer, and the [De
 
 For data ownership, telemetry, retention, and responsibility boundaries, see
 [Governance and responsible operation](governance_overview.md). The correlated
-audit event contract on that page is under development and is not part of the
-current released runtime.
+audit event implementation on that page is unreleased, disabled by default, and
+not part of the current GPT-RAG deployment.
 
 ## Key Capabilities
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,11 @@ Use the table below for the deployment parameters behind each layer, and the [De
 | Existing platform / AI Landing Zone integration | Optional enterprise integration | `DEPLOYMENT_MODE=ailz-integrated`, `USE_EXISTING_VNET`, `EXISTING_*_RESOURCE_ID`, `HUB_INTEGRATION_*` | Reusing central network, DNS, observability, Bastion, NAT, or hub-spoke resources. |
 | Scenario capabilities | Optional feature add-ons | `DEPLOY_SPEECH_SERVICE`, `DEPLOY_GROUNDING_WITH_BING`, `ENABLE_AGENTIC_RETRIEVAL` | Enabling voice, Bing grounding, or agentic retrieval scenarios. MCP/tool-hosting and NL2SQL application behavior are configured outside the Bicep-deployed infrastructure shown in this diagram. |
 
+For data ownership, telemetry, retention, and responsibility boundaries, see
+[Governance and responsible operation](governance_overview.md). The correlated
+audit event contract on that page is under development and is not part of the
+current released runtime.
+
 ## Key Capabilities
 
 - **Enterprise-Grade Security**  

--- a/docs/governance_audit_contract_v1.md
+++ b/docs/governance_audit_contract_v1.md
@@ -1,282 +1,562 @@
 # Audit Contract v1
 
-This page is the proposed technical contract for reconstructing GPT-RAG request,
-route, source, tool, and outcome activity through Azure Monitor.
+Use this page to understand the unreleased GPT-RAG orchestrator audit event
+contract, estimate its telemetry volume, and prepare queries for a future
+runtime release.
 
-!!! warning "Proposed contract, not released"
-    Current GPT-RAG releases do not emit this event set. The names, fields,
-    enums, bounds, feature flags, health behavior, and queries below are
-    implementation assumptions based on the design brief for issue
-    [#571](https://github.com/Azure/GPT-RAG/issues/571). They must be compared
-    field by field with the runtime schema pull request and validated against
-    deployed telemetry before this contract is described as available.
+!!! warning "Implemented in a pull request, but not released"
+    This page is reconciled with orchestrator pull request
+    [#277](https://github.com/Azure/gpt-rag-orchestrator/pull/277) at commit
+    `40e581aafed7051132859d95bc07e3b08ef17e68`. That code is not in a released
+    orchestrator version. Audit events also remain disabled by default and need
+    GPT-RAG umbrella deployment integration before they are available through a
+    normal GPT-RAG deployment. Do not configure the flags below until the
+    runtime release and integration are complete.
 
-## Contract goals
+The contract provides best-effort operational evidence. It is not a transaction
+log, an immutable or nonrepudiable record, independent attestation, or proof
+that a component behaved correctly. It does not establish legal or regulatory
+compliance.
 
-Audit Contract v1 is designed to:
+## What the implementation covers
 
-- reconstruct a representative request without recording sensitive content;
-- correlate custom events with request and dependency telemetry;
-- keep event values bounded and machine-readable;
-- state when content was omitted or redacted;
-- remain additive so consumers can ignore unknown optional fields; and
-- reuse GPT-RAG's OpenTelemetry and Application Insights integration.
-
-It is not a transaction log, a source of legal conclusions, an immutable
-ledger, or proof that the producing component behaved correctly.
+The orchestrator implementation adds request, route, grounding source, tool,
+outcome, and audit-emission events over the existing OpenTelemetry and Azure
+Monitor connection.
 
 ```mermaid
 flowchart LR
-  Runtime[GPT-RAG runtime] -->|metadata-only custom events| Events[AppEvents]
-  Runtime -->|requests and calls| Traces[AppRequests and AppDependencies]
-  Runtime -. explicit content opt-in .-> Content[AppGenAIContent]
-  Events --> Query[Correlation query]
-  Traces --> Query
+  Request[Request] --> Route[Route selection]
+  Route --> Sources[Grounding sources]
+  Sources --> Tools[Tool calls]
+  Tools --> Outcome[Outcome]
+  Request -. correlation ID .-> Events[AppEvents]
+  Route -. audit event .-> Events
+  Sources -. audit events .-> Events
+  Tools -. audit events .-> Events
+  Outcome -. audit events .-> Events
 ```
 
-## Application Insights representation
+The shared schema reserves ingestion event names, but orchestrator pull request
+#277 does not implement an ingestion producer.
 
-The proposal uses Azure Monitor OpenTelemetry custom events. The producer sets
-`microsoft.custom_event.name`; workspace-based Application Insights stores the
-event in `AppEvents`.
+The exact reviewed artifacts are:
 
-| Contract value | `AppEvents` representation |
+- [logical v1 schema](https://github.com/Azure/gpt-rag-orchestrator/blob/40e581aafed7051132859d95bc07e3b08ef17e68/contracts/audit-event-v1.schema.json)
+- [Application Insights wire schema](https://github.com/Azure/gpt-rag-orchestrator/blob/40e581aafed7051132859d95bc07e3b08ef17e68/contracts/audit-event-v1.application-insights.schema.json)
+- [golden logical event](https://github.com/Azure/gpt-rag-orchestrator/blob/40e581aafed7051132859d95bc07e3b08ef17e68/tests/golden/audit_event_v1.json)
+- [runtime configuration guidance](https://github.com/Azure/gpt-rag-orchestrator/blob/40e581aafed7051132859d95bc07e3b08ef17e68/README.md#audit-event-configuration)
+
+## Application Insights wire format
+
+The producer writes through the `gptrag.audit` logger with the fixed log body
+`GPT-RAG audit event`. It sets `microsoft.custom_event.name` to
+`gptrag.audit.<event_type>`, which the pinned Azure Monitor exporter converts to
+an `AppEvents` row.
+
+| Logical value | Workspace-based Application Insights value |
 | --- | --- |
-| Event name | `Name` |
-| Event timestamp | `TimeGenerated` |
-| W3C trace ID | `OperationId` |
-| Parent operation or span | `ParentId` |
-| GPT-RAG envelope and event fields | `Properties` |
-| Producing service | `AppRoleName` and `gptrag.audit.component` |
-| Producing version | `AppVersion` and `gptrag.audit.service_version` |
+| Custom event name | `AppEvents.Name` |
+| Export time | `AppEvents.TimeGenerated` |
+| Current OpenTelemetry trace ID | `AppEvents.OperationId` |
+| Current OpenTelemetry span ID | `AppEvents.ParentId` |
+| Event fields | Unprefixed keys in `AppEvents.Properties` |
+| Service name | `AppEvents.AppRoleName` and `Properties["service_name"]` |
+| Runtime version | `AppEvents.AppVersion` and `Properties["service_version"]` |
 
-Application Insights uses `customEvents` in the classic Application Insights
-query experience and `AppEvents` in the workspace schema. The queries on this
-page use the workspace schema provisioned by GPT-RAG.
+The event property names are not prefixed with `gptrag.audit.`. For example,
+use `Properties["correlation_id"]`, not
+`Properties["gptrag.audit.correlation_id"]`.
+The exporter can add properties such as source-code attributes or
+`logger_name`; v1 readers must ignore unknown optional properties.
 
-Sensitive prompts, responses, system instructions, and tool content must not be
-placed in `AppEvents`. Azure Monitor maps the relevant `gen_ai.*` content
-attributes to `AppGenAIContent`. Sensitive-content capture remains an explicit
-opt-in and the table should be protected. Follow the current Azure Monitor
-migration guidance before enabling content capture. During the table migration,
-the same content attributes can also be routed to existing telemetry tables
-unless the documented protection feature is enabled.
+Azure Monitor stringifies every custom event property. Logical numbers,
+booleans, and arrays therefore arrive as strings. Parse scalar values in KQL
+before comparing or calculating with them. The wire contract does not guarantee
+JSON encoding for arrays. Treat `omitted_fields` and `truncated_fields` as
+display values on the wire unless a future contract defines a portable array
+encoding.
 
-## Proposed event names
+The logical schema allows a root `parent_event_id` to be `null`. Azure Monitor
+drops null custom properties, so the wire event uses this required sentinel:
 
-The `Name` value is proposed as:
+```text
+evt_00000000000000000000000000000000
+```
 
-| Event name | Meaning |
-| --- | --- |
-| `gptrag.audit.request.started` | GPT-RAG accepted a request for processing. |
-| `gptrag.audit.request.completed` | Request processing completed. |
-| `gptrag.audit.request.failed` | Request processing failed. |
-| `gptrag.audit.request.cancelled` | The caller or runtime cancelled processing. |
-| `gptrag.audit.orchestration.decision` | A strategy, route, or fallback was selected. |
-| `gptrag.audit.source.selected` | A grounding source was selected. |
-| `gptrag.audit.source.rejected` | A grounding source was considered but not used. |
-| `gptrag.audit.tool.started` | A tool invocation started. |
-| `gptrag.audit.tool.completed` | A tool invocation completed. |
-| `gptrag.audit.tool.failed` | A tool invocation failed or timed out. |
-| `gptrag.audit.outcome.produced` | A final outcome was produced. |
-| `gptrag.audit.outcome.rejected` | A final outcome was not returned because a bounded policy or runtime reason rejected it. |
+When an event has a valid active span:
 
-A runtime health signal such as `gptrag.audit.health.degraded` is also proposed,
-but it is not part of the per-request audit taxonomy. Its exact name, metric,
-rate limit, and alert behavior are pending implementation.
+- `Properties["trace_id"]` equals `OperationId`;
+- `Properties["span_id"]` equals `ParentId`; and
+- `Properties["parent_event_id"]` expresses the logical audit relationship,
+  not the OpenTelemetry span relationship.
 
-## Common envelope
+If no valid span is active, the logical `trace_id` and `span_id` and the
+exported `OperationId` and `ParentId` use all-zero hexadecimal values. Exclude
+the all-zero trace ID from joins.
 
-Every event should expose this logical envelope. Property names are proposed
-and pending runtime verification.
+The runtime reads `service_version` from the repository root `VERSION` file and
+uses the same value for the OpenTelemetry `service.version` resource attribute.
+The reviewed branch reports `3.7.0`, but the audit feature itself is unreleased.
+The eventual release will report the version packaged in its own `VERSION`
+file.
 
-| Proposed property or column | Type | Semantics |
+## Event names
+
+The orchestrator event name is the `gptrag.audit.` prefix followed by one of
+these exact logical event types:
+
+| `event_type` | `AppEvents.Name` | Current meaning |
 | --- | --- | --- |
-| `gptrag.audit.schema_version` | string | Contract version. Proposed initial value: `1.0`. Consumers branch on this value and ignore unknown optional fields. |
-| `gptrag.audit.event_id` | UUID string | Unique identifier for one audit event. |
-| `gptrag.audit.correlation_id` | opaque string | Operator-facing identifier shared by all events for one logical activity. It is separate from the trace ID because asynchronous work can cross trace boundaries. |
-| `gptrag.audit.parent_event_id` | UUID string, optional | Previous logical audit event when a parent is known. |
-| `OperationId` | 32 hexadecimal characters | W3C `trace-id` populated by Application Insights correlation. |
-| `gptrag.audit.span_id` | 16 hexadecimal characters | W3C span identifier for the emitting operation when available. |
-| `ParentId` | string, optional | Application Insights parent operation or span identifier. |
-| `gptrag.audit.component` | bounded string | Producing component, initially `orchestrator` or `ingestion`. |
-| `gptrag.audit.operation` | bounded string | Activity such as `chat`, `retrieve`, `ingest`, or `tool_call`. |
-| `gptrag.audit.environment` | bounded string | Deployment environment label. Do not store subscription, tenant, or resource credentials. |
-| `gptrag.audit.service_version` | bounded string | Deployed component version. |
-| `gptrag.audit.status` | enum | Current event status from the enum below. |
-| `gptrag.audit.start_time` | ISO 8601 UTC string, optional | Logical activity start when it differs from `TimeGenerated`. |
-| `gptrag.audit.duration_ms` | non-negative integer, optional | Elapsed time for completed, failed, cancelled, or timed-out activity. |
-| `gptrag.audit.capture_mode` | enum | Whether only metadata or explicitly approved sensitive content was enabled. |
-| `gptrag.audit.redaction_applied` | boolean | `true` when the producer omitted or transformed a permitted field. It is not a guarantee that arbitrary content is safe. |
-| `gptrag.audit.omitted_fields` | bounded string array | Field names omitted by policy or validation. Never include omitted values. |
-| `gptrag.audit.actor_id` | HMAC pseudonym, optional | Off by default. Never a raw email, user name, object ID, or token claim. Exact format and configuration are pending. |
+| `request.started` | `gptrag.audit.request.started` | Streaming request processing started. |
+| `request.completed` | `gptrag.audit.request.completed` | Streaming request processing completed. |
+| `request.failed` | `gptrag.audit.request.failed` | Request processing raised an exception. |
+| `request.cancelled` | `gptrag.audit.request.cancelled` | The stream was cancelled or disconnected. |
+| `route.selected` | `gptrag.audit.route.selected` | An agent strategy or single-agent route was selected. |
+| `grounding.source.selected` | `gptrag.audit.grounding.source.selected` | A grounding source or result was selected. |
+| `grounding.source.rejected` | `gptrag.audit.grounding.source.rejected` | A source was rejected, empty, or not selected. |
+| `tool.invocation.started` | `gptrag.audit.tool.invocation.started` | A proxied tool invocation started, or a Foundry IQ activity was reconstructed as started. |
+| `tool.invocation.completed` | `gptrag.audit.tool.invocation.completed` | A tool invocation completed. |
+| `tool.invocation.failed` | `gptrag.audit.tool.invocation.failed` | A tool invocation failed or timed out. |
+| `tool.invocation.cancelled` | `gptrag.audit.tool.invocation.cancelled` | A proxied tool invocation was cancelled. |
+| `outcome.produced` | `gptrag.audit.outcome.produced` | A streamed response was produced. |
+| `outcome.rejected` | `gptrag.audit.outcome.rejected` | A streamed response was rejected after a failure. |
+| `audit.emission.failed` | `gptrag.audit.audit.emission.failed` | Sanitization, serialization, size, attribute, or synchronous logging failed. |
 
-## Event-specific fields
+The shared schema also reserves these names for a future ingestion producer:
 
-| Event group | Proposed fields |
+- `ingestion.request.started`
+- `ingestion.request.completed`
+- `ingestion.request.failed`
+- `ingestion.request.cancelled`
+- `ingestion.document.selected`
+- `ingestion.document.rejected`
+- `ingestion.outcome.produced`
+- `ingestion.outcome.rejected`
+
+## Required logical fields
+
+Every logical event requires these fields. Readers of major version 1 must
+ignore unknown optional fields.
+
+| Field | Logical type and constraint |
 | --- | --- |
-| Request lifecycle | `request_kind`, `status`, `duration_ms`, and, for failure, `error_class` and bounded `reason_code`. |
-| Orchestration decision | `action_type`, `route`, `decision_outcome`, and bounded `reason_code`. Do not record chain-of-thought or free-form model reasoning. |
-| Source selection | `source_kind`, opaque `source_id`, `decision_outcome`, and bounded `reason_code`. Do not record a title, URL query string, document text, or excerpt by default. |
-| Tool invocation | `tool_name`, opaque `invocation_id`, `tool_operation`, `status`, `duration_ms`, and bounded `error_class`. Do not record arguments or results by default. |
-| Final outcome | `outcome_kind`, `status`, `duration_ms`, and bounded `reason_code`. Do not record the response body by default. |
+| `schema_version` | Integer constant `1`. |
+| `event_id` | `evt_` plus 32 lowercase hexadecimal characters. |
+| `event_type` | One of the event types in the shared schema. |
+| `event_time_utc` | UTC timestamp with exactly six fractional digits and a `Z` suffix. |
+| `correlation_id` | `req_` plus 32 lowercase hexadecimal characters. |
+| `trace_id` | 32 lowercase hexadecimal characters. |
+| `span_id` | 16 lowercase hexadecimal characters. |
+| `parent_event_id` | Event ID or `null` in the logical schema. The wire uses the root sentinel instead of `null`. |
+| `service_name` | String, maximum 512 characters. Current value: `gpt-rag-orchestrator`. |
+| `service_version` | String, maximum 512 characters, read from `VERSION`. |
+| `environment` | String, maximum 64 characters. Uses `ENVIRONMENT_NAME`, then `AZURE_ENV_NAME`, then `unknown`. |
+| `operation` | String, maximum 512 characters. |
+| `status` | Exact status enum below. |
+| `reason_code` | Exact reason enum below. |
+| `capture_mode` | `metadata_only` or `sensitive_allowlist`. |
+| `redaction_applied` | Boolean. This indicates that the sanitizer changed a value, not that arbitrary content is safe. |
+| `omitted_fields` | Array of at most 32 field paths, each at most 512 characters. |
+| `truncated_fields` | Array of at most 32 field paths, each at most 512 characters. |
 
-## Proposed enums
+Terminal request and tool events also require `started_at_utc` and
+`duration_ms`. This applies to completed, failed, and cancelled request or tool
+events, including the reserved ingestion request terminal events.
 
-Exact values remain an implementation dependency. The runtime must reject or
-map unknown values rather than emitting unbounded free text.
+## Optional logical fields
 
-| Enum | Proposed values |
+| Fields | Logical type and constraint |
 | --- | --- |
-| `status` | `started`, `ok`, `failed`, `cancelled`, `rejected`, `timeout` |
-| `capture_mode` | `metadata_only`, `sensitive_content_enabled` |
-| `decision_outcome` | `selected`, `rejected`, `fallback` |
-| `error_class` | `authentication`, `authorization`, `validation`, `rate_limited`, `timeout`, `dependency`, `cancelled`, `internal`, `unknown` |
-| `source_kind` | `ai_search`, `foundry_iq_documents`, `work_iq`, `fabric_ontology`, `fabric_data_agent`, `onelake`, `sharepoint_remote`, `sharepoint_indexed`, `web_bing`, `mcp` |
+| `started_at_utc` | UTC timestamp in the same format as `event_time_utc`. |
+| `duration_ms` | Non-negative number. The producer rounds to three decimal places. |
+| `decision_type`, `decision_value` | String, maximum 512 characters. |
+| `source_id` | String or `null`, maximum 512 characters. |
+| `source_type` | String, maximum 512 characters. |
+| `source_rank` | Non-negative integer. |
+| `tool_name` | String, maximum 512 characters. |
+| `tool_id`, `tool_invocation_id` | String or `null`, maximum 512 characters. |
+| `outcome_type`, `failure_type` | String, maximum 512 characters. |
+| `input_count`, `output_count`, `source_count` | Non-negative integer. Current request counts are character and emitted-source-event counts, not token counts. |
+| `partial_output` | Boolean. |
+| `http_status_code` | Integer from 100 through 599. Reserved by the contract but not populated by the reviewed request lifecycle. |
+| `transport` | String, maximum 512 characters. |
+| `actor_id`, `conversation_id`, `question_id`, `thread_id` | String or `null`, maximum 512 characters. `thread_id` is reserved but not populated by the reviewed implementation. |
+| `hmac_key_id` | String, maximum 512 characters. Present on normal emitted events, but not on the minimal `audit.emission.failed` fallback. |
+| `prompt`, `response`, `source_excerpt`, `tool_arguments`, `tool_result` | Sensitive allowlist string, maximum 2,048 characters after conversion and sanitization. |
 
-The source enum represents the specific integrations documented by GPT-RAG. It
-does not imply complete support for Microsoft IQ or access to telemetry produced
-inside Work IQ, Fabric IQ, Foundry IQ, Bing, SharePoint, or an MCP server.
+The logical JSON Schema allows additional properties for forward-compatible
+readers. The current producer is stricter: it omits fields outside its required
+and optional allowlists and records their names in `omitted_fields`.
 
-## Bounds
+## Status and reason enums
 
-OpenTelemetry SDKs default to 128 attributes per span or log record and 128
-events per span. OpenTelemetry does not define a default attribute-value length,
-so the runtime serializer must add explicit limits.
+The exact `status` values are:
 
-| Item | Proposed v1 ceiling | Reconciliation required |
+```text
+started
+completed
+failed
+cancelled
+selected
+rejected
+produced
+```
+
+The exact `reason_code` values are:
+
+```text
+none
+request_received
+request_completed
+request_failed
+request_cancelled
+client_disconnected
+partial_output
+strategy_configured
+direct_model_selected
+agent_selected
+source_selected
+source_rejected
+source_empty
+source_limit_reached
+tool_invoked
+tool_completed
+tool_failed
+tool_cancelled
+timeout
+outcome_produced
+outcome_rejected
+validation_failed
+redaction_failure
+serialization_failure
+event_too_large
+attribute_limit_exceeded
+export_failure
+unknown
+```
+
+Not every reserved reason is emitted by the current orchestrator paths. For
+example, reaching the source event limit stops further source events silently;
+it does not currently emit `source_limit_reached`.
+
+## Bounds and sanitizer behavior
+
+| Bound | Current value |
+| --- | --- |
+| Serialized logical event | 16 KiB UTF-8 |
+| Producer attributes | 60, leaving room for the custom-event marker and three OpenTelemetry source-code attributes |
+| Logical or wire properties | 64 maximum |
+| Metadata string | 512 characters |
+| Environment | 64 characters |
+| Sensitive string | 2,048 characters |
+| Recursive depth | 6 |
+| Dictionary entries considered | 64 |
+| Items emitted from an array | 32 |
+| Recorded omitted or truncated field paths | 32 per list |
+| Source events per request | Configurable from 1 through 25, default 25 |
+
+Metadata and approved sensitive strings that exceed their character limits are
+truncated and named in `truncated_fields`. If the whole event still exceeds 16
+KiB, optional fields are removed until it fits. If only required fields remain
+and the event is still too large, the payload is discarded and an
+`audit.emission.failed` event is attempted.
+
+The recursive sanitizer:
+
+- strips control characters other than tab, line feed, and carriage return;
+- redacts prohibited key classes and configured additional nested keys;
+- scans for bearer and basic credentials, cookies, JWT-like values, connection
+  strings, SAS signatures, private keys, embedded URL credentials, and similar
+  secret forms;
+- handles cycles, unsupported objects, collection bounds, and depth bounds by
+  omitting or truncating fields; and
+- scans the final serialized event before logging it.
+
+This filtering is defense in depth, not a data-loss-prevention boundary.
+
+## Configuration
+
+These values are loaded at startup from Azure App Configuration. The HMAC key
+must be a Key Vault reference and must not be exposed through the admin
+dashboard.
+
+| Key | Default | Exact behavior |
 | --- | --- | --- |
-| Total event properties | 128 | Confirm the runtime serializer and exporter apply the same or a lower limit. |
-| Event name and enum value | 128 characters | Confirm whether validation rejects or maps longer values. |
-| Identifier, component, operation, source, route, and tool fields | 256 characters each | Confirm the exact UTF-8 byte or character rule. |
-| `reason_code` and `error_class` | 128 characters each | Confirm these are allowlisted values, not truncated exception messages. |
-| `omitted_fields` | 32 entries, 128 characters per field name | Confirm serialization and overflow behavior. |
-| Optional properties | 64 in addition to the required envelope, while remaining within the 128 total | Confirm the exact count. |
-| `duration_ms` | Non-negative integer | Define and test the maximum accepted value in the runtime PR. |
+| `AUDIT_EVENTS_ENABLED` | `false` | Enables the emitter. When `false`, inactive audit settings are ignored and no HMAC key is required. |
+| `AUDIT_HMAC_KEY` | Unset | Required when auditing is enabled. Accepts Base64, Base64URL, or hexadecimal encoding of exactly 32 random bytes. Invalid or missing values fail startup. |
+| `AUDIT_HMAC_KEY_ID` | `v1` | Non-secret key version stored on normal events. Required and limited to 512 characters when enabled. |
+| `AUDIT_SENSITIVE_CONTENT_ENABLED` | `false` | Allows fields in the sensitive field allowlist to be considered. |
+| `AUDIT_SENSITIVE_CONTENT_FIELDS` | Empty | Comma-separated subset of `prompt`, `response`, `source_excerpt`, `tool_arguments`, and `tool_result`. Unknown values fail startup when auditing is enabled. |
+| `AUDIT_ACTOR_PSEUDONYM_ENABLED` | `false` | Adds an HMAC pseudonym for the authenticated actor. |
+| `AUDIT_SOURCE_EVENT_LIMIT` | `25` | Accepts an integer from 1 through 25. |
+| `AUDIT_ADDITIONAL_REDACTED_KEYS` | Empty | Comma-separated nested key fragments that the sanitizer always redacts. |
 
-Values that exceed a limit should be omitted or mapped to a bounded sentinel.
-Do not truncate and export a token, secret, arbitrary prompt, exception body, or
-tool payload. Exact byte limits, Unicode handling, and sentinel values are
-pending runtime verification.
+If `AZURE_MONITOR_DISABLE_LOGGING=true` while auditing is enabled, the
+orchestrator enables Azure Monitor log export only for the `gptrag.audit`
+namespace. If normal log export is enabled, audit events use that existing
+export path. A valid `APPLICATIONINSIGHTS_CONNECTION_STRING` is still required.
+If it is unavailable, monitoring export is disabled rather than making the
+orchestrator fail.
 
-## Correlation semantics
+To roll back, set `AUDIT_EVENTS_ENABLED=false` and restart the orchestrator.
+This stops new events. It does not delete previously exported telemetry.
 
-Use [W3C Trace Context](https://www.w3.org/TR/trace-context/) to propagate
-`traceparent` and `tracestate` across supported HTTP boundaries.
+## HMAC identifiers and rotation
 
-- `OperationId` is the W3C trace correlation used to connect `AppEvents`,
-  `AppRequests`, and `AppDependencies`.
-- `gptrag.audit.correlation_id` groups the logical GPT-RAG activity, including
-  work that can cross traces or asynchronous boundaries.
-- `gptrag.audit.event_id` identifies one event.
-- `gptrag.audit.parent_event_id` expresses logical audit ordering when a trace
-  parent is not sufficient.
-- `gptrag.audit.span_id` and `ParentId` retain trace structure when available.
+Auditing requires a 256-bit HMAC key even when actor pseudonyms are disabled.
+The producer uses HMAC-SHA256 over:
 
-Do not put personal or business meaning into trace, correlation, event, or
-invocation identifiers. Generate opaque values with sufficient randomness.
+```text
+<identifier-kind>:<raw-value>
+```
 
-OpenTelemetry generative AI semantic conventions are currently marked
-Development. GPT-RAG can align with fields such as `gen_ai.operation.name` and
-`gen_ai.conversation.id`, but the runtime must pin and document the convention
-version before treating those names as a stable public contract.
+It exports `hmac_` followed by the first 32 lowercase hexadecimal characters of
+the digest. Current code pseudonymizes conversation IDs, question IDs, source
+references, tool IDs, tool invocation IDs, and optional actor IDs. Raw values
+are not placed in those audit properties.
 
-## Privacy semantics
+Create and restrict the key in Key Vault. To rotate it, update
+`AUDIT_HMAC_KEY` and `AUDIT_HMAC_KEY_ID` together, then restart. Identical raw
+values produce different pseudonyms after rotation, so correlation does not
+continue automatically across key versions.
 
-Metadata-only events may include bounded identifiers, statuses, timings,
-component and tool names, source kinds, and reason codes. They must not contain
-prompts, responses, source excerpts, tool arguments, tool results, arbitrary
-exception messages, or URLs with query strings.
+## Sensitive-content capture
 
-Even when sensitive-content capture is explicitly enabled, producers must never
-capture access tokens, API keys, authorization headers, cookies, connection
-strings, credentials, or detected secrets. Redaction must occur before export.
+The default `capture_mode` is `metadata_only`. It changes to
+`sensitive_allowlist` only when both the feature flag is true and the allowlist
+is non-empty. A field not in the allowlist is omitted and named in
+`omitted_fields`.
 
-If actor correlation is later enabled:
+The reviewed implementation places approved sensitive fields in the same
+`AppEvents.Properties` collection as the rest of the audit event. It does not
+route audit content to `AppGenAIContent`. Protect access to `AppEvents`,
+retention, exports, workbooks, alerts, and query results accordingly. Other
+OpenTelemetry generative AI instrumentation may use `AppGenAIContent`
+independently.
 
-1. derive the pseudonym with a deployment-specific HMAC key;
-2. keep the key in Azure Key Vault;
-3. never emit the key identifier, raw actor identifier, or input claim;
-4. define rotation and historical-correlation behavior; and
-5. restrict access to the workload identity that performs the HMAC.
+Even when allowlisted, content is bounded and scanned for prohibited values.
+Do not enable sensitive capture as a troubleshooting shortcut. The scanner
+cannot guarantee that every secret or sensitive business value will be found.
 
-## Best-effort evidence and producer trust
+## MCP and Foundry IQ evidence
 
-The contract provides best-effort reconstruction. It does not guarantee a
-complete record.
+Direct MCP calls from the MCP strategy are wrapped with public Microsoft Agent
+Framework `AIFunction` proxies. The same invocation seam covers SSE and
+streamable HTTP. It emits a started event before delegation and one completed,
+failed, timed-out, or cancelled terminal event. Tool arguments and results are
+only present when their sensitive fields are explicitly allowlisted.
 
-Evidence can be missing because of sampling, filtering, exporter queue loss,
-throttling, process termination, network failure, async context loss, a disabled
-feature flag, an upstream service, or activity generated before instrumentation
-was enabled.
+Both direct MCP transports propagate W3C Trace Context and remove OpenTelemetry
+baggage. This supports trace correlation without forwarding ambient identity
+or other baggage to the MCP server.
 
-Audit events are producer-asserted telemetry from the same process they
-describe. They are not cryptographically signed or independently attested.
-Azure Monitor retention, purge, RBAC, and export settings are operator
-controls. If stronger immutability is required, export to an operator-managed
-destination and apply an appropriate immutable-storage policy.
+Foundry IQ MCP activity has a different evidence quality. The Azure AI Search
+response exposes completed activity but no pre-invocation callback. The
+orchestrator therefore converts each returned activity into a reconstructed
+started and terminal pair after the response arrives. It derives
+`started_at_utc` by subtracting `elapsedMs` from the observation time and uses
+`elapsedMs` as `duration_ms`. The tool name is the bounded
+`foundry_iq_mcp_tool`, and the started event records transport
+`foundry_iq`.
 
-The runtime should not fail a user request only because audit emission failed.
-Instead, it should expose a bounded, rate-limited health signal and let the
-operator identify the affected interval as an evidence gap. This behavior must
-be tested and reconciled with the runtime pull request.
+This reconstructed pair is not proof that a start event was observed when the
+remote call began. If the response or its activity array is missing, those tool
+events are also missing.
+
+Grounding source normalization covers the specific integrations implemented by
+GPT-RAG:
+
+```text
+azure_ai_search
+azure_ai_search_multimodal
+foundry_iq
+foundry_iq_mcp
+web_grounding
+work_iq
+fabric_iq
+fabric_data_agent
+sharepoint_remote
+sharepoint_indexed
+onelake
+nl2sql_datasource
+unknown
+```
+
+This list describes specific Work IQ, Fabric IQ, Foundry IQ, and web grounding
+integrations. It does not claim complete support for Microsoft IQ or visibility
+into telemetry produced inside those upstream services.
+
+## Failure semantics and evidence gaps
+
+Audit emission is deliberately best effort:
+
+- sanitization or serialization failure discards the original payload and
+  attempts a payload-free `audit.emission.failed` event;
+- oversize and attribute-limit failures use the same minimal event;
+- a synchronous logging failure is caught and mapped to `export_failure`;
+- if the minimal event also cannot be logged, the runtime attempts a fixed
+  warning and continues the user operation; and
+- the Azure Monitor batch exporter has no application callback for later
+  delivery failure, so an asynchronous export failure cannot produce a reliable
+  failure event.
+
+The implementation does not add a separate health event, metric, rate limiter,
+or delivery acknowledgment. Operators must use Azure Monitor ingestion health,
+application logs, and expected-volume checks to identify gaps.
+
+Additional known gaps include:
+
+- sampling, filtering, throttling, queue loss, process termination, and network
+  failure;
+- request dependency or body-validation failures before the endpoint handler,
+  which may not receive `X-Correlation-ID` or lifecycle audit events;
+- feedback requests, which receive a server correlation header but do not enter
+  the streaming request audit lifecycle;
+- upstream actions that occur outside instrumented seams;
+- source events after the configured per-request source limit; and
+- the reconstructed Foundry IQ MCP timing described above.
+
+The server ignores an inbound `X-Correlation-ID` and generates a new
+`req_<32 lowercase hex>` value. Successful orchestrator and feedback responses
+return it in `X-Correlation-ID`. The identifier is also saved with a question in
+Cosmos when a question is persisted. It is not authentication, authorization,
+idempotency, proof of delivery, or an immutability mechanism.
+
+## Event volume and benchmark
+
+A normal successful streaming request emits four lifecycle events before source
+or tool activity:
+
+1. `request.started`
+2. `route.selected`
+3. `outcome.produced`
+4. `request.completed`
+
+A failed stream normally emits four events, replacing the last two with
+`outcome.rejected` and `request.failed`. A cancelled stream normally emits
+three: request start, route selection, and request cancellation. The
+single-agent strategy can add another `route.selected` event for its internal
+direct-model or agent-service choice.
+
+Each selected or rejected grounding source adds one event, up to
+`AUDIT_SOURCE_EVENT_LIMIT`. Each proxied direct MCP invocation adds a started
+and terminal pair. Each returned Foundry IQ MCP activity also adds a
+reconstructed pair. There is no separate global per-request tool-event ceiling,
+so do not estimate a fixed maximum using only the 25-event source limit.
+
+The pull request validation ran a non-gating metadata-only microbenchmark with a
+null logging handler for 10,000 events:
+
+| Measurement | Result |
+| --- | --- |
+| Median emitter time | 886.85 microseconds |
+| p95 emitter time | 1,706.20 microseconds |
+| Peak traced memory | 334.1 KiB |
+
+This isolates event construction and sanitization. It does not include Azure
+Monitor export, network latency, production concurrency, or end-to-end request
+p95. Measure representative traffic and ingestion cost before production
+enablement.
 
 ## KQL: reconstruct audit events
 
-This query uses the proposed property names. It is syntactically aligned with
-the workspace-based `AppEvents` schema, but it has not been validated against
-runtime telemetry.
+Replace the correlation ID with the value returned in `X-Correlation-ID`.
+This query uses the exact unprefixed wire properties and converts scalar strings
+to useful KQL types.
 
 ```kusto
 let lookback = 30d;
-let audit_correlation_id = "<gptrag-audit-correlation-id>";
+let audit_correlation_id = "req_0123456789abcdef0123456789abcdef";
 AppEvents
 | where TimeGenerated >= ago(lookback)
 | where Name startswith "gptrag.audit."
-| extend AuditCorrelationId =
-    tostring(Properties["gptrag.audit.correlation_id"])
+| extend AuditCorrelationId = tostring(Properties["correlation_id"])
 | where AuditCorrelationId == audit_correlation_id
 | extend
-    AuditEventId = tostring(Properties["gptrag.audit.event_id"]),
-    SchemaVersion = tostring(Properties["gptrag.audit.schema_version"]),
-    AuditStatus = tostring(Properties["gptrag.audit.status"]),
-    Component = tostring(Properties["gptrag.audit.component"]),
-    DurationMs = tolong(Properties["gptrag.audit.duration_ms"])
+    AuditEventTime = todatetime(Properties["event_time_utc"]),
+    AuditEventId = tostring(Properties["event_id"]),
+    AuditEventType = tostring(Properties["event_type"]),
+    SchemaVersion = toint(Properties["schema_version"]),
+    AuditStatus = tostring(Properties["status"]),
+    ReasonCode = tostring(Properties["reason_code"]),
+    ServiceName = tostring(Properties["service_name"]),
+    ServiceVersion = tostring(Properties["service_version"]),
+    AuditOperation = tostring(Properties["operation"]),
+    DurationMs = todouble(Properties["duration_ms"]),
+    SourceRank = toint(Properties["source_rank"]),
+    OutputCount = tolong(Properties["output_count"]),
+    PartialOutput = tobool(Properties["partial_output"]),
+    RedactionApplied = tobool(Properties["redaction_applied"])
 | project
     TimeGenerated,
+    AuditEventTime,
     Name,
+    AuditEventType,
     AuditCorrelationId,
     AuditEventId,
-    SchemaVersion,
     AuditStatus,
-    Component,
+    ReasonCode,
+    ServiceName,
+    ServiceVersion,
+    AuditOperation,
     DurationMs,
+    SourceRank,
+    OutputCount,
+    PartialOutput,
+    RedactionApplied,
     OperationId,
     ParentId,
     AppRoleName,
+    AppVersion,
     Properties
-| order by TimeGenerated asc
+| order by AuditEventTime asc, TimeGenerated asc
 ```
 
 ## KQL: add requests and dependencies
 
-The second query finds trace operation IDs from the correlated audit events,
-then unions the matching `AppRequests` and `AppDependencies` rows.
+This query builds one timeline from the audit events and matching
+`AppRequests` and `AppDependencies` rows. It uses the official workspace table
+columns, including `DurationMs`, `ResultCode`, `DependencyType`, `Target`, and
+`Data`.
 
 ```kusto
 let lookback = 30d;
-let audit_correlation_id = "<gptrag-audit-correlation-id>";
-let operation_ids = materialize(
+let audit_correlation_id = "req_0123456789abcdef0123456789abcdef";
+let audit_events = materialize(
     AppEvents
     | where TimeGenerated >= ago(lookback)
     | where Name startswith "gptrag.audit."
-    | where tostring(
-        Properties["gptrag.audit.correlation_id"]
-      ) == audit_correlation_id
+    | where tostring(Properties["correlation_id"]) == audit_correlation_id
+);
+let operation_ids = materialize(
+    audit_events
     | where isnotempty(OperationId)
+    | where OperationId != "00000000000000000000000000000000"
     | distinct OperationId
 );
 union
+(
+    audit_events
+    | project
+        TimeGenerated,
+        TelemetryType = "audit",
+        Name,
+        OperationId,
+        ParentId,
+        Id = tostring(Properties["event_id"]),
+        Success = case(
+            tostring(Properties["status"]) in ("failed", "cancelled", "rejected"), false,
+            tostring(Properties["status"]) in ("completed", "selected", "produced"), true,
+            bool(null)
+        ),
+        ResultCode = tostring(Properties["reason_code"]),
+        DurationMs = todouble(Properties["duration_ms"]),
+        DependencyType = "",
+        Target = "",
+        Data = "",
+        Properties
+),
 (
     AppRequests
     | where TimeGenerated >= ago(lookback)
@@ -293,7 +573,8 @@ union
         DurationMs,
         DependencyType = "",
         Target = "",
-        Data = ""
+        Data = Url,
+        Properties
 ),
 (
     AppDependencies
@@ -311,31 +592,35 @@ union
         DurationMs,
         DependencyType,
         Target,
-        Data
+        Data,
+        Properties
 )
 | order by TimeGenerated asc
 ```
 
-`AppDependencies.Data` can contain a URI or other dependency detail. Treat the
-second query's output as potentially sensitive and apply the same access and
-export controls as the underlying workspace.
+`AppRequests.Url`, `AppDependencies.Data`, and arbitrary `Properties` can
+contain sensitive details. Restrict access to query results and exported copies.
 
-## Runtime reconciliation checklist
+The queries are reconciled with the exporter wire conversion test in pull
+request #277 and the official Azure Monitor table schemas. They cannot be run
+against released audit telemetry until the runtime is released and enabled.
 
-Before describing Audit Contract v1 as available:
+## What evidence can support
 
-- replace every proposed event name with the runtime constant;
-- compare every property name, type, required flag, and default;
-- replace proposed enums and bounds with tested runtime values;
-- document exact audit, actor, content, and rollback configuration keys;
-- verify how `OperationId`, span ID, `ParentId`, and logical correlation are
-  populated across sync and async paths;
-- verify prohibited-data filtering before the exporter;
-- verify how `AppGenAIContent` is used when sensitive content is enabled;
-- run both KQL queries against canary telemetry;
-- test sampling, exporter failure, health signaling, and evidence-gap behavior;
-- measure latency, volume, and cost; and
-- preserve the preview warning until the runtime version is released.
+When combined with adopter-owned identity, access, retention, review, and
+incident processes, this evidence can help with:
+
+- security and architecture reviews;
+- incident reconstruction;
+- privacy and risk assessments;
+- adopter-led
+  [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
+  activities; and
+- adopter-led assessments involving the
+  [EU AI Act](https://eur-lex.europa.eu/eli/reg/2024/1689/oj).
+
+The evidence is an input to those activities, not automatic compliance,
+certification, or a legal conclusion.
 
 ## Official references
 
@@ -344,7 +629,4 @@ Before describing Audit Contract v1 as available:
 - [`AppEvents` table](https://learn.microsoft.com/azure/azure-monitor/reference/tables/appevents)
 - [`AppRequests` table](https://learn.microsoft.com/azure/azure-monitor/reference/tables/apprequests)
 - [`AppDependencies` table](https://learn.microsoft.com/azure/azure-monitor/reference/tables/appdependencies)
-- [`AppGenAIContent` table](https://learn.microsoft.com/azure/azure-monitor/reference/tables/appgenaicontent)
 - [W3C Trace Context](https://www.w3.org/TR/trace-context/)
-- [OpenTelemetry SDK environment variables and limits](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)
-- [OpenTelemetry generative AI events](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md)

--- a/docs/governance_audit_contract_v1.md
+++ b/docs/governance_audit_contract_v1.md
@@ -7,7 +7,7 @@ runtime release.
 !!! warning "Implemented in a pull request, but not released"
     This page is reconciled with orchestrator pull request
     [#277](https://github.com/Azure/gpt-rag-orchestrator/pull/277) at commit
-    `40e581aafed7051132859d95bc07e3b08ef17e68`. That code is not in a released
+    `a017fa61914ce5c3ccc560ed91d96e5b5d09b628`. That code is not in a released
     orchestrator version. Audit events also remain disabled by default and need
     GPT-RAG umbrella deployment integration before they are available through a
     normal GPT-RAG deployment. Do not configure the flags below until the
@@ -42,10 +42,23 @@ The shared schema reserves ingestion event names, but orchestrator pull request
 
 The exact reviewed artifacts are:
 
-- [logical v1 schema](https://github.com/Azure/gpt-rag-orchestrator/blob/40e581aafed7051132859d95bc07e3b08ef17e68/contracts/audit-event-v1.schema.json)
-- [Application Insights wire schema](https://github.com/Azure/gpt-rag-orchestrator/blob/40e581aafed7051132859d95bc07e3b08ef17e68/contracts/audit-event-v1.application-insights.schema.json)
-- [golden logical event](https://github.com/Azure/gpt-rag-orchestrator/blob/40e581aafed7051132859d95bc07e3b08ef17e68/tests/golden/audit_event_v1.json)
-- [runtime configuration guidance](https://github.com/Azure/gpt-rag-orchestrator/blob/40e581aafed7051132859d95bc07e3b08ef17e68/README.md#audit-event-configuration)
+- [logical v1 schema](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/contracts/audit-event-v1.schema.json)
+- [Application Insights wire schema](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/contracts/audit-event-v1.application-insights.schema.json)
+- [contract SHA-256 digests](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/contracts/audit-event-v1.sha256)
+- [golden logical event](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/tests/golden/audit_event_v1.json)
+- [golden logical root event](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/tests/golden/audit_event_v1_root.json)
+- [runtime configuration guidance](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/README.md#audit-event-configuration)
+
+The pinned SHA-256 digests of the two schema files, recorded in
+`contracts/audit-event-v1.sha256`, are:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `audit-event-v1.schema.json` | `3c96e4a2ab355bdc87ad9bdba0f4cb369f0d23c3a6c74022e83f971d30b852d9` |
+| `audit-event-v1.application-insights.schema.json` | `cb983f8d48ed3593e91bec8620f3c328e37d3245d50cf544e45892f290f6985a` |
+
+Recompute these digests against the pinned commit before relying on this page
+if the contract is revised.
 
 ## Application Insights wire format
 
@@ -78,11 +91,18 @@ display values on the wire unless a future contract defines a portable array
 encoding.
 
 The logical schema allows a root `parent_event_id` to be `null`. Azure Monitor
-drops null custom properties, so the wire event uses this required sentinel:
+drops null custom properties, so the wire adapter encodes that logical null as
+this reserved sentinel before export:
 
 ```text
 evt_00000000000000000000000000000000
 ```
+
+A consumer must decode `Properties["parent_event_id"] ==
+"evt_00000000000000000000000000000000"` back to logical `null` and must never
+treat it as an identifier or join it as an event. The all-zero value is also
+explicitly rejected as an `event_id` and as any non-root `parent_event_id`, in
+both the logical and wire schemas: it can only ever mean "no logical parent."
 
 When an event has a valid active span:
 
@@ -142,13 +162,13 @@ ignore unknown optional fields.
 | Field | Logical type and constraint |
 | --- | --- |
 | `schema_version` | Integer constant `1`. |
-| `event_id` | `evt_` plus 32 lowercase hexadecimal characters. |
+| `event_id` | `evt_` plus 32 lowercase hexadecimal characters. The all-zero value (`evt_00000000000000000000000000000000`) is reserved and rejected; it can never identify a real event. |
 | `event_type` | One of the event types in the shared schema. |
 | `event_time_utc` | UTC timestamp with exactly six fractional digits and a `Z` suffix. |
 | `correlation_id` | `req_` plus 32 lowercase hexadecimal characters. |
 | `trace_id` | 32 lowercase hexadecimal characters. |
 | `span_id` | 16 lowercase hexadecimal characters. |
-| `parent_event_id` | Event ID or `null` in the logical schema. The wire uses the root sentinel instead of `null`. |
+| `parent_event_id` | Event ID or `null` in the logical schema. `null` marks a root event. The reserved all-zero value is rejected as a non-root parent; the wire uses the all-zero sentinel only to represent `null`. |
 | `service_name` | String, maximum 512 characters. Current value: `gpt-rag-orchestrator`. |
 | `service_version` | String, maximum 512 characters, read from `VERSION`. |
 | `environment` | String, maximum 64 characters. Uses `ENVIRONMENT_NAME`, then `AZURE_ENV_NAME`, then `unknown`. |
@@ -169,7 +189,8 @@ events, including the reserved ingestion request terminal events.
 | Fields | Logical type and constraint |
 | --- | --- |
 | `started_at_utc` | UTC timestamp in the same format as `event_time_utc`. |
-| `duration_ms` | Non-negative number. The producer rounds to three decimal places. |
+| `duration_ms` | Number from 0 through 86,400,000 (24 hours), rounded to three decimal places. The producer rejects out-of-range or non-finite values rather than clamping them. |
+| `timing_source` | `observed` or `reconstructed`. Present only on Foundry IQ MCP tool events today, always as `reconstructed`; absent elsewhere, which means the timestamp was observed directly. `reconstructed` values are approximate, described further in [MCP and Foundry IQ evidence](#mcp-and-foundry-iq-evidence). |
 | `decision_type`, `decision_value` | String, maximum 512 characters. |
 | `source_id` | String or `null`, maximum 512 characters. |
 | `source_type` | String, maximum 512 characters. |
@@ -179,6 +200,7 @@ events, including the reserved ingestion request terminal events.
 | `outcome_type`, `failure_type` | String, maximum 512 characters. |
 | `input_count`, `output_count`, `source_count` | Non-negative integer. Current request counts are character and emitted-source-event counts, not token counts. |
 | `partial_output` | Boolean. |
+| `audit_events_omitted`, `source_events_omitted`, `tool_invocations_omitted` | Non-negative integer. Present only on request-terminal events (`request.completed`, `request.failed`, `request.cancelled`), reporting how many detail, grounding-source, and complete tool-invocation-pair events this request could not emit because a fixed per-request budget was reached. See [Event and tool budgets](#event-and-tool-budgets). |
 | `http_status_code` | Integer from 100 through 599. Reserved by the contract but not populated by the reviewed request lifecycle. |
 | `transport` | String, maximum 512 characters. |
 | `actor_id`, `conversation_id`, `question_id`, `thread_id` | String or `null`, maximum 512 characters. `thread_id` is reserved but not populated by the reviewed implementation. |
@@ -251,8 +273,9 @@ it does not currently emit `source_limit_reached`.
 | Environment | 64 characters |
 | Sensitive string | 2,048 characters |
 | Recursive depth | 6 |
-| Dictionary entries considered | 64 |
-| Items emitted from an array | 32 |
+| Mapping entries inspected | 65 (64 considered plus one truncation lookahead) |
+| Sequence items inspected | 33 (32 emitted plus one truncation lookahead) |
+| Total nested values inspected per event | 256 |
 | Recorded omitted or truncated field paths | 32 per list |
 | Source events per request | Configurable from 1 through 25, default 25 |
 
@@ -264,16 +287,42 @@ and the event is still too large, the payload is discarded and an
 
 The recursive sanitizer:
 
-- strips control characters other than tab, line feed, and carriage return;
+- strips control characters other than tab, line feed, and carriage return,
+  then truncates and records oversize strings and keys;
 - redacts prohibited key classes and configured additional nested keys;
 - scans for bearer and basic credentials, cookies, JWT-like values, connection
   strings, SAS signatures, private keys, embedded URL credentials, and similar
   secret forms;
-- handles cycles, unsupported objects, collection bounds, and depth bounds by
-  omitting or truncating fields; and
+- inspects mappings and sequences through a bounded lookahead so it can detect
+  and record truncation without materializing an entire oversize collection;
+- handles cycles, unsupported objects, malformed iterables, collection bounds,
+  depth bounds, and the total inspected-node cap by omitting or truncating
+  fields instead of raising; and
 - scans the final serialized event before logging it.
 
 This filtering is defense in depth, not a data-loss-prevention boundary.
+
+## Event and tool budgets
+
+Independent of the per-event serialization bounds above, each request has a
+fixed, non-configurable ceiling on how many audit events it can produce:
+
+| Budget | Limit |
+| --- | --- |
+| Audit events per request | 64 total, including one reserved request-terminal event and at most one reserved `audit.emission.failed` event |
+| Tool invocation pairs per request | 16 complete `started` and terminal event pairs |
+| Grounding-source events per request | 25 maximum, the same limit as `AUDIT_SOURCE_EVENT_LIMIT` above |
+
+Tool invocation pairs are reserved atomically: the producer only emits a
+`tool.invocation.started` event once request capacity also guarantees room for
+its terminal event, so a start is never recorded without a matching outcome.
+When a budget is exhausted, the orchestrator drops further detail, source, or
+tool events for that request rather than emitting a partial or malformed one,
+while the reserved request-terminal event still fires. That terminal event
+(`request.completed`, `request.failed`, or `request.cancelled`) reports how
+much was dropped in `audit_events_omitted`, `source_events_omitted`, and
+`tool_invocations_omitted`, so a consumer can tell that evidence is incomplete
+for that request instead of assuming silence means nothing else happened.
 
 ## Configuration
 
@@ -352,17 +401,26 @@ baggage. This supports trace correlation without forwarding ambient identity
 or other baggage to the MCP server.
 
 Foundry IQ MCP activity has a different evidence quality. The Azure AI Search
-response exposes completed activity but no pre-invocation callback. The
-orchestrator therefore converts each returned activity into a reconstructed
-started and terminal pair after the response arrives. It derives
-`started_at_utc` by subtracting `elapsedMs` from the observation time and uses
-`elapsedMs` as `duration_ms`. The tool name is the bounded
-`foundry_iq_mcp_tool`, and the started event records transport
-`foundry_iq`.
+response exposes completed activity but no pre-invocation callback, and
+reconstruction only runs when auditing is enabled and a request audit context
+is present; it never touches retrieval when auditing is disabled. For each
+returned activity, the orchestrator validates that `elapsedMs` is a finite,
+non-negative number of at most 86,400,000 milliseconds (24 hours). If the value
+is invalid, the orchestrator does not clamp it: it omits that tool-invocation
+pair, records it in `tool_invocations_omitted` on the request-terminal event,
+and attempts a bounded, payload-free `audit.emission.failed` event, all without
+failing the underlying retrieval call. If the value is valid, the orchestrator
+reserves a started and terminal event pair atomically, the same way it reserves
+direct tool invocation pairs, and derives `started_at_utc` by subtracting
+`elapsedMs` from the observation time; `elapsedMs` becomes `duration_ms`. The
+tool name is the bounded `foundry_iq_mcp_tool`, the started event records
+transport `foundry_iq`, and both the started and terminal events set
+`timing_source=reconstructed`.
 
 This reconstructed pair is not proof that a start event was observed when the
-remote call began. If the response or its activity array is missing, those tool
-events are also missing.
+remote call began; `timing_source=reconstructed` marks it as approximate. If
+the response or its activity array is missing, those tool events are also
+missing.
 
 Grounding source normalization covers the specific integrations implemented by
 GPT-RAG:
@@ -389,11 +447,23 @@ into telemetry produced inside those upstream services.
 
 ## Failure semantics and evidence gaps
 
+Enabling, disabling, or exhausting a budget in the audit instrumentation never
+changes response bodies, SSE streams, retrieval results, cache behavior,
+application logs, traces, or metrics. For example, a grounding source with
+empty content is still appended to the result list whether or not its
+`grounding.source.rejected` audit event was emitted; audit evidence describes
+what the orchestrator did, it does not gate what the orchestrator does.
+
 Audit emission is deliberately best effort:
 
 - sanitization or serialization failure discards the original payload and
-  attempts a payload-free `audit.emission.failed` event;
+  attempts a payload-free, constant-safe `audit.emission.failed` event, one
+  with a fixed `service_name`, `service_version`, `environment`, and
+  `capture_mode` instead of values derived from the event that failed, so the
+  fallback event itself cannot fail to serialize or redact;
 - oversize and attribute-limit failures use the same minimal event;
+- at most one `audit.emission.failed` event is attempted per request, guarded
+  against re-entrant failures;
 - a synchronous logging failure is caught and mapped to `export_failure`;
 - if the minimal event also cannot be logged, the runtime attempts a fixed
   warning and continues the user operation; and
@@ -414,7 +484,11 @@ Additional known gaps include:
 - feedback requests, which receive a server correlation header but do not enter
   the streaming request audit lifecycle;
 - upstream actions that occur outside instrumented seams;
-- source events after the configured per-request source limit; and
+- detail, source, or tool events dropped after a request reaches the fixed
+  event or tool budgets described in
+  [Event and tool budgets](#event-and-tool-budgets), reported through
+  `audit_events_omitted`, `source_events_omitted`, and
+  `tool_invocations_omitted` on the request-terminal event; and
 - the reconstructed Foundry IQ MCP timing described above.
 
 The server ignores an inbound `X-Correlation-ID` and generates a new
@@ -441,9 +515,14 @@ direct-model or agent-service choice.
 
 Each selected or rejected grounding source adds one event, up to
 `AUDIT_SOURCE_EVENT_LIMIT`. Each proxied direct MCP invocation adds a started
-and terminal pair. Each returned Foundry IQ MCP activity also adds a
-reconstructed pair. There is no separate global per-request tool-event ceiling,
-so do not estimate a fixed maximum using only the 25-event source limit.
+and terminal pair, and each returned Foundry IQ MCP activity also adds a
+reconstructed pair, up to the fixed 16-pair tool budget described in
+[Event and tool budgets](#event-and-tool-budgets). The request also has an
+overall 64-event ceiling that includes its reserved terminal event. A request
+with unusually heavy source or tool activity can reach these budgets; check
+`audit_events_omitted`, `source_events_omitted`, and `tool_invocations_omitted`
+on the request-terminal event rather than assuming the visible event count is
+complete.
 
 The pull request validation ran a non-gating metadata-only microbenchmark with a
 null logging handler for 10,000 events:
@@ -463,7 +542,13 @@ enablement.
 
 Replace the correlation ID with the value returned in `X-Correlation-ID`.
 This query uses the exact unprefixed wire properties and converts scalar strings
-to useful KQL types.
+to useful KQL types. `ParentEventId` decodes the Application Insights wire
+sentinel back to logical `null`: an empty `ParentEventId` means the event is a
+logical root, not that decoding failed. `TimingSource`,
+`AuditEventsOmitted`, `SourceEventsOmitted`, and `ToolInvocationsOmitted` are
+optional fields; expect empty values on events that do not set them, for
+example on every event except reconstructed Foundry IQ MCP tool events and
+request-terminal events respectively.
 
 ```kusto
 let lookback = 30d;
@@ -484,10 +569,22 @@ AppEvents
     ServiceVersion = tostring(Properties["service_version"]),
     AuditOperation = tostring(Properties["operation"]),
     DurationMs = todouble(Properties["duration_ms"]),
+    TimingSource = tostring(Properties["timing_source"]),
     SourceRank = toint(Properties["source_rank"]),
     OutputCount = tolong(Properties["output_count"]),
     PartialOutput = tobool(Properties["partial_output"]),
-    RedactionApplied = tobool(Properties["redaction_applied"])
+    RedactionApplied = tobool(Properties["redaction_applied"]),
+    AuditEventsOmitted = tolong(Properties["audit_events_omitted"]),
+    SourceEventsOmitted = tolong(Properties["source_events_omitted"]),
+    ToolInvocationsOmitted = tolong(Properties["tool_invocations_omitted"])
+| extend
+    // Decode the Application Insights wire sentinel back to a logical null.
+    // Never join or treat this sentinel as an event.
+    ParentEventId = iff(
+        tostring(Properties["parent_event_id"]) == "evt_00000000000000000000000000000000",
+        "",
+        tostring(Properties["parent_event_id"])
+    )
 | project
     TimeGenerated,
     AuditEventTime,
@@ -495,16 +592,21 @@ AppEvents
     AuditEventType,
     AuditCorrelationId,
     AuditEventId,
+    ParentEventId,
     AuditStatus,
     ReasonCode,
     ServiceName,
     ServiceVersion,
     AuditOperation,
     DurationMs,
+    TimingSource,
     SourceRank,
     OutputCount,
     PartialOutput,
     RedactionApplied,
+    AuditEventsOmitted,
+    SourceEventsOmitted,
+    ToolInvocationsOmitted,
     OperationId,
     ParentId,
     AppRoleName,

--- a/docs/governance_audit_contract_v1.md
+++ b/docs/governance_audit_contract_v1.md
@@ -7,7 +7,7 @@ runtime release.
 !!! warning "Implemented in a pull request, but not released"
     This page is reconciled with orchestrator pull request
     [#277](https://github.com/Azure/gpt-rag-orchestrator/pull/277) at commit
-    `a017fa61914ce5c3ccc560ed91d96e5b5d09b628`. That code is not in a released
+    `844fe14757d07a2cdc828189105fbce831f3c11d`. That code is not in a released
     orchestrator version. Audit events also remain disabled by default and need
     GPT-RAG umbrella deployment integration before they are available through a
     normal GPT-RAG deployment. Do not configure the flags below until the
@@ -42,20 +42,20 @@ The shared schema reserves ingestion event names, but orchestrator pull request
 
 The exact reviewed artifacts are:
 
-- [logical v1 schema](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/contracts/audit-event-v1.schema.json)
-- [Application Insights wire schema](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/contracts/audit-event-v1.application-insights.schema.json)
-- [contract SHA-256 digests](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/contracts/audit-event-v1.sha256)
-- [golden logical event](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/tests/golden/audit_event_v1.json)
-- [golden logical root event](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/tests/golden/audit_event_v1_root.json)
-- [runtime configuration guidance](https://github.com/Azure/gpt-rag-orchestrator/blob/a017fa61914ce5c3ccc560ed91d96e5b5d09b628/README.md#audit-event-configuration)
+- [logical v1 schema](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/contracts/audit-event-v1.schema.json)
+- [Application Insights wire schema](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/contracts/audit-event-v1.application-insights.schema.json)
+- [contract SHA-256 digests](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/contracts/audit-event-v1.sha256)
+- [golden logical event](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/tests/golden/audit_event_v1.json)
+- [golden logical root event](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/tests/golden/audit_event_v1_root.json)
+- [runtime configuration guidance](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/README.md#audit-event-configuration)
 
 The pinned SHA-256 digests of the two schema files, recorded in
 `contracts/audit-event-v1.sha256`, are:
 
 | Artifact | SHA-256 |
 | --- | --- |
-| `audit-event-v1.schema.json` | `3c96e4a2ab355bdc87ad9bdba0f4cb369f0d23c3a6c74022e83f971d30b852d9` |
-| `audit-event-v1.application-insights.schema.json` | `cb983f8d48ed3593e91bec8620f3c328e37d3245d50cf544e45892f290f6985a` |
+| `audit-event-v1.schema.json` | `825db8ef40a81e2c19e5d80d37c565b6b47fc9a6540e9881d35cc12b8fde5aab` |
+| `audit-event-v1.application-insights.schema.json` | `066c8f5408610ab839d5121d06ca5bc59e8797e551d5c47c875c5ba52f7e0588` |
 
 Recompute these digests against the pinned commit before relying on this page
 if the contract is revised.
@@ -145,14 +145,13 @@ these exact logical event types:
 
 The shared schema also reserves these names for a future ingestion producer:
 
-- `ingestion.request.started`
-- `ingestion.request.completed`
-- `ingestion.request.failed`
-- `ingestion.request.cancelled`
-- `ingestion.document.selected`
+- `ingestion.run.started`
+- `ingestion.run.completed`
+- `ingestion.run.failed`
+- `ingestion.run.cancelled`
+- `ingestion.document.indexed`
 - `ingestion.document.rejected`
-- `ingestion.outcome.produced`
-- `ingestion.outcome.rejected`
+- `ingestion.document.deleted`
 
 ## Required logical fields
 
@@ -182,7 +181,7 @@ ignore unknown optional fields.
 
 Terminal request and tool events also require `started_at_utc` and
 `duration_ms`. This applies to completed, failed, and cancelled request or tool
-events, including the reserved ingestion request terminal events.
+events, including the reserved ingestion run terminal events.
 
 ## Optional logical fields
 

--- a/docs/governance_audit_contract_v1.md
+++ b/docs/governance_audit_contract_v1.md
@@ -1,0 +1,350 @@
+# Audit Contract v1
+
+This page is the proposed technical contract for reconstructing GPT-RAG request,
+route, source, tool, and outcome activity through Azure Monitor.
+
+!!! warning "Proposed contract, not released"
+    Current GPT-RAG releases do not emit this event set. The names, fields,
+    enums, bounds, feature flags, health behavior, and queries below are
+    implementation assumptions based on the design brief for issue
+    [#571](https://github.com/Azure/GPT-RAG/issues/571). They must be compared
+    field by field with the runtime schema pull request and validated against
+    deployed telemetry before this contract is described as available.
+
+## Contract goals
+
+Audit Contract v1 is designed to:
+
+- reconstruct a representative request without recording sensitive content;
+- correlate custom events with request and dependency telemetry;
+- keep event values bounded and machine-readable;
+- state when content was omitted or redacted;
+- remain additive so consumers can ignore unknown optional fields; and
+- reuse GPT-RAG's OpenTelemetry and Application Insights integration.
+
+It is not a transaction log, a source of legal conclusions, an immutable
+ledger, or proof that the producing component behaved correctly.
+
+```mermaid
+flowchart LR
+  Runtime[GPT-RAG runtime] -->|metadata-only custom events| Events[AppEvents]
+  Runtime -->|requests and calls| Traces[AppRequests and AppDependencies]
+  Runtime -. explicit content opt-in .-> Content[AppGenAIContent]
+  Events --> Query[Correlation query]
+  Traces --> Query
+```
+
+## Application Insights representation
+
+The proposal uses Azure Monitor OpenTelemetry custom events. The producer sets
+`microsoft.custom_event.name`; workspace-based Application Insights stores the
+event in `AppEvents`.
+
+| Contract value | `AppEvents` representation |
+| --- | --- |
+| Event name | `Name` |
+| Event timestamp | `TimeGenerated` |
+| W3C trace ID | `OperationId` |
+| Parent operation or span | `ParentId` |
+| GPT-RAG envelope and event fields | `Properties` |
+| Producing service | `AppRoleName` and `gptrag.audit.component` |
+| Producing version | `AppVersion` and `gptrag.audit.service_version` |
+
+Application Insights uses `customEvents` in the classic Application Insights
+query experience and `AppEvents` in the workspace schema. The queries on this
+page use the workspace schema provisioned by GPT-RAG.
+
+Sensitive prompts, responses, system instructions, and tool content must not be
+placed in `AppEvents`. Azure Monitor maps the relevant `gen_ai.*` content
+attributes to `AppGenAIContent`. Sensitive-content capture remains an explicit
+opt-in and the table should be protected. Follow the current Azure Monitor
+migration guidance before enabling content capture. During the table migration,
+the same content attributes can also be routed to existing telemetry tables
+unless the documented protection feature is enabled.
+
+## Proposed event names
+
+The `Name` value is proposed as:
+
+| Event name | Meaning |
+| --- | --- |
+| `gptrag.audit.request.started` | GPT-RAG accepted a request for processing. |
+| `gptrag.audit.request.completed` | Request processing completed. |
+| `gptrag.audit.request.failed` | Request processing failed. |
+| `gptrag.audit.request.cancelled` | The caller or runtime cancelled processing. |
+| `gptrag.audit.orchestration.decision` | A strategy, route, or fallback was selected. |
+| `gptrag.audit.source.selected` | A grounding source was selected. |
+| `gptrag.audit.source.rejected` | A grounding source was considered but not used. |
+| `gptrag.audit.tool.started` | A tool invocation started. |
+| `gptrag.audit.tool.completed` | A tool invocation completed. |
+| `gptrag.audit.tool.failed` | A tool invocation failed or timed out. |
+| `gptrag.audit.outcome.produced` | A final outcome was produced. |
+| `gptrag.audit.outcome.rejected` | A final outcome was not returned because a bounded policy or runtime reason rejected it. |
+
+A runtime health signal such as `gptrag.audit.health.degraded` is also proposed,
+but it is not part of the per-request audit taxonomy. Its exact name, metric,
+rate limit, and alert behavior are pending implementation.
+
+## Common envelope
+
+Every event should expose this logical envelope. Property names are proposed
+and pending runtime verification.
+
+| Proposed property or column | Type | Semantics |
+| --- | --- | --- |
+| `gptrag.audit.schema_version` | string | Contract version. Proposed initial value: `1.0`. Consumers branch on this value and ignore unknown optional fields. |
+| `gptrag.audit.event_id` | UUID string | Unique identifier for one audit event. |
+| `gptrag.audit.correlation_id` | opaque string | Operator-facing identifier shared by all events for one logical activity. It is separate from the trace ID because asynchronous work can cross trace boundaries. |
+| `gptrag.audit.parent_event_id` | UUID string, optional | Previous logical audit event when a parent is known. |
+| `OperationId` | 32 hexadecimal characters | W3C `trace-id` populated by Application Insights correlation. |
+| `gptrag.audit.span_id` | 16 hexadecimal characters | W3C span identifier for the emitting operation when available. |
+| `ParentId` | string, optional | Application Insights parent operation or span identifier. |
+| `gptrag.audit.component` | bounded string | Producing component, initially `orchestrator` or `ingestion`. |
+| `gptrag.audit.operation` | bounded string | Activity such as `chat`, `retrieve`, `ingest`, or `tool_call`. |
+| `gptrag.audit.environment` | bounded string | Deployment environment label. Do not store subscription, tenant, or resource credentials. |
+| `gptrag.audit.service_version` | bounded string | Deployed component version. |
+| `gptrag.audit.status` | enum | Current event status from the enum below. |
+| `gptrag.audit.start_time` | ISO 8601 UTC string, optional | Logical activity start when it differs from `TimeGenerated`. |
+| `gptrag.audit.duration_ms` | non-negative integer, optional | Elapsed time for completed, failed, cancelled, or timed-out activity. |
+| `gptrag.audit.capture_mode` | enum | Whether only metadata or explicitly approved sensitive content was enabled. |
+| `gptrag.audit.redaction_applied` | boolean | `true` when the producer omitted or transformed a permitted field. It is not a guarantee that arbitrary content is safe. |
+| `gptrag.audit.omitted_fields` | bounded string array | Field names omitted by policy or validation. Never include omitted values. |
+| `gptrag.audit.actor_id` | HMAC pseudonym, optional | Off by default. Never a raw email, user name, object ID, or token claim. Exact format and configuration are pending. |
+
+## Event-specific fields
+
+| Event group | Proposed fields |
+| --- | --- |
+| Request lifecycle | `request_kind`, `status`, `duration_ms`, and, for failure, `error_class` and bounded `reason_code`. |
+| Orchestration decision | `action_type`, `route`, `decision_outcome`, and bounded `reason_code`. Do not record chain-of-thought or free-form model reasoning. |
+| Source selection | `source_kind`, opaque `source_id`, `decision_outcome`, and bounded `reason_code`. Do not record a title, URL query string, document text, or excerpt by default. |
+| Tool invocation | `tool_name`, opaque `invocation_id`, `tool_operation`, `status`, `duration_ms`, and bounded `error_class`. Do not record arguments or results by default. |
+| Final outcome | `outcome_kind`, `status`, `duration_ms`, and bounded `reason_code`. Do not record the response body by default. |
+
+## Proposed enums
+
+Exact values remain an implementation dependency. The runtime must reject or
+map unknown values rather than emitting unbounded free text.
+
+| Enum | Proposed values |
+| --- | --- |
+| `status` | `started`, `ok`, `failed`, `cancelled`, `rejected`, `timeout` |
+| `capture_mode` | `metadata_only`, `sensitive_content_enabled` |
+| `decision_outcome` | `selected`, `rejected`, `fallback` |
+| `error_class` | `authentication`, `authorization`, `validation`, `rate_limited`, `timeout`, `dependency`, `cancelled`, `internal`, `unknown` |
+| `source_kind` | `ai_search`, `foundry_iq_documents`, `work_iq`, `fabric_ontology`, `fabric_data_agent`, `onelake`, `sharepoint_remote`, `sharepoint_indexed`, `web_bing`, `mcp` |
+
+The source enum represents the specific integrations documented by GPT-RAG. It
+does not imply complete support for Microsoft IQ or access to telemetry produced
+inside Work IQ, Fabric IQ, Foundry IQ, Bing, SharePoint, or an MCP server.
+
+## Bounds
+
+OpenTelemetry SDKs default to 128 attributes per span or log record and 128
+events per span. OpenTelemetry does not define a default attribute-value length,
+so the runtime serializer must add explicit limits.
+
+| Item | Proposed v1 ceiling | Reconciliation required |
+| --- | --- | --- |
+| Total event properties | 128 | Confirm the runtime serializer and exporter apply the same or a lower limit. |
+| Event name and enum value | 128 characters | Confirm whether validation rejects or maps longer values. |
+| Identifier, component, operation, source, route, and tool fields | 256 characters each | Confirm the exact UTF-8 byte or character rule. |
+| `reason_code` and `error_class` | 128 characters each | Confirm these are allowlisted values, not truncated exception messages. |
+| `omitted_fields` | 32 entries, 128 characters per field name | Confirm serialization and overflow behavior. |
+| Optional properties | 64 in addition to the required envelope, while remaining within the 128 total | Confirm the exact count. |
+| `duration_ms` | Non-negative integer | Define and test the maximum accepted value in the runtime PR. |
+
+Values that exceed a limit should be omitted or mapped to a bounded sentinel.
+Do not truncate and export a token, secret, arbitrary prompt, exception body, or
+tool payload. Exact byte limits, Unicode handling, and sentinel values are
+pending runtime verification.
+
+## Correlation semantics
+
+Use [W3C Trace Context](https://www.w3.org/TR/trace-context/) to propagate
+`traceparent` and `tracestate` across supported HTTP boundaries.
+
+- `OperationId` is the W3C trace correlation used to connect `AppEvents`,
+  `AppRequests`, and `AppDependencies`.
+- `gptrag.audit.correlation_id` groups the logical GPT-RAG activity, including
+  work that can cross traces or asynchronous boundaries.
+- `gptrag.audit.event_id` identifies one event.
+- `gptrag.audit.parent_event_id` expresses logical audit ordering when a trace
+  parent is not sufficient.
+- `gptrag.audit.span_id` and `ParentId` retain trace structure when available.
+
+Do not put personal or business meaning into trace, correlation, event, or
+invocation identifiers. Generate opaque values with sufficient randomness.
+
+OpenTelemetry generative AI semantic conventions are currently marked
+Development. GPT-RAG can align with fields such as `gen_ai.operation.name` and
+`gen_ai.conversation.id`, but the runtime must pin and document the convention
+version before treating those names as a stable public contract.
+
+## Privacy semantics
+
+Metadata-only events may include bounded identifiers, statuses, timings,
+component and tool names, source kinds, and reason codes. They must not contain
+prompts, responses, source excerpts, tool arguments, tool results, arbitrary
+exception messages, or URLs with query strings.
+
+Even when sensitive-content capture is explicitly enabled, producers must never
+capture access tokens, API keys, authorization headers, cookies, connection
+strings, credentials, or detected secrets. Redaction must occur before export.
+
+If actor correlation is later enabled:
+
+1. derive the pseudonym with a deployment-specific HMAC key;
+2. keep the key in Azure Key Vault;
+3. never emit the key identifier, raw actor identifier, or input claim;
+4. define rotation and historical-correlation behavior; and
+5. restrict access to the workload identity that performs the HMAC.
+
+## Best-effort evidence and producer trust
+
+The contract provides best-effort reconstruction. It does not guarantee a
+complete record.
+
+Evidence can be missing because of sampling, filtering, exporter queue loss,
+throttling, process termination, network failure, async context loss, a disabled
+feature flag, an upstream service, or activity generated before instrumentation
+was enabled.
+
+Audit events are producer-asserted telemetry from the same process they
+describe. They are not cryptographically signed or independently attested.
+Azure Monitor retention, purge, RBAC, and export settings are operator
+controls. If stronger immutability is required, export to an operator-managed
+destination and apply an appropriate immutable-storage policy.
+
+The runtime should not fail a user request only because audit emission failed.
+Instead, it should expose a bounded, rate-limited health signal and let the
+operator identify the affected interval as an evidence gap. This behavior must
+be tested and reconciled with the runtime pull request.
+
+## KQL: reconstruct audit events
+
+This query uses the proposed property names. It is syntactically aligned with
+the workspace-based `AppEvents` schema, but it has not been validated against
+runtime telemetry.
+
+```kusto
+let lookback = 30d;
+let audit_correlation_id = "<gptrag-audit-correlation-id>";
+AppEvents
+| where TimeGenerated >= ago(lookback)
+| where Name startswith "gptrag.audit."
+| extend AuditCorrelationId =
+    tostring(Properties["gptrag.audit.correlation_id"])
+| where AuditCorrelationId == audit_correlation_id
+| extend
+    AuditEventId = tostring(Properties["gptrag.audit.event_id"]),
+    SchemaVersion = tostring(Properties["gptrag.audit.schema_version"]),
+    AuditStatus = tostring(Properties["gptrag.audit.status"]),
+    Component = tostring(Properties["gptrag.audit.component"]),
+    DurationMs = tolong(Properties["gptrag.audit.duration_ms"])
+| project
+    TimeGenerated,
+    Name,
+    AuditCorrelationId,
+    AuditEventId,
+    SchemaVersion,
+    AuditStatus,
+    Component,
+    DurationMs,
+    OperationId,
+    ParentId,
+    AppRoleName,
+    Properties
+| order by TimeGenerated asc
+```
+
+## KQL: add requests and dependencies
+
+The second query finds trace operation IDs from the correlated audit events,
+then unions the matching `AppRequests` and `AppDependencies` rows.
+
+```kusto
+let lookback = 30d;
+let audit_correlation_id = "<gptrag-audit-correlation-id>";
+let operation_ids = materialize(
+    AppEvents
+    | where TimeGenerated >= ago(lookback)
+    | where Name startswith "gptrag.audit."
+    | where tostring(
+        Properties["gptrag.audit.correlation_id"]
+      ) == audit_correlation_id
+    | where isnotempty(OperationId)
+    | distinct OperationId
+);
+union
+(
+    AppRequests
+    | where TimeGenerated >= ago(lookback)
+    | where OperationId in (operation_ids)
+    | project
+        TimeGenerated,
+        TelemetryType = "request",
+        Name,
+        OperationId,
+        ParentId,
+        Id,
+        Success,
+        ResultCode,
+        DurationMs,
+        DependencyType = "",
+        Target = "",
+        Data = ""
+),
+(
+    AppDependencies
+    | where TimeGenerated >= ago(lookback)
+    | where OperationId in (operation_ids)
+    | project
+        TimeGenerated,
+        TelemetryType = "dependency",
+        Name,
+        OperationId,
+        ParentId,
+        Id,
+        Success,
+        ResultCode,
+        DurationMs,
+        DependencyType,
+        Target,
+        Data
+)
+| order by TimeGenerated asc
+```
+
+`AppDependencies.Data` can contain a URI or other dependency detail. Treat the
+second query's output as potentially sensitive and apply the same access and
+export controls as the underlying workspace.
+
+## Runtime reconciliation checklist
+
+Before describing Audit Contract v1 as available:
+
+- replace every proposed event name with the runtime constant;
+- compare every property name, type, required flag, and default;
+- replace proposed enums and bounds with tested runtime values;
+- document exact audit, actor, content, and rollback configuration keys;
+- verify how `OperationId`, span ID, `ParentId`, and logical correlation are
+  populated across sync and async paths;
+- verify prohibited-data filtering before the exporter;
+- verify how `AppGenAIContent` is used when sensitive content is enabled;
+- run both KQL queries against canary telemetry;
+- test sampling, exporter failure, health signaling, and evidence-gap behavior;
+- measure latency, volume, and cost; and
+- preserve the preview warning until the runtime version is released.
+
+## Official references
+
+- [Azure Monitor OpenTelemetry custom telemetry](https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-add-modify#collect-custom-telemetry)
+- [Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete)
+- [`AppEvents` table](https://learn.microsoft.com/azure/azure-monitor/reference/tables/appevents)
+- [`AppRequests` table](https://learn.microsoft.com/azure/azure-monitor/reference/tables/apprequests)
+- [`AppDependencies` table](https://learn.microsoft.com/azure/azure-monitor/reference/tables/appdependencies)
+- [`AppGenAIContent` table](https://learn.microsoft.com/azure/azure-monitor/reference/tables/appgenaicontent)
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- [OpenTelemetry SDK environment variables and limits](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md)
+- [OpenTelemetry generative AI events](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-events.md)

--- a/docs/governance_overview.md
+++ b/docs/governance_overview.md
@@ -4,13 +4,13 @@ Use this guide to decide what data GPT-RAG may process, who owns each
 control, and what evidence an operator should preserve for security reviews
 and incident investigations.
 
-!!! warning "Audit trail feature under development"
+!!! warning "Audit trail implementation is not released"
     The governance practices on this page can be applied today. The correlated
-    audit events described in the [Audit Contract v1](governance_audit_contract_v1.md)
-    are a proposal for a coming release and are not emitted by the current
-    released runtime. Event names, fields, limits, configuration keys, and KQL
-    must be reconciled with the runtime schema pull request before this warning
-    is removed.
+    [Audit Contract v1](governance_audit_contract_v1.md) is reconciled with
+    orchestrator pull request #277, but that implementation is not in a released
+    runtime. It is disabled by default and still needs GPT-RAG umbrella
+    deployment integration. Do not configure it until the runtime release and
+    integration are complete.
 
 ## Why this matters
 
@@ -25,21 +25,20 @@ questions without searching unrelated logs:
 - Who configured access, retention, deletion, and export?
 
 GPT-RAG already uses logs, traces, metrics, and source references. Those signals
-are useful, but current releases do not provide the versioned, end-to-end audit
-contract described in issue
-[#571](https://github.com/Azure/GPT-RAG/issues/571). The coming contract is
-intended to correlate operational metadata while leaving prompts, responses,
-source excerpts, tool arguments, and tool results out of the default event
-stream.
+are useful, but current releases do not provide the versioned audit contract
+described in issue
+[#571](https://github.com/Azure/GPT-RAG/issues/571). The unreleased contract
+correlates operational metadata while leaving prompts, responses, source
+excerpts, tool arguments, and tool results out of the default event stream.
 
 ```mermaid
 flowchart LR
   Request[User request] --> Route[Route and source selection]
   Route --> Tools[Retrieval and tools]
   Tools --> Outcome[Outcome]
-  Route -. proposed audit events .-> Evidence[Correlated operational evidence]
-  Tools -. proposed audit events .-> Evidence
-  Outcome -. proposed audit events .-> Evidence
+  Route -. unreleased audit events .-> Evidence[Correlated operational evidence]
+  Tools -. unreleased audit events .-> Evidence
+  Outcome -. unreleased audit events .-> Evidence
 ```
 
 ## What GPT-RAG can and cannot establish
@@ -83,11 +82,11 @@ Do not assume that:
 - retention in Azure Monitor satisfies a records-management obligation; or
 - technical evidence establishes legal compliance.
 
-The proposed audit trail is best-effort telemetry. Sampling, exporter failures,
+The unreleased audit trail is best-effort telemetry. Sampling, exporter failures,
 process termination, asynchronous boundaries, disabled instrumentation, and
 upstream systems can create evidence gaps. Events are asserted by the producing
 GPT-RAG process. They are not independently attested, cryptographically signed,
-or a tamper-evident ledger.
+tamper-evident, or nonrepudiable.
 
 ## Shared responsibility
 
@@ -104,8 +103,9 @@ explicitly before production use.
 ## Govern ingested and connected data
 
 Apply these controls to indexed content and to sources queried at request time.
-That includes Blob Storage, Azure AI Search, SharePoint, OneLake, Work IQ,
-Fabric ontology, Fabric Data Agent, web grounding, and remote MCP servers.
+That includes Blob Storage, Azure AI Search, SharePoint, OneLake, specific Work
+IQ, Fabric IQ, Foundry IQ and web grounding integrations, and remote MCP
+servers.
 
 ### Before connecting a source
 
@@ -136,9 +136,9 @@ access review, or downstream handling controls.
 
 For the concrete capabilities GPT-RAG integrates, see the
 [Grounding sources overview](howto_grounding_overview.md). GPT-RAG integrates
-specific Work IQ, Fabric ontology, Fabric Data Agent, Foundry IQ, and web
-grounding capabilities. It does not claim complete support for a unified
-"Microsoft IQ" product or governance layer.
+specific Work IQ, Fabric IQ, Foundry IQ, and web grounding capabilities. It
+does not claim complete Microsoft IQ support or provide a Microsoft IQ
+governance layer.
 
 ## Govern generated telemetry
 
@@ -146,16 +146,17 @@ grounding capabilities. It does not claim complete support for a unified
 
 | Class | Examples | Required posture |
 | --- | --- | --- |
-| Operational metadata | Event and correlation IDs, component and version, bounded status and reason codes, durations, tool names, source kinds, opaque source references | Permitted by the proposed metadata-only contract. Classify and minimize it because identifiers and operational context can still be sensitive. |
+| Operational metadata | Event and correlation IDs, service and version, bounded status and reason codes, durations, tool names, source kinds, opaque source references | Permitted by the unreleased metadata-only contract. Classify and minimize it because identifiers and operational context can still be sensitive. |
 | Sensitive content | Prompts, responses, source excerpts, system instructions, tool arguments, tool results | Off by default. Enable only after an explicit need, privacy review, access design, retention decision, and cost review. |
 | Prohibited data | Access tokens, API keys, authorization headers, cookies, connection strings, credentials, and detected secrets | Never capture or export, including when sensitive-content capture is enabled. Redact before telemetry leaves the producing process and fail closed by omitting unsafe values. |
 
-The default proposal records no actor identity. If a future deployment enables
-actor correlation, use a deployment-specific HMAC pseudonym rather than a raw
-user name, email address, object ID, or token claim. Store and rotate the HMAC
-key in Azure Key Vault, restrict access to the producing workload, and document
-the effect of key rotation on historical correlation. The exact actor field and
-configuration are pending the runtime schema pull request.
+Actor correlation is disabled by default. If
+`AUDIT_ACTOR_PSEUDONYM_ENABLED=true`, the producer records `actor_id` as
+`hmac_` plus the first 32 hexadecimal characters of an HMAC-SHA256 digest. It
+never places the raw user name, email address, object ID, or token claim in that
+property. Store `AUDIT_HMAC_KEY` in Azure Key Vault, restrict it to the
+producing workload, and rotate it together with `AUDIT_HMAC_KEY_ID`. Rotation
+breaks direct pseudonym correlation across key versions.
 
 Redaction metadata should say that redaction occurred and list omitted field
 names, never the omitted values. A successful redaction flag does not prove that
@@ -179,14 +180,17 @@ Use this operational baseline:
 - Keep access least-privileged and review role assignments regularly.
 - Separate platform administration from routine telemetry reading where
   practical.
-- If sensitive generative AI content is enabled, use the dedicated
-  `AppGenAIContent` table and configure it as a
-  [protected table](https://learn.microsoft.com/azure/azure-monitor/logs/protected-tables-configure).
-  Check the current
+- The audit implementation stores allowlisted `prompt`, `response`,
+  `source_excerpt`, `tool_arguments`, and `tool_result` values in
+  `AppEvents.Properties`, not `AppGenAIContent`. If audit sensitive capture is
+  approved, restrict `AppEvents`, its query results, alerts, workbooks, and
+  exports accordingly.
+- Other generative AI instrumentation can use `AppGenAIContent`. Follow the
+  current
   [Application Insights routing guidance](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete#generative-ai-telemetry)
-  as well. During Azure Monitor's table migration, content attributes can
-  also appear in existing telemetry tables unless the documented protection
-  feature is enabled, so protecting only `AppGenAIContent` may be insufficient.
+  and configure it as a
+  [protected table](https://learn.microsoft.com/azure/azure-monitor/logs/protected-tables-configure)
+  when that separate content capture is enabled.
 - Test retention changes and deletion procedures in a non-production
   environment.
 - Use
@@ -203,32 +207,35 @@ guarantee complete evidence. Verify the deployed OpenTelemetry and Azure Monitor
 sampling behavior, exporter health, and throttling before relying on telemetry
 for an investigation.
 
-## Roll out the coming audit feature safely
+## Roll out the audit feature after release
 
-The exact configuration keys remain pending until the runtime schema pull
-request is available.
+Do not begin this procedure until the orchestrator implementation is released
+and GPT-RAG umbrella deployment integration is complete.
 
 1. Upgrade with audit emission disabled.
 2. Enable metadata-only events in a non-production environment.
-3. Keep actor correlation and sensitive-content capture disabled.
+3. Keep `AUDIT_ACTOR_PSEUDONYM_ENABLED` and
+   `AUDIT_SENSITIVE_CONTENT_ENABLED` disabled.
 4. If actor correlation is approved, create and restrict a Key Vault HMAC key
    before enabling it.
 5. Canary a small production slice and reconstruct representative requests.
 6. Monitor latency, exporter failures, ingestion volume, retention cost, and
    evidence-gap health signals.
 7. Confirm that existing traces, logs, dashboards, and alerts still work.
-8. Roll back by disabling the audit-emission feature flag. Do not enable
-   sensitive content as a troubleshooting shortcut.
+8. Roll back by setting `AUDIT_EVENTS_ENABLED=false` and restarting the
+   orchestrator. Do not enable sensitive content as a troubleshooting shortcut.
 
 Audit emission should not make the user request fail. If event production or
-export is degraded, the runtime should continue the request, expose a
-rate-limited health signal, and mark the period as an evidence gap for
-operators. The exact health signal and alert threshold are pending runtime
-verification.
+the synchronous logging path fails, the runtime continues the request and
+attempts an `audit.emission.failed` event, then a fixed warning if that also
+fails. The Azure Monitor batch exporter does not expose an application callback
+for later delivery failure. The implementation has no separate health event,
+rate limiter, or delivery acknowledgment, so operators must monitor expected
+volume and Azure Monitor ingestion health.
 
 ## Related reading
 
-- [Audit Contract v1 proposal](governance_audit_contract_v1.md)
+- [Audit Contract v1, unreleased](governance_audit_contract_v1.md)
 - [Authentication and Document-Level Security](howto_authentication.md)
 - [Grounding sources overview](howto_grounding_overview.md)
 - [Azure Monitor Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete)

--- a/docs/governance_overview.md
+++ b/docs/governance_overview.md
@@ -1,0 +1,236 @@
+# Governance and responsible operation
+
+Use this guide to decide what data GPT-RAG may process, who owns each
+control, and what evidence an operator should preserve for security reviews
+and incident investigations.
+
+!!! warning "Audit trail feature under development"
+    The governance practices on this page can be applied today. The correlated
+    audit events described in the [Audit Contract v1](governance_audit_contract_v1.md)
+    are a proposal for a coming release and are not emitted by the current
+    released runtime. Event names, fields, limits, configuration keys, and KQL
+    must be reconciled with the runtime schema pull request before this warning
+    is removed.
+
+## Why this matters
+
+During a review or incident, an operator should be able to answer practical
+questions without searching unrelated logs:
+
+- What route or orchestration strategy handled the request?
+- Which grounding sources and tools were selected?
+- Did each tool call complete, fail, time out, or get cancelled?
+- Was an outcome produced or rejected?
+- What data classes could have entered telemetry?
+- Who configured access, retention, deletion, and export?
+
+GPT-RAG already uses logs, traces, metrics, and source references. Those signals
+are useful, but current releases do not provide the versioned, end-to-end audit
+contract described in issue
+[#571](https://github.com/Azure/GPT-RAG/issues/571). The coming contract is
+intended to correlate operational metadata while leaving prompts, responses,
+source excerpts, tool arguments, and tool results out of the default event
+stream.
+
+```mermaid
+flowchart LR
+  Request[User request] --> Route[Route and source selection]
+  Route --> Tools[Retrieval and tools]
+  Tools --> Outcome[Outcome]
+  Route -. proposed audit events .-> Evidence[Correlated operational evidence]
+  Tools -. proposed audit events .-> Evidence
+  Outcome -. proposed audit events .-> Evidence
+```
+
+## What GPT-RAG can and cannot establish
+
+GPT-RAG cannot determine whether a deployment or use case is legally compliant.
+It does not certify a system, enforce an external governance framework, provide
+a complete legal crosswalk, or replace an adopter's legal, privacy, security,
+risk, records-management, or human-oversight processes.
+
+Clear responsibilities, documented data practices, correlated audit events,
+configurable retention, and reviewable technical evidence can help adopters
+perform their own:
+
+- security and architecture reviews;
+- incident investigations;
+- privacy, risk, and audit assessments;
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
+  activities; and
+- assessments involving the
+  [EU AI Act](https://eur-lex.europa.eu/eli/reg/2024/1689/oj).
+
+These are inputs to an adopter-led assessment, not proof of conformance or a
+legal conclusion. Applicability and evidence requirements depend on the
+deployment, data, users, jurisdiction, and intended use.
+
+## Intended use and limitations
+
+The governance baseline is intended for teams that deploy GPT-RAG as a
+retrieval-augmented assistant and need a repeatable way to manage enterprise
+data and operational evidence.
+
+Do not assume that:
+
+- a citation proves that an answer is correct or complete;
+- a recorded event proves that the producer behaved correctly;
+- missing telemetry proves that an action did not occur;
+- an opaque identifier is anonymous in every environment;
+- permission trimming replaces source-system authorization review;
+- a preview grounding capability is production-ready because it has audit
+  events;
+- retention in Azure Monitor satisfies a records-management obligation; or
+- technical evidence establishes legal compliance.
+
+The proposed audit trail is best-effort telemetry. Sampling, exporter failures,
+process termination, asynchronous boundaries, disabled instrumentation, and
+upstream systems can create evidence gaps. Events are asserted by the producing
+GPT-RAG process. They are not independently attested, cryptographically signed,
+or a tamper-evident ledger.
+
+## Shared responsibility
+
+One organization may perform more than one role. Assign each responsibility
+explicitly before production use.
+
+| Role | Responsibilities |
+| --- | --- |
+| GPT-RAG maintainers | Publish accurate behavior and limitations; provide privacy-conscious defaults; version the audit contract; test schema compatibility, redaction, and bounds; preserve compatibility or publish migration guidance. |
+| Deployer or platform team | Select the deployment topology; configure identities, networking, Key Vault, Azure Monitor, retention, export, and backup; apply least-privilege RBAC; keep secrets out of configuration and telemetry; verify regional and service boundaries. |
+| Runtime operator | Monitor health, cost, sampling, and evidence gaps; review access regularly; investigate incidents; validate deletion and export procedures; canary changes; roll back audit emission if it harms reliability. |
+| Adopter, business owner, or data owner | Define the intended and prohibited uses; assert the right to use each data source; classify data; set minimization and retention policy; determine legal and regulatory obligations; define human oversight, risk acceptance, and user communication. |
+
+## Govern ingested and connected data
+
+Apply these controls to indexed content and to sources queried at request time.
+That includes Blob Storage, Azure AI Search, SharePoint, OneLake, Work IQ,
+Fabric ontology, Fabric Data Agent, web grounding, and remote MCP servers.
+
+### Before connecting a source
+
+1. **Record provenance.** Identify the system of record, data owner, ingestion
+   or query path, refresh cadence, and applicable permission model.
+2. **Obtain a right-to-use assertion.** The operator or data owner should record
+   that the organization is authorized to process the source for the intended
+   users and purpose. GPT-RAG cannot make this determination.
+3. **Classify the data.** Apply the organization's classification for personal,
+   confidential, regulated, export-controlled, or other sensitive content.
+4. **Minimize scope.** Include only the sites, containers, indexes, tables,
+   fields, date ranges, and tools required by the use case.
+5. **Define retention and deletion.** Document how source data, indexes,
+   conversation history, caches, and backups are removed. Test the process.
+6. **Review access.** Use source-system permissions, managed identities,
+   delegated access, and GPT-RAG retrieval controls as applicable. Test with
+   representative allowed and denied users.
+7. **Review data movement.** Confirm region, service, public internet, and
+   cross-boundary behavior for every enabled source.
+
+### Sensitive content
+
+Treat retrieved content as sensitive whenever its source classification says
+so. Grounding can copy excerpts into prompts, responses, conversation history,
+dependency telemetry, or troubleshooting logs. Permission trimming reduces
+unauthorized retrieval, but it does not replace classification, minimization,
+access review, or downstream handling controls.
+
+For the concrete capabilities GPT-RAG integrates, see the
+[Grounding sources overview](howto_grounding_overview.md). GPT-RAG integrates
+specific Work IQ, Fabric ontology, Fabric Data Agent, Foundry IQ, and web
+grounding capabilities. It does not claim complete support for a unified
+"Microsoft IQ" product or governance layer.
+
+## Govern generated telemetry
+
+### Data classes
+
+| Class | Examples | Required posture |
+| --- | --- | --- |
+| Operational metadata | Event and correlation IDs, component and version, bounded status and reason codes, durations, tool names, source kinds, opaque source references | Permitted by the proposed metadata-only contract. Classify and minimize it because identifiers and operational context can still be sensitive. |
+| Sensitive content | Prompts, responses, source excerpts, system instructions, tool arguments, tool results | Off by default. Enable only after an explicit need, privacy review, access design, retention decision, and cost review. |
+| Prohibited data | Access tokens, API keys, authorization headers, cookies, connection strings, credentials, and detected secrets | Never capture or export, including when sensitive-content capture is enabled. Redact before telemetry leaves the producing process and fail closed by omitting unsafe values. |
+
+The default proposal records no actor identity. If a future deployment enables
+actor correlation, use a deployment-specific HMAC pseudonym rather than a raw
+user name, email address, object ID, or token claim. Store and rotate the HMAC
+key in Azure Key Vault, restrict access to the producing workload, and document
+the effect of key rotation on historical correlation. The exact actor field and
+configuration are pending the runtime schema pull request.
+
+Redaction metadata should say that redaction occurred and list omitted field
+names, never the omitted values. A successful redaction flag does not prove that
+all sensitive information was found, so producers must use allowlisted fields
+and bounded enums instead of trying to sanitize arbitrary objects.
+
+## Retention, access, and export
+
+GPT-RAG's current AI Landing Zone template configures the Log Analytics
+workspace for 30 days of retention. A reused workspace or table-level override
+can differ, so inspect the deployed settings rather than assuming the template
+value applies.
+
+Azure Monitor supports up to two years of analytics retention for Analytics
+tables and up to 12 years of total retention with long-term retention. Longer
+retention and additional ingestion can increase cost. The adopter must choose a
+period that matches incident, privacy, records-management, and legal needs.
+
+Use this operational baseline:
+
+- Keep access least-privileged and review role assignments regularly.
+- Separate platform administration from routine telemetry reading where
+  practical.
+- If sensitive generative AI content is enabled, use the dedicated
+  `AppGenAIContent` table and configure it as a
+  [protected table](https://learn.microsoft.com/azure/azure-monitor/logs/protected-tables-configure).
+  Check the current
+  [Application Insights routing guidance](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete#generative-ai-telemetry)
+  as well. During Azure Monitor's table migration, content attributes can
+  also appear in existing telemetry tables unless the documented protection
+  feature is enabled, so protecting only `AppGenAIContent` may be insufficient.
+- Test retention changes and deletion procedures in a non-production
+  environment.
+- Use
+  [Log Analytics data export](https://learn.microsoft.com/azure/azure-monitor/logs/logs-data-export)
+  when continuous export to Azure Storage or Event Hubs is required.
+- If an organization needs WORM retention, configure
+  [immutable Blob Storage](https://learn.microsoft.com/azure/storage/blobs/immutable-storage-overview)
+  on the export destination as an operator-owned control. GPT-RAG does not
+  configure an immutable evidence store.
+
+Sampling affects evidence. A 100 percent sampling configuration may reduce
+sampling gaps, but it increases ingestion and retention cost and still does not
+guarantee complete evidence. Verify the deployed OpenTelemetry and Azure Monitor
+sampling behavior, exporter health, and throttling before relying on telemetry
+for an investigation.
+
+## Roll out the coming audit feature safely
+
+The exact configuration keys remain pending until the runtime schema pull
+request is available.
+
+1. Upgrade with audit emission disabled.
+2. Enable metadata-only events in a non-production environment.
+3. Keep actor correlation and sensitive-content capture disabled.
+4. If actor correlation is approved, create and restrict a Key Vault HMAC key
+   before enabling it.
+5. Canary a small production slice and reconstruct representative requests.
+6. Monitor latency, exporter failures, ingestion volume, retention cost, and
+   evidence-gap health signals.
+7. Confirm that existing traces, logs, dashboards, and alerts still work.
+8. Roll back by disabling the audit-emission feature flag. Do not enable
+   sensitive content as a troubleshooting shortcut.
+
+Audit emission should not make the user request fail. If event production or
+export is degraded, the runtime should continue the request, expose a
+rate-limited health signal, and mark the period as an evidence gap for
+operators. The exact health signal and alert threshold are pending runtime
+verification.
+
+## Related reading
+
+- [Audit Contract v1 proposal](governance_audit_contract_v1.md)
+- [Authentication and Document-Level Security](howto_authentication.md)
+- [Grounding sources overview](howto_grounding_overview.md)
+- [Azure Monitor Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete)
+- [Manage Log Analytics retention](https://learn.microsoft.com/azure/azure-monitor/logs/data-retention-configure)
+- [Manage access to Log Analytics workspaces](https://learn.microsoft.com/azure/azure-monitor/logs/manage-access)

--- a/docs/howto_grounding_fabric_data_agent.md
+++ b/docs/howto_grounding_fabric_data_agent.md
@@ -151,8 +151,8 @@ Managed identity is never used to reach this source, by design.
 
 Fabric Data Agent forwards the caller OBO token to Microsoft Fabric and
 returns grounded answers plus tabular evidence from Fabric data back to
-the orchestrator. Operators enabling Fabric Data Agent should confirm
-this data flow is compliant with their tenant data-boundary and
+the orchestrator. Operators enabling Fabric Data Agent should determine
+whether this data flow is permitted by their tenant data-boundary and
 Fabric-workspace access policies before turning the flag on. Grounded
 content still ends up in orchestrator responses and, transitively, in
 downstream telemetry and chat history.

--- a/docs/howto_grounding_web_bing.md
+++ b/docs/howto_grounding_web_bing.md
@@ -136,8 +136,8 @@ Query terms are sent to Bing and web page snippets are returned to the
 orchestrator. Both cross the public internet and land outside the Azure
 compliance boundary. Grounded snippets still end up in orchestrator
 responses and, transitively, in downstream telemetry and chat history.
-Operators enabling Web grounding should confirm this data flow is
-compliant with their tenant data-boundary policies before turning the
+Operators enabling Web grounding should determine whether this data flow
+is permitted by their tenant data-boundary policies before turning the
 flag on.
 
 ## Citations shape

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,13 @@ The complementary modular view below separates the basic deployment from optiona
 
 ![Modular architecture layers](media/architecture_modular_layers.svg)
 
+## Governance
+
+Before connecting enterprise data or relying on telemetry as evidence, review
+[Governance and responsible operation](governance_overview.md). It explains
+intended use, limitations, data and telemetry responsibilities, retention,
+access, and the proposed audit trail for a coming release.
+
 ## Runtime Services
 
 | Services                                                          | Description                                                                             |

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ The complementary modular view below separates the basic deployment from optiona
 Before connecting enterprise data or relying on telemetry as evidence, review
 [Governance and responsible operation](governance_overview.md). It explains
 intended use, limitations, data and telemetry responsibilities, retention,
-access, and the proposed audit trail for a coming release.
+access, and the exact but unreleased audit trail contract.
 
 ## Runtime Services
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,7 @@ nav:
     - Overview: architecture.md
   - Governance:
     - Overview and responsibilities: governance_overview.md
-    - Audit Contract v1 (proposed): governance_audit_contract_v1.md
+    - Audit Contract v1 (unreleased): governance_audit_contract_v1.md
   - Services:
     - Orchestrator: services_orchestrator.md
     - Ingestion:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ nav:
     - NL2SQL: quickstart_nl2sql.md
   - Architecture:
     - Overview: architecture.md
+  - Governance:
+    - Overview and responsibilities: governance_overview.md
+    - Audit Contract v1 (proposed): governance_audit_contract_v1.md
   - Services:
     - Orchestrator: services_orchestrator.md
     - Ingestion:


### PR DESCRIPTION
## Summary

- add the canonical GPT-RAG governance and shared-responsibility baseline for issue #571
- reconcile Audit Contract v1 exactly with orchestrator PR #277 at `40e581aafed7051132859d95bc07e3b08ef17e68`
- add copy/paste KQL for the actual `AppEvents`, `AppRequests`, and `AppDependencies` wire shape
- preserve the corrections that avoid claiming GPT-RAG determines compliance
- link the governance pages from the docs home page, architecture page, and MkDocs navigation

## Exact reconciliation

- corrected every orchestrator event name, including `route.selected`, `grounding.source.*`, `tool.invocation.*`, and `gptrag.audit.audit.emission.failed`
- documented all required and optional fields, logical types, defaults, enums, and tested bounds from both v1 schemas
- documented string-valued Application Insights properties, unprefixed property keys, exporter-added fields, and the all-zero root `parent_event_id` sentinel
- documented `OperationId`, `ParentId`, logical trace/span fields, `X-Correlation-ID`, and Cosmos question metadata mapping
- documented every audit configuration key, defaults, startup validation, audit-only logger export, HMAC-SHA256 pseudonyms, key rotation, and rollback
- corrected sensitive capture to `AppEvents.Properties`, not `AppGenAIContent`, with exact allowlisted fields and sanitizer behavior
- documented synchronous emission failure handling, the missing asynchronous exporter callback, and all known evidence gaps without inventing a health event or rate limiter
- documented direct MCP `AIFunction` proxies, W3C-only propagation, and reconstructed Foundry IQ MCP started/terminal pairs
- bounded Microsoft IQ wording to the implemented Work IQ, Fabric IQ, Foundry IQ, and web grounding integrations
- added baseline event-volume guidance and the PR's non-gating 10,000-event microbenchmark results
- kept claims bounded to best-effort adopter-owned evidence for security, risk, NIST AI RMF, and EU AI Act work, with no immutable, nonrepudiation, certification, or automatic-compliance claim

## Status and merge gate

**Ready for documentation review, but do not merge yet.** Parent confirmation of the runtime review is still required.

The implementation remains unreleased and disabled by default. Orchestrator PR #277 must be approved, merged, and released, and GPT-RAG umbrella deployment integration must be completed before these events are available through a normal GPT-RAG deployment.

## Validation

- [x] `python -m mkdocs build --strict`
- [x] logical schema, wire schema, enum, field, and configuration cross-check
- [x] both KQL queries checked against the exact wire properties and official Azure Monitor table columns
- [x] focused orchestrator source validation: 41 audit contract, emitter, telemetry, propagation, and Foundry source tests passed
- [x] 31 internal Markdown targets checked
- [x] 25 unique external links checked successfully
- [x] UTF-8, replacement-character, control-character, and added long-dash scan
- [x] `git diff --check`

Live KQL execution remains blocked by design because no released deployment emits this audit event set yet.

Closes the documentation portion of #571 after runtime approval and release coordination.