### PR TITLE
fix(deployment): resolve az CLI executable path on Windows

### DIFF
--- a/config/deployment/appconfig.py
+++ b/config/deployment/appconfig.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 from typing import Mapping
 
@@ -15,9 +16,22 @@ from config.deployment.composition import (
 )
 
 
+def _resolve_az_command() -> str:
+    """Resolve the Azure CLI executable path.
+
+    On Windows, ``az`` is a ``.cmd`` shim. ``subprocess.run`` invokes
+    ``CreateProcess`` directly and does not consult ``PATHEXT`` the way a
+    shell does, so passing the bare ``"az"`` argument fails with
+    ``FileNotFoundError: [WinError 2]`` even though ``az`` works fine from
+    an interactive shell. Resolving the executable via :func:`shutil.which`
+    keeps this cross-platform without resorting to ``shell=True``.
+    """
+    return shutil.which("az") or "az"
+
+
 def _run_az(arguments: list[str], *, required: bool = True) -> str:
     completed = subprocess.run(
-        ["az", *arguments],
+        [_resolve_az_command(), *arguments],
         check=False,
         capture_output=True,
         text=True,

--- a/tests/test_deployment_modes.py
+++ b/tests/test_deployment_modes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -198,6 +199,41 @@ class AppConfigurationContractTests(unittest.TestCase):
                 },
                 require_hosted_endpoint=True,
             )
+
+
+class RunAzCommandResolutionTests(unittest.TestCase):
+    """Regression tests for the Windows ``az.cmd`` shim lookup.
+
+    ``subprocess.run(["az", ...])`` fails with ``FileNotFoundError``
+    on Windows because ``CreateProcess`` does not consult ``PATHEXT``
+    the way an interactive shell does. ``_run_az`` must resolve the
+    executable via ``shutil.which`` first.
+    """
+
+    @patch("config.deployment.appconfig.shutil.which")
+    @patch("config.deployment.appconfig.subprocess.run")
+    def test_uses_resolved_executable_path(
+        self, mock_run: object, mock_which: object
+    ) -> None:
+        mock_which.return_value = r"C:\path\to\az.cmd"
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="ok", stderr=""
+        )
+
+        result = appconfig._run_az(["group", "show"])
+
+        mock_which.assert_called_once_with("az")
+        called_args = mock_run.call_args.args[0]
+        self.assertEqual(r"C:\path\to\az.cmd", called_args[0])
+        self.assertEqual("ok", result)
+
+    @patch("config.deployment.appconfig.shutil.which")
+    def test_falls_back_to_bare_command_when_unresolved(
+        self, mock_which: object
+    ) -> None:
+        mock_which.return_value = None
+
+        self.assertEqual("az", appconfig._resolve_az_command())
 
 
 class HostedEndpointContractTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
`config/deployment/appconfig.py::_run_az()` called `subprocess.run(["az", *arguments], ...)`. On Windows this fails with `FileNotFoundError [WinError 2]` because `az` is a `.cmd` shim and `CreateProcess` does not consult `PATHEXT` the way an interactive shell does — even though `az` works fine from any shell prompt.

Discovered during real end-to-end Azure deployment validation of #592 (fresh `azd provision` on a Windows machine).

## Fix
- Added `_resolve_az_command()` = `shutil.which("az") or "az"`.
- `_run_az()` now invokes the resolved executable path instead of the bare `"az"` string.
- No behavior change on non-Windows platforms (`shutil.which` resolves the same binary either way).

## Tests
- Added `RunAzCommandResolutionTests` (2 cases) to `tests/test_deployment_modes.py`:
  - confirms the resolved path from `shutil.which` is what gets passed to `subprocess.run`
  - confirms fallback to the bare `"az"` command when `shutil.which` returns `None`
- Full suite: `python -m pytest tests/` → 20 passed, 4 subtests passed.
- Validated live: re-ran `azd provision` on Windows after the fix and postProvision App Configuration publishing (143 keys) completed successfully, where it previously failed.

## Scope
Surgical, single-purpose fix isolated to the `az` CLI invocation helper. No other logic changed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>