### PR TITLE
fix(hosted-agent): use literal agent-definition fields azure.ai.agent extension can parse

### DIFF
--- a/hosted-agent/azure.yaml
+++ b/hosted-agent/azure.yaml
@@ -6,19 +6,34 @@ services:
     project: .
     image: ${AZURE_CONTAINER_REGISTRY_ENDPOINT}/${HOSTED_AGENT_IMAGE=gpt-rag-orchestrator}@${HOSTED_AGENT_IMAGE_VERSION}
     kind: hosted
-    name: ${HOSTED_AGENT_NAME=gpt-rag-orchestrator}
+    # NOTE: The azure.ai.agent azd extension (v1.0.0-beta.8) reads name, container.resources,
+    # protocols[].version and startupCommand directly from this file to build the Foundry
+    # "Create Agent" REST payload, bypassing azd's core ${VAR=default} interpolation (confirmed
+    # via "template.name not in valid format" and Go-struct type errors when templated). The
+    # `image` field above and the `env:` block below use azd's separate, core/host-agnostic
+    # interpolation engine and resolve correctly, so they stay templated. These agent-definition
+    # fields are hardcoded to composition.py's own defaults (config/deployment/composition.py) so
+    # `azd deploy` from this directory works out of the box; to customize, edit this file directly
+    # instead of `azd env set HOSTED_AGENT_*`, which only affects the separate `azd provision`
+    # (main.parameters.json) path today.
+    name: gpt-rag-orchestrator
     displayName: GPT-RAG hosted orchestrator
     description: GPT-RAG orchestration hosted by Microsoft Foundry.
-    startupCommand: ${HOSTED_AGENT_STARTUP_COMMAND=uvicorn src.api.hosted_entrypoint:app --host 0.0.0.0 --port 8088}
+    startupCommand: uvicorn src.api.hosted_entrypoint:app --host 0.0.0.0 --port 8088
     container:
       resources:
-        cpu: ${HOSTED_AGENT_CONTAINER_CPU=2}
-        memory: ${HOSTED_AGENT_CONTAINER_MEMORY=4Gi}
+        # Must be quoted strings: the Foundry API's Go struct requires string type
+        # (unquoted numeric YAML like `cpu: 2` fails with a JSON unmarshal type error).
+        cpu: "2"
+        memory: "4Gi"
     protocols:
       - protocol: responses
-        version: ${HOSTED_AGENT_RESPONSES_PROTOCOL_VERSION=2.0.0}
+        version: "2.0.0"
       - protocol: invocations
-        version: ${HOSTED_AGENT_INVOCATIONS_PROTOCOL_VERSION=1.0.0}
+        version: "1.0.0"
     env:
       APP_CONFIG_ENDPOINT: ${APP_CONFIG_ENDPOINT}
-      APPLICATIONINSIGHTS_CONNECTION_STRING: ${APPLICATIONINSIGHTS_CONNECTION_STRING=}
+      # APPLICATIONINSIGHTS_CONNECTION_STRING intentionally omitted: it is a reserved env var
+      # name for Foundry hosted agents (all FOUNDRY_*/AGENT_* vars, plus this one, are reserved
+      # per the container-image-spec) and the Create Agent API rejects it if present. The
+      # platform auto-injects telemetry wiring for hosted agents.


### PR DESCRIPTION
## Summary

Fixes 4 real defects in hosted-agent/azure.yaml (the standalone azd sub-project used by zd deploy orchestrator-agent to create/update the Azure AI Foundry hosted agent) discovered while executing end-to-end validation of issue #592's hosted deployment modes.

## Root cause

The zure.ai.agents azd extension (v1.0.0-beta.8) reads several "agent definition" fields directly from the raw YAML file, **bypassing azd's core \ interpolation engine** — unlike image and the nv: block, which ARE correctly resolved through azd's host-agnostic templating. As a result, unresolved \ placeholder strings were being sent verbatim to the Foundry "Create/Update Agent" API for these fields, causing deploy failures.

## Fixes

1. 
ame — literal agent name (was an unresolved \ placeholder)
2. esources.cpu / esources.memory — literal 2 / 4Gi (quoted where required), matching the fallback defaults already used by the parallel config/deployment/composition.py path (lines 84-119) for parity across the two configuration mechanisms
3. protocols[].version and startupCommand — literal values (same templating-bypass bug class; fixed defensively even though not conclusively proven to throw a distinct error for these two specifically)
4. Removed APPLICATIONINSIGHTS_CONNECTION_STRING — this var is not part of the hosted-agent's supported env surface and was causing a separate downstream issue

Each change includes an inline comment documenting the root cause and the zd env set HOSTED_AGENT_* customization trade-off (i.e., these are now literals, so customizing them requires editing this file directly rather than via env var overrides — infra/README.md already documents that the main.parameters.json/Bicep path, a separate mechanism, supports env-var customization).

## Validation

- Full 	ests/test_release_contracts.py suite: 7/7 passed
- Full 	ests/test_deployment_modes.py + 	ests/test_release_contracts.py: 20 passed, 4 subtests passed
- Independently reviewed by a separate code-review pass: **APPROVE** — confirmed diff correctness, exact parity with composition.py defaults, accurate customization-trade-off documentation, and no stale references elsewhere in the repo (repo-wide search for all affected env-var names).
- Verified against a real Azure AI Foundry hosted-agent deploy attempt (zd deploy orchestrator-agent) in a disposable validation environment: after these fixes, the deploy correctly progresses past all local/templating issues and reaches the real Foundry "Create Agent" API call (which then separately fails with a 403 caused by a tenant-wide Azure Policy forcing the Foundry project's backing Cosmos DB publicNetworkAccess to Disabled — an environmental/policy constraint unrelated to this fix, tracked as a blocker on issue #592, not a code defect).

## Related

Found during execution of #592 (validating all three GPT-RAG deployment modes end-to-end).
