### PR TITLE
Add temporary Copilot OIDC write smoke

### DIFF
--- a/.github/workflows/copilot-oidc-write-smoke.yml
+++ b/.github/workflows/copilot-oidc-write-smoke.yml
@@ -1,0 +1,168 @@
+name: Copilot OIDC write smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  write-delete-smoke:
+    runs-on: ubuntu-latest
+    environment: copilot
+
+    steps:
+      - name: Sign in to Azure with OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Create, authorize, and delete a temporary identity
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resource_group="rg-gptrag-evaluation"
+          location="eastus"
+          identity_name="oidc-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          identity_id=""
+          principal_id=""
+          assignment_id=""
+
+          cleanup() {
+            local exit_code=$?
+            local cleanup_failed=0
+            trap - EXIT
+            set +e
+
+            if [[ -n "${assignment_id:-}" ]]; then
+              echo "Cleanup: deleting temporary role assignment"
+              az role assignment delete \
+                --ids "$assignment_id" \
+                --only-show-errors || cleanup_failed=1
+            fi
+
+            if [[ -n "${identity_id:-}" ]]; then
+              echo "Cleanup: deleting temporary managed identity"
+              az identity delete \
+                --ids "$identity_id" \
+                --only-show-errors || cleanup_failed=1
+            fi
+
+            if (( exit_code != 0 )); then
+              exit "$exit_code"
+            fi
+            exit "$cleanup_failed"
+          }
+          trap cleanup EXIT
+
+          acting_app_id="$(az account show --query user.name -o tsv)"
+          expected_app_id="${{ vars.AZURE_CLIENT_ID }}"
+          if [[ "${acting_app_id,,}" != "${expected_app_id,,}" ]]; then
+            echo "::error::Azure CLI is not authenticated as the configured OIDC application."
+            exit 1
+          fi
+          echo "EVIDENCE_ACTING_APP_ID=${acting_app_id}"
+
+          identity_json="$(
+            az identity create \
+              --resource-group "$resource_group" \
+              --name "$identity_name" \
+              --location "$location" \
+              --tags purpose=github-oidc-write-smoke githubRunId="$GITHUB_RUN_ID" \
+              --only-show-errors \
+              --output json
+          )"
+          identity_id="$(jq -r '.id' <<<"$identity_json")"
+          principal_id="$(jq -r '.principalId' <<<"$identity_json")"
+          identity_client_id="$(jq -r '.clientId' <<<"$identity_json")"
+
+          created_identity="$(
+            az identity show \
+              --ids "$identity_id" \
+              --query '{name:name,id:id,location:location,clientId:clientId,principalId:principalId}' \
+              --only-show-errors \
+              --output json
+          )"
+          created_name="$(jq -r '.name' <<<"$created_identity")"
+          created_location="$(jq -r '.location' <<<"$created_identity")"
+          if [[ "$created_name" != "$identity_name" || "$created_location" != "$location" ]]; then
+            echo "::error::Temporary managed identity metadata did not match the requested values."
+            exit 1
+          fi
+          echo "EVIDENCE_IDENTITY_CREATED name=${identity_name} id=${identity_id} location=${created_location} clientId=${identity_client_id} principalId=${principal_id}"
+
+          assignment_json="$(
+            az role assignment create \
+              --assignee-object-id "$principal_id" \
+              --assignee-principal-type ServicePrincipal \
+              --role Reader \
+              --scope "$identity_id" \
+              --only-show-errors \
+              --output json
+          )"
+          assignment_id="$(jq -r '.id' <<<"$assignment_json")"
+          assignment_name="$(jq -r '.name' <<<"$assignment_json")"
+
+          assignment_count="$(
+            az role assignment list \
+              --assignee-object-id "$principal_id" \
+              --scope "$identity_id" \
+              --query "length([?name=='${assignment_name}' && roleDefinitionName=='Reader' && scope=='${identity_id}'])" \
+              --only-show-errors \
+              --output tsv
+          )"
+          if [[ "$assignment_count" != "1" ]]; then
+            echo "::error::Temporary Reader role assignment could not be verified."
+            exit 1
+          fi
+          echo "EVIDENCE_ROLE_ASSIGNMENT_CREATED id=${assignment_id} role=Reader scope=${identity_id} principalId=${principal_id}"
+
+          az role assignment delete \
+            --ids "$assignment_id" \
+            --only-show-errors
+
+          for attempt in {1..12}; do
+            assignment_count="$(
+              az role assignment list \
+                --assignee-object-id "$principal_id" \
+                --scope "$identity_id" \
+                --query "length([?name=='${assignment_name}'])" \
+                --only-show-errors \
+                --output tsv
+            )"
+            if [[ "$assignment_count" == "0" ]]; then
+              break
+            fi
+            if [[ "$attempt" == "12" ]]; then
+              echo "::error::Temporary role assignment still exists after deletion."
+              exit 1
+            fi
+            sleep 5
+          done
+          echo "EVIDENCE_ROLE_ASSIGNMENT_DELETED id=${assignment_id} verified_absent=true"
+          assignment_id=""
+
+          az identity delete \
+            --ids "$identity_id" \
+            --only-show-errors
+
+          for attempt in {1..12}; do
+            if ! az identity show \
+              --resource-group "$resource_group" \
+              --name "$identity_name" \
+              --only-show-errors \
+              >/dev/null 2>&1; then
+              break
+            fi
+            if [[ "$attempt" == "12" ]]; then
+              echo "::error::Temporary managed identity still exists after deletion."
+              exit 1
+            fi
+            sleep 5
+          done
+          echo "EVIDENCE_IDENTITY_DELETED name=${identity_name} verified_absent=true"
+          identity_id=""


### PR DESCRIPTION
## Temporary validation
- Adds a workflow-dispatch-only OIDC write/delete smoke test.
- Creates and removes one temporary user-assigned managed identity in `rg-gptrag-evaluation`.
- Creates, verifies, and removes one Reader assignment scoped to that identity.
- Uses the `copilot` environment and repository variables; no client secret.

This workflow will be removed immediately after a successful run from `main`.