### PR TITLE
docs(governance): publish umbrella rollout guidance

### DIFF
--- a/docs/governance_audit_contract_v1.md
+++ b/docs/governance_audit_contract_v1.md
@@ -1,17 +1,16 @@
 # Audit Contract v1
 
-Use this page to understand the unreleased GPT-RAG orchestrator audit event
-contract, estimate its telemetry volume, and prepare queries for a future
-runtime release.
+Use this page to understand the GPT-RAG audit event contract, estimate its
+telemetry volume, and prepare operational queries.
 
-!!! warning "Implemented in a pull request, but not released"
-    This page is reconciled with orchestrator pull request
-    [#277](https://github.com/Azure/gpt-rag-orchestrator/pull/277) at commit
-    `844fe14757d07a2cdc828189105fbce831f3c11d`. That code is not in a released
-    orchestrator version. Audit events also remain disabled by default and need
-    GPT-RAG umbrella deployment integration before they are available through a
-    normal GPT-RAG deployment. Do not configure the flags below until the
-    runtime release and integration are complete.
+!!! info "Runtime components released; umbrella release pending"
+    Orchestrator
+    [`v3.8.0`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v3.8.0)
+    and ingestion
+    [`v2.5.0`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.5.0)
+    implement this contract. Audit and provenance controls remain disabled by
+    default. GPT-RAG umbrella `v3.7.0` integration is implemented in pull
+    request #573 but is not yet released.
 
 The contract provides best-effort operational evidence. It is not a transaction
 log, an immutable or nonrepudiable record, independent attestation, or proof
@@ -37,17 +36,16 @@ flowchart LR
   Outcome -. audit events .-> Events
 ```
 
-The shared schema reserves ingestion event names, but orchestrator pull request
-#277 does not implement an ingestion producer.
+Ingestion `v2.5.0` implements the schema's ingestion run and document events.
 
 The exact reviewed artifacts are:
 
-- [logical v1 schema](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/contracts/audit-event-v1.schema.json)
-- [Application Insights wire schema](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/contracts/audit-event-v1.application-insights.schema.json)
-- [contract SHA-256 digests](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/contracts/audit-event-v1.sha256)
-- [golden logical event](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/tests/golden/audit_event_v1.json)
-- [golden logical root event](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/tests/golden/audit_event_v1_root.json)
-- [runtime configuration guidance](https://github.com/Azure/gpt-rag-orchestrator/blob/844fe14757d07a2cdc828189105fbce831f3c11d/README.md#audit-event-configuration)
+- [logical v1 schema](https://github.com/Azure/gpt-rag-orchestrator/blob/v3.8.0/contracts/audit-event-v1.schema.json)
+- [Application Insights wire schema](https://github.com/Azure/gpt-rag-orchestrator/blob/v3.8.0/contracts/audit-event-v1.application-insights.schema.json)
+- [contract SHA-256 digests](https://github.com/Azure/gpt-rag-orchestrator/blob/v3.8.0/contracts/audit-event-v1.sha256)
+- [golden logical event](https://github.com/Azure/gpt-rag-orchestrator/blob/v3.8.0/tests/golden/audit_event_v1.json)
+- [golden logical root event](https://github.com/Azure/gpt-rag-orchestrator/blob/v3.8.0/tests/golden/audit_event_v1_root.json)
+- [runtime configuration guidance](https://github.com/Azure/gpt-rag-orchestrator/blob/v3.8.0/README.md#audit-event-configuration)
 
 The pinned SHA-256 digests of the two schema files, recorded in
 `contracts/audit-event-v1.sha256`, are:
@@ -117,9 +115,8 @@ the all-zero trace ID from joins.
 
 The runtime reads `service_version` from the repository root `VERSION` file and
 uses the same value for the OpenTelemetry `service.version` resource attribute.
-The reviewed branch reports `3.7.0`, but the audit feature itself is unreleased.
-The eventual release will report the version packaged in its own `VERSION`
-file.
+Orchestrator `v3.8.0` reports `3.8.0`. Ingestion audit events report their own
+released component version.
 
 ## Event names
 
@@ -341,17 +338,18 @@ dashboard.
 | `AUDIT_ADDITIONAL_REDACTED_KEYS` | Empty | Comma-separated nested key fragments that the sanitizer always redacts. |
 
 GPT-RAG's next minor umbrella release pins orchestrator `v3.8.0` and ingestion
-`v2.5.0`. Post-provisioning creates `AUDIT-HMAC-KEY` in Key Vault from 256
-cryptographically random bits when it does not already exist, then registers
-only an `AUDIT_HMAC_KEY` Key Vault reference in App Configuration. Ordinary
-reprovisioning reuses the existing secret. The key value is not an admin
-setting, deployment output, or log value.
+`v2.5.0`. When `AUDIT_HMAC_KEY` is absent, post-provisioning creates
+`AUDIT-HMAC-KEY` in Key Vault from 256 cryptographically random bits, then
+registers only its Key Vault reference in App Configuration. Ordinary
+reprovisioning reuses that secret. An existing operator-managed Key Vault
+reference is preserved instead. The key value is not an admin setting,
+deployment output, or log value.
 
 Ingestion provenance uses a separate, non-secret configuration surface:
 
 | Key | Default | Exact behavior |
 | --- | --- | --- |
-| `INGESTION_PROVENANCE_ENABLED` | `false` | Adds provenance and governance values to supported ingestion document events and indexed documents when enabled. |
+| `INGESTION_PROVENANCE_ENABLED` | `false` | Adds provenance and governance values to supported ingestion document audit events when enabled. |
 | `INGESTION_REQUIRE_GOVERNANCE_METADATA` | `false` | Requires explicit classification and right-to-use values when provenance is enabled. Setting this to `true` while provenance is disabled is invalid. |
 | `INGESTION_DEFAULT_CLASSIFICATION` | `unclassified` | Fallback classification when provenance is enabled and strict mode is off. |
 | `INGESTION_DEFAULT_RIGHT_TO_USE` | `not_asserted` | Fallback right-to-use value when provenance is enabled and strict mode is off. |
@@ -391,9 +389,10 @@ operator-added fields. If a same-name field has an incompatible type or
 attributes, setup fails before making the update. GPT-RAG does not fall back to
 deleting and recreating the index.
 
-Existing documents can leave the new fields empty until they are reingested by
-ingestion `v2.5.0`. Older component versions ignore the additive fields, so
-rollback does not require removing them.
+Ingestion `v2.5.0` emits these values in audit events; it does not populate the
+new Search index fields. The fields remain empty unless another indexing
+pipeline explicitly supplies them. Older component versions ignore the
+additive fields, so rollback does not require removing them.
 
 `delete_after` is policy intent only. No GPT-RAG job reads this field to
 schedule or perform a purge. The operator must implement retention enforcement
@@ -751,9 +750,9 @@ union
 `AppRequests.Url`, `AppDependencies.Data`, and arbitrary `Properties` can
 contain sensitive details. Restrict access to query results and exported copies.
 
-The queries are reconciled with the exporter wire conversion test in pull
-request #277 and the official Azure Monitor table schemas. They cannot be run
-against released audit telemetry until the runtime is released and enabled.
+The queries are reconciled with the exporter wire conversion tests in
+orchestrator `v3.8.0` and the official Azure Monitor table schemas. They return
+results after the released runtime is deployed and audit events are enabled.
 
 ## What evidence can support
 

--- a/docs/governance_audit_contract_v1.md
+++ b/docs/governance_audit_contract_v1.md
@@ -340,6 +340,29 @@ dashboard.
 | `AUDIT_SOURCE_EVENT_LIMIT` | `25` | Accepts an integer from 1 through 25. |
 | `AUDIT_ADDITIONAL_REDACTED_KEYS` | Empty | Comma-separated nested key fragments that the sanitizer always redacts. |
 
+GPT-RAG's next minor umbrella release pins orchestrator `v3.8.0` and ingestion
+`v2.5.0`. Post-provisioning creates `AUDIT-HMAC-KEY` in Key Vault from 256
+cryptographically random bits when it does not already exist, then registers
+only an `AUDIT_HMAC_KEY` Key Vault reference in App Configuration. Ordinary
+reprovisioning reuses the existing secret. The key value is not an admin
+setting, deployment output, or log value.
+
+Ingestion provenance uses a separate, non-secret configuration surface:
+
+| Key | Default | Exact behavior |
+| --- | --- | --- |
+| `INGESTION_PROVENANCE_ENABLED` | `false` | Adds provenance and governance values to supported ingestion document events and indexed documents when enabled. |
+| `INGESTION_REQUIRE_GOVERNANCE_METADATA` | `false` | Requires explicit classification and right-to-use values when provenance is enabled. Setting this to `true` while provenance is disabled is invalid. |
+| `INGESTION_DEFAULT_CLASSIFICATION` | `unclassified` | Fallback classification when provenance is enabled and strict mode is off. |
+| `INGESTION_DEFAULT_RIGHT_TO_USE` | `not_asserted` | Fallback right-to-use value when provenance is enabled and strict mode is off. |
+
+These four ingestion values contain no credentials and are safe to display and
+edit as normal configuration. Ingestion does not consume `AUDIT_HMAC_KEY`.
+Post-provisioning seeds only missing values and preserves operator-managed
+settings unless an AZD environment value explicitly overrides them. A deployment
+that explicitly disables Key Vault receives the disabled defaults but cannot
+enable audit events until a valid HMAC Key Vault reference is supplied.
+
 If `AZURE_MONITOR_DISABLE_LOGGING=true` while auditing is enabled, the
 orchestrator enables Azure Monitor log export only for the `gptrag.audit`
 namespace. If normal log export is enabled, audit events use that existing
@@ -349,6 +372,32 @@ orchestrator fail.
 
 To roll back, set `AUDIT_EVENTS_ENABLED=false` and restart the orchestrator.
 This stops new events. It does not delete previously exported telemetry.
+
+## Search provenance schema and migration
+
+The RAG Azure AI Search index has optional, retrievable fields for
+`provenance_id`, `source_uri_id`, `source_version_id`,
+`content_checksum_sha256`, `ingested_at`, `ingest_run_id`,
+`data_classification`, `right_to_use`, `retention_class`, and `delete_after`.
+Identifiers and checksums are filterable. Guaranteed UTC `ingested_at` values
+use filterable, sortable `Edm.DateTimeOffset`. `delete_after` remains a
+filterable, sortable string because ingestion v2.5.0 passes through operator
+policy values without imposing a date format. Classification, right-to-use, and
+retention class are also facetable.
+
+Post-provisioning updates an existing index in place by merging only missing
+fields into its current definition. It preserves existing documents and
+operator-added fields. If a same-name field has an incompatible type or
+attributes, setup fails before making the update. GPT-RAG does not fall back to
+deleting and recreating the index.
+
+Existing documents can leave the new fields empty until they are reingested by
+ingestion `v2.5.0`. Older component versions ignore the additive fields, so
+rollback does not require removing them.
+
+`delete_after` is policy intent only. No GPT-RAG job reads this field to
+schedule or perform a purge. The operator must implement retention enforcement
+and verify the deletion outcome.
 
 ## HMAC identifiers and rotation
 

--- a/docs/governance_audit_contract_v1.md
+++ b/docs/governance_audit_contract_v1.md
@@ -412,10 +412,21 @@ the digest. Current code pseudonymizes conversation IDs, question IDs, source
 references, tool IDs, tool invocation IDs, and optional actor IDs. Raw values
 are not placed in those audit properties.
 
-Create and restrict the key in Key Vault. To rotate it, update
-`AUDIT_HMAC_KEY` and `AUDIT_HMAC_KEY_ID` together, then restart. Identical raw
-values produce different pseudonyms after rotation, so correlation does not
-continue automatically across key versions.
+Create and restrict the key in Key Vault. The `AUDIT_HMAC_KEY` App
+Configuration value is an unversioned Key Vault reference to the
+`AUDIT-HMAC-KEY` secret, so it always resolves to that secret's current
+version. Ordinary reprovisioning reuses the existing secret and does not
+rotate it.
+
+To rotate the key: create a new version of the `AUDIT-HMAC-KEY` secret in Key
+Vault (do not edit `AUDIT_HMAC_KEY` itself), then advance `AUDIT_HMAC_KEY_ID`
+to a new value that identifies the new pseudonymization epoch. Restart or
+redeploy the affected workloads so they pick up the new secret version and key
+identifier together. Identical raw values produce different pseudonyms after
+rotation, so correlation does not continue automatically across key versions.
+Retain or remove prior secret versions according to the deployment's rollback
+and retention policy; keep a prior version available if you may need to roll
+back to the previous `AUDIT_HMAC_KEY_ID`.
 
 ## Sensitive-content capture
 

--- a/docs/governance_overview.md
+++ b/docs/governance_overview.md
@@ -4,13 +4,11 @@ Use this guide to decide what data GPT-RAG may process, who owns each
 control, and what evidence an operator should preserve for security reviews
 and incident investigations.
 
-!!! warning "Audit trail implementation is not released"
-    The governance practices on this page can be applied today. The correlated
-    [Audit Contract v1](governance_audit_contract_v1.md) is reconciled with
-    orchestrator pull request #277, but that implementation is not in a released
-    runtime. It is disabled by default and still needs GPT-RAG umbrella
-    deployment integration. Do not configure it until the runtime release and
-    integration are complete.
+!!! info "Runtime components released; umbrella release pending"
+    Orchestrator `v3.8.0` and ingestion `v2.5.0` implement the correlated
+    [Audit Contract v1](governance_audit_contract_v1.md). GPT-RAG umbrella
+    `v3.7.0` integration is implemented in pull request #573 but is not yet
+    released. Keep the feature disabled until that umbrella release is deployed.
 
 ## Why this matters
 
@@ -27,7 +25,7 @@ questions without searching unrelated logs:
 GPT-RAG already uses logs, traces, metrics, and source references. Those signals
 are useful, but current releases do not provide the versioned audit contract
 described in issue
-[#571](https://github.com/Azure/GPT-RAG/issues/571). The unreleased contract
+[#571](https://github.com/Azure/GPT-RAG/issues/571). The contract
 correlates operational metadata while leaving prompts, responses, source
 excerpts, tool arguments, and tool results out of the default event stream.
 
@@ -36,9 +34,9 @@ flowchart LR
   Request[User request] --> Route[Route and source selection]
   Route --> Tools[Retrieval and tools]
   Tools --> Outcome[Outcome]
-  Route -. unreleased audit events .-> Evidence[Correlated operational evidence]
-  Tools -. unreleased audit events .-> Evidence
-  Outcome -. unreleased audit events .-> Evidence
+  Route -. audit events .-> Evidence[Correlated operational evidence]
+  Tools -. audit events .-> Evidence
+  Outcome -. audit events .-> Evidence
 ```
 
 ## What GPT-RAG can and cannot establish
@@ -82,7 +80,7 @@ Do not assume that:
 - retention in Azure Monitor satisfies a records-management obligation; or
 - technical evidence establishes legal compliance.
 
-The unreleased audit trail is best-effort telemetry. Sampling, exporter failures,
+The audit trail is best-effort telemetry. Sampling, exporter failures,
 process termination, asynchronous boundaries, disabled instrumentation, and
 upstream systems can create evidence gaps. Events are asserted by the producing
 GPT-RAG process. They are not independently attested, cryptographically signed,
@@ -146,7 +144,7 @@ governance layer.
 
 | Class | Examples | Required posture |
 | --- | --- | --- |
-| Operational metadata | Event and correlation IDs, service and version, bounded status and reason codes, durations, tool names, source kinds, opaque source references | Permitted by the unreleased metadata-only contract. Classify and minimize it because identifiers and operational context can still be sensitive. |
+| Operational metadata | Event and correlation IDs, service and version, bounded status and reason codes, durations, tool names, source kinds, opaque source references | Permitted by the metadata-only contract. Classify and minimize it because identifiers and operational context can still be sensitive. |
 | Sensitive content | Prompts, responses, source excerpts, system instructions, tool arguments, tool results | Off by default. Enable only after an explicit need, privacy review, access design, retention decision, and cost review. |
 | Prohibited data | Access tokens, API keys, authorization headers, cookies, connection strings, credentials, and detected secrets | Never capture or export, including when sensitive-content capture is enabled. Redact before telemetry leaves the producing process and fail closed by omitting unsafe values. |
 

--- a/docs/governance_overview.md
+++ b/docs/governance_overview.md
@@ -207,23 +207,33 @@ guarantee complete evidence. Verify the deployed OpenTelemetry and Azure Monitor
 sampling behavior, exporter health, and throttling before relying on telemetry
 for an investigation.
 
-## Roll out the audit feature after release
+## Roll out the audit feature
 
-Do not begin this procedure until the orchestrator implementation is released
-and GPT-RAG umbrella deployment integration is complete.
+Use GPT-RAG umbrella `v3.7.0` or later with orchestrator `v3.8.0` and ingestion
+`v2.5.0`. Do not mix older component versions with this shared-contract rollout.
 
-1. Upgrade with audit emission disabled.
-2. Enable metadata-only events in a non-production environment.
-3. Keep `AUDIT_ACTOR_PSEUDONYM_ENABLED` and
+1. Upgrade with `AUDIT_EVENTS_ENABLED=false`,
+   `AUDIT_SENSITIVE_CONTENT_ENABLED=false`, and
+   `INGESTION_PROVENANCE_ENABLED=false`.
+2. Run post-provisioning. Verify that `AUDIT_HMAC_KEY` is a Key Vault reference
+   and that the existing Search index gained the optional provenance fields
+   without being recreated.
+3. Enable metadata-only audit events in a non-production environment.
+4. Enable ingestion provenance separately if the deployment has reviewed the
+   classification and right-to-use defaults.
+5. Keep `AUDIT_ACTOR_PSEUDONYM_ENABLED` and
    `AUDIT_SENSITIVE_CONTENT_ENABLED` disabled.
-4. If actor correlation is approved, create and restrict a Key Vault HMAC key
-   before enabling it.
-5. Canary a small production slice and reconstruct representative requests.
-6. Monitor latency, exporter failures, ingestion volume, retention cost, and
+6. If actor correlation is approved, enable pseudonymization only after
+   reviewing access to the automatically provisioned Key Vault key.
+7. Canary a small production slice and reconstruct representative requests.
+8. Monitor latency, exporter failures, ingestion volume, retention cost, and
    evidence-gap health signals.
-7. Confirm that existing traces, logs, dashboards, and alerts still work.
-8. Roll back by setting `AUDIT_EVENTS_ENABLED=false` and restarting the
-   orchestrator. Do not enable sensitive content as a troubleshooting shortcut.
+9. Confirm that existing traces, logs, dashboards, alerts, indexed documents,
+   and operator-added Search fields still work.
+10. Roll back by setting `AUDIT_EVENTS_ENABLED=false` and
+    `INGESTION_PROVENANCE_ENABLED=false`, then restart the components. Additive
+    Search fields can remain. Do not enable sensitive content as a
+    troubleshooting shortcut.
 
 Audit emission should not make the user request fail. If event production or
 the synchronous logging path fails, the runtime continues the request and
@@ -235,7 +245,7 @@ volume and Azure Monitor ingestion health.
 
 ## Related reading
 
-- [Audit Contract v1, unreleased](governance_audit_contract_v1.md)
+- [Audit Contract v1](governance_audit_contract_v1.md)
 - [Authentication and Document-Level Security](howto_authentication.md)
 - [Grounding sources overview](howto_grounding_overview.md)
 - [Azure Monitor Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete)

--- a/docs/governance_overview.md
+++ b/docs/governance_overview.md
@@ -223,12 +223,21 @@ Use GPT-RAG umbrella `v3.7.0` or later with orchestrator `v3.8.0` and ingestion
    `AUDIT_SENSITIVE_CONTENT_ENABLED` disabled.
 6. If actor correlation is approved, enable pseudonymization only after
    reviewing access to the automatically provisioned Key Vault key.
-7. Canary a small production slice and reconstruct representative requests.
-8. Monitor latency, exporter failures, ingestion volume, retention cost, and
+7. Rotate the pseudonymization key on your schedule, or immediately after a
+   suspected exposure: create a new version of the `AUDIT-HMAC-KEY` secret in
+   Key Vault, advance `AUDIT_HMAC_KEY_ID` to a new value that marks the new
+   pseudonymization epoch, then restart or redeploy the affected workloads so
+   both changes take effect together. Do not edit `AUDIT_HMAC_KEY` itself; it
+   is an unversioned Key Vault reference and always resolves to the secret's
+   current version. Retain or remove prior secret versions according to your
+   rollback and retention policy. See
+   [HMAC identifiers and rotation](governance_audit_contract_v1.md#hmac-identifiers-and-rotation).
+8. Canary a small production slice and reconstruct representative requests.
+9. Monitor latency, exporter failures, ingestion volume, retention cost, and
    evidence-gap health signals.
-9. Confirm that existing traces, logs, dashboards, alerts, indexed documents,
-   and operator-added Search fields still work.
-10. Roll back by setting `AUDIT_EVENTS_ENABLED=false` and
+10. Confirm that existing traces, logs, dashboards, alerts, indexed documents,
+    and operator-added Search fields still work.
+11. Roll back by setting `AUDIT_EVENTS_ENABLED=false` and
     `INGESTION_PROVENANCE_ENABLED=false`, then restart the components. Additive
     Search fields can remain. Do not enable sensitive content as a
     troubleshooting shortcut.

--- a/docs/whatisnew.md
+++ b/docs/whatisnew.md
@@ -10,9 +10,11 @@ patch, and fix, see the [GitHub releases](https://github.com/Azure/GPT-RAG/relea
   The next minor umbrella release pins orchestrator `v3.8.0` and ingestion
   `v2.5.0` to the shared `audit-event-v1` contract. Audit, sensitive-content
   capture, actor pseudonymization, and ingestion provenance remain off by
-  default. Post-provisioning creates a stable 256-bit HMAC key in Key Vault,
-  registers only its Key Vault reference, and adds optional provenance fields
-  to existing Azure AI Search indexes without recreating them. See
+  default. When no operator-managed HMAC reference exists, post-provisioning
+  creates a stable 256-bit key in Key Vault and registers only its Key Vault
+  reference; existing Key Vault references are preserved. It also adds optional
+  provenance fields to existing Azure AI Search indexes without recreating
+  them. See
   [Audit Contract v1](governance_audit_contract_v1.md) for configuration,
   migration, rollback, and evidence limitations. `delete_after` records policy
   intent only; it does not trigger automatic deletion.

--- a/docs/whatisnew.md
+++ b/docs/whatisnew.md
@@ -6,6 +6,16 @@ patch, and fix, see the [GitHub releases](https://github.com/Azure/GPT-RAG/relea
 
 ### July 2026
 
+- **Governance audit and provenance integration (planned for GPT-RAG v3.7.0).**
+  The next minor umbrella release pins orchestrator `v3.8.0` and ingestion
+  `v2.5.0` to the shared `audit-event-v1` contract. Audit, sensitive-content
+  capture, actor pseudonymization, and ingestion provenance remain off by
+  default. Post-provisioning creates a stable 256-bit HMAC key in Key Vault,
+  registers only its Key Vault reference, and adds optional provenance fields
+  to existing Azure AI Search indexes without recreating them. See
+  [Audit Contract v1](governance_audit_contract_v1.md) for configuration,
+  migration, rollback, and evidence limitations. `delete_after` records policy
+  intent only; it does not trigger automatic deletion.
 - **Generic MCP Server knowledge source (preview, [v3.6.0](https://github.com/Azure/GPT-RAG/releases/tag/v3.6.0)).**
   The Knowledge Base can call approved tools on a remote MCP server you
   operate or trust and blend those results with other Foundry IQ sources.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,7 @@ nav:
     - Overview: architecture.md
   - Governance:
     - Overview and responsibilities: governance_overview.md
-    - Audit Contract v1 (unreleased): governance_audit_contract_v1.md
+    - Audit Contract v1: governance_audit_contract_v1.md
   - Services:
     - Orchestrator: services_orchestrator.md
     - Ingestion:


### PR DESCRIPTION
## Purpose

Publish the operator-facing documentation for the #571 umbrella integration. This companion targets the `docs` branch and accompanies implementation PR #573.

## Changes

- Documents the GPT-RAG v3.7.0, orchestrator v3.8.0, and ingestion v2.5.0 rollout contract.
- Lists disabled-by-default audit and provenance controls.
- Explains stable Key Vault HMAC-key provisioning and operator-managed rotation.
- Documents additive Azure AI Search migration and rollback without index recreation.
- Clarifies that `delete_after` is policy intent, not automatic purge.
- Preserves the distinction between technical evidence and legal compliance.

## Validation

- `python -m mkdocs build --strict` passed.
- `git diff --check` passed.

Related to #571 and #573.