### PR TITLE
fix(hosted-agent): auto-build hosted-entrypoint image via ACR Tasks

### DIFF
--- a/config/deployment/composition.py
+++ b/config/deployment/composition.py
@@ -72,6 +72,15 @@ def compose_parameters(
     parameters["deployCosmosDb"] = {"value": panel}
 
     if hosted:
+        # This digest only feeds the landing-zone parameter document at
+        # provision time; it is informational and does not run a container.
+        # The digest that is actually deployed as the hosted agent's image is
+        # whatever HOSTED_AGENT_IMAGE_VERSION resolves to later, at `azd
+        # deploy` time, in hosted-agent/azure.yaml. When
+        # HOSTED_AGENT_AUTO_BUILD_IMAGE=true, scripts/preDeploy re-pins that
+        # env var to a freshly built derivative image before deploying (see
+        # config/deployment/hosted_image.py and ADR-0001), so the two digests
+        # may legitimately differ across a provision+deploy cycle.
         digest = (environment.get("HOSTED_AGENT_IMAGE_VERSION") or "").strip()
         if not HOSTED_IMAGE_DIGEST_PATTERN.fullmatch(digest):
             raise ValueError(

--- a/config/deployment/hosted_image.py
+++ b/config/deployment/hosted_image.py
@@ -1,0 +1,208 @@
+"""Build a hosted-agent-specific derivative container image via ACR Tasks.
+
+Context
+-------
+Microsoft Foundry's hosted-agent "Create Agent" API for container-mode agents
+only accepts an ``image`` reference (see ``ContainerConfigurationAPI`` in the
+``azure.ai.agent`` azd extension). It never receives the ``startupCommand``
+declared in ``hosted-agent/azure.yaml`` or ``composition.py``'s
+``hostedAgent.startupCommand`` parameter -- that field only affects the local
+``azd ai agent run`` developer flow, not real container deploys. Because of
+this, whatever ``CMD``/``ENTRYPOINT`` is baked into the published
+``gpt-rag-orchestrator`` image is what a Foundry hosted agent will actually
+run, and today that image's ``CMD`` is always the classic Container-App
+entrypoint (``uvicorn main:app --host 0.0.0.0 --port 8080``), not the hosted
+entrypoint (``uvicorn src.api.hosted_entrypoint:app --host 0.0.0.0 --port
+8088``). This module builds a tiny derivative image, layered ``FROM`` the
+already-published/immutable base image with only the port/entrypoint ``CMD``
+overridden, so the image actually deployed to the hosted agent runs the
+correct process. The build goes through ACR Tasks (``az acr build``),
+supporting a VNet-injected agent pool for ``NETWORK_ISOLATION=true``
+deployments -- no Docker daemon or public registry access is required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOSTED_STARTUP_COMMAND_DEFAULT = (
+    "uvicorn src.api.hosted_entrypoint:app --host 0.0.0.0 --port 8088"
+)
+HOSTED_PORT_DEFAULT = 8088
+DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+
+
+def render_hosted_dockerfile(
+    base_image_ref: str,
+    startup_command: str = HOSTED_STARTUP_COMMAND_DEFAULT,
+    port: int = HOSTED_PORT_DEFAULT,
+) -> str:
+    """Render the derivative Dockerfile content.
+
+    ``base_image_ref`` must already be a fully-qualified, digest-pinned image
+    reference (``<registry>/<repo>@sha256:<digest>``) so the derivative image
+    stays anchored to an immutable base, consistent with the rest of this
+    repo's "no mutable tags" deployment contract.
+    """
+    if "@sha256:" not in base_image_ref:
+        raise ValueError(
+            "base_image_ref must be digest-pinned (contain '@sha256:...'), "
+            f"got: {base_image_ref!r}"
+        )
+    command_parts = startup_command.strip().split()
+    if not command_parts:
+        raise ValueError("startup_command must not be empty")
+    cmd_json = json.dumps(command_parts)
+    return (
+        f"FROM {base_image_ref}\n"
+        f"EXPOSE {port}\n"
+        f"CMD {cmd_json}\n"
+    )
+
+
+def build_acr_build_args(
+    *,
+    registry: str,
+    image_name: str,
+    image_tag: str,
+    dockerfile_path: str,
+    context_dir: str,
+    agent_pool: str | None = None,
+) -> list[str]:
+    """Return the argv for ``az acr build`` (pure, no execution)."""
+    if not registry:
+        raise ValueError("registry is required")
+    if not image_name:
+        raise ValueError("image_name is required")
+    if not image_tag:
+        raise ValueError("image_tag is required")
+    args = [
+        "az",
+        "acr",
+        "build",
+        "--registry",
+        registry,
+        "--image",
+        f"{image_name}:{image_tag}",
+        "--file",
+        dockerfile_path,
+        context_dir,
+    ]
+    if agent_pool:
+        args.extend(["--agent-pool", agent_pool])
+    return args
+
+
+def parse_digest_from_build_output(output: str) -> str | None:
+    """Best-effort extraction of the pushed manifest digest from ``az acr
+    build`` text output (used when ``--query``/JSON parsing of the run isn't
+    available; callers should prefer looking up the digest via
+    ``az acr repository show-manifests`` after a successful build, which is
+    what the CLI entrypoint below does)."""
+    match = re.search(r"sha256:[0-9a-fA-F]{64}", output)
+    return match.group(0) if match else None
+
+
+def resolve_pushed_digest(
+    *, registry: str, image_name: str, image_tag: str
+) -> str:
+    """Look up the digest that was just pushed for ``image_name:image_tag``."""
+    result = subprocess.run(
+        [
+            "az",
+            "acr",
+            "repository",
+            "show",
+            "--name",
+            registry,
+            "--image",
+            f"{image_name}:{image_tag}",
+            "--query",
+            "digest",
+            "-o",
+            "tsv",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    digest = result.stdout.strip()
+    if not DIGEST_PATTERN.fullmatch(digest):
+        raise RuntimeError(
+            f"Unexpected digest format returned by az acr repository show: {digest!r}"
+        )
+    return digest
+
+
+def build_hosted_image(
+    *,
+    registry: str,
+    base_image_ref: str,
+    image_name: str,
+    image_tag: str,
+    startup_command: str = HOSTED_STARTUP_COMMAND_DEFAULT,
+    port: int = HOSTED_PORT_DEFAULT,
+    agent_pool: str | None = None,
+) -> str:
+    """Build+push the hosted derivative image via ACR Tasks; return its digest."""
+    dockerfile_content = render_hosted_dockerfile(base_image_ref, startup_command, port)
+    with tempfile.TemporaryDirectory(prefix="hosted-agent-image-") as tmp:
+        dockerfile_path = Path(tmp) / "Dockerfile"
+        dockerfile_path.write_text(dockerfile_content, encoding="utf-8")
+        args = build_acr_build_args(
+            registry=registry,
+            image_name=image_name,
+            image_tag=image_tag,
+            dockerfile_path=str(dockerfile_path),
+            context_dir=tmp,
+            agent_pool=agent_pool,
+        )
+        subprocess.run(args, check=True)
+    return resolve_pushed_digest(
+        registry=registry, image_name=image_name, image_tag=image_tag
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", required=True, help="ACR name, e.g. myregistry")
+    parser.add_argument(
+        "--base-image-ref",
+        required=True,
+        help="Digest-pinned base image, e.g. myregistry.azurecr.io/gpt-rag-orchestrator@sha256:...",
+    )
+    parser.add_argument("--image-name", default="gpt-rag-orchestrator")
+    parser.add_argument("--image-tag", required=True, help="Tag for the derivative image")
+    parser.add_argument(
+        "--startup-command",
+        default=HOSTED_STARTUP_COMMAND_DEFAULT,
+    )
+    parser.add_argument("--port", type=int, default=HOSTED_PORT_DEFAULT)
+    parser.add_argument(
+        "--agent-pool",
+        default=None,
+        help="ACR Tasks agent pool name (required under NETWORK_ISOLATION=true)",
+    )
+    args = parser.parse_args(argv)
+
+    digest = build_hosted_image(
+        registry=args.registry,
+        base_image_ref=args.base_image_ref,
+        image_name=args.image_name,
+        image_tag=args.image_tag,
+        startup_command=args.startup_command,
+        port=args.port,
+        agent_pool=args.agent_pool,
+    )
+    print(digest)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/adr/ADR-0001-hosted-agents.md
+++ b/docs/adr/ADR-0001-hosted-agents.md
@@ -248,6 +248,19 @@ the reusable landing zone:
   `sha256:<digest>` supplied by the operator. A mutable release tag is rejected.
   This is necessary because the `v3.9.0` orchestrator release contains source but
   no immutable published release image.
+- The published orchestrator image's baked-in entrypoint is the classic
+  Container Apps command. Foundry's container-mode hosted-agent API deploys
+  whatever `CMD`/`ENTRYPOINT` is in the image and does not read `azure.yaml`'s
+  `startupCommand`, so pointing `HOSTED_AGENT_IMAGE_VERSION` straight at the
+  classic image's digest starts the wrong process. Setting
+  `HOSTED_AGENT_AUTO_BUILD_IMAGE=true` (default `false`) makes `preDeploy`
+  derive a hosted-specific image first: an ACR Tasks build, using the same
+  private registry and agent pool as every other network-isolated build, whose
+  only instructions are `FROM <the pinned classic digest>` plus a `CMD`
+  override to the hosted entrypoint. `HOSTED_AGENT_IMAGE_VERSION` is then
+  re-pinned to the derivative image's digest before `azd deploy
+  orchestrator-agent` runs. Operators who already publish a correctly
+  configured hosted image can leave the flag off.
 - The deterministic rollback contract restores the complete `v3.7.0` classic
   pin set, resets both flags to `false`, clears hosted endpoint inputs, and
   restores `CHAT_BACKEND=orchestrator`.

--- a/scripts/preDeploy.ps1
+++ b/scripts/preDeploy.ps1
@@ -157,6 +157,61 @@ if ($hostedMode) {
     exit 1
   }
 
+  # The Foundry "Create Agent" API for container-mode hosted agents only reads the
+  # image field; startupCommand (above, in azure.yaml) never reaches the real wire
+  # request, so whatever CMD is baked into the published orchestrator image is what
+  # actually runs. That image's CMD is the classic Container App entrypoint, not the
+  # hosted one. When HOSTED_AGENT_AUTO_BUILD_IMAGE=true, build a small derivative
+  # image (same digest-pinned base, CMD overridden to the hosted entrypoint) via ACR
+  # Tasks -- honoring the same VNet-injected agent pool used for every other
+  # NETWORK_ISOLATION=true build -- and point HOSTED_AGENT_IMAGE_VERSION at its
+  # digest before deploying. Defaults to false to preserve today's behavior for
+  # operators who already publish a correctly-configured hosted image themselves.
+  $hostedAutoBuildImage = "$($globalEnv.HOSTED_AGENT_AUTO_BUILD_IMAGE)".ToLowerInvariant() -match '^(1|true|t|yes|y)$'
+  if ($hostedAutoBuildImage) {
+    $acrEndpoint = "$($globalEnv.AZURE_CONTAINER_REGISTRY_ENDPOINT)"
+    if (-not $acrEndpoint) {
+      Write-Error "HOSTED_AGENT_AUTO_BUILD_IMAGE=true requires AZURE_CONTAINER_REGISTRY_ENDPOINT from provisioning."
+      exit 1
+    }
+    $acrName = $acrEndpoint.Split('.')[0]
+    $hostedImageName = if ($globalEnv.HOSTED_AGENT_IMAGE) { "$($globalEnv.HOSTED_AGENT_IMAGE)" } else { 'gpt-rag-orchestrator' }
+    $baseImageDigest = "$($globalEnv.HOSTED_AGENT_IMAGE_VERSION)"
+    $baseImageRef = "$acrEndpoint/$hostedImageName@$baseImageDigest"
+    $hostedImageTag = "hosted-$($baseImageDigest -replace '^sha256:', '').Substring(0,12)"
+    Write-Host "Building hosted-agent derivative image via ACR Tasks (base: $baseImageRef)..." -ForegroundColor Cyan
+    Push-Location $repoRoot
+    try {
+      $buildArgs = @(
+        '-m', 'config.deployment.hosted_image',
+        '--registry', $acrName,
+        '--base-image-ref', $baseImageRef,
+        '--image-name', $hostedImageName,
+        '--image-tag', $hostedImageTag
+      )
+      if ($globalEnv.ACR_TASK_AGENT_POOL) {
+        $buildArgs += @('--agent-pool', "$($globalEnv.ACR_TASK_AGENT_POOL)")
+      }
+      $hostedDigest = & python @buildArgs
+      if ($LASTEXITCODE -ne 0 -or -not $hostedDigest) {
+        Write-Error "Failed to build the hosted-agent derivative image."
+        exit $LASTEXITCODE
+      }
+      $hostedDigest = "$hostedDigest".Trim()
+    } finally {
+      Pop-Location
+    }
+    Write-Host "Hosted-agent derivative image built: $hostedDigest" -ForegroundColor Green
+    $env:HOSTED_AGENT_IMAGE_VERSION = $hostedDigest
+    $globalEnv.HOSTED_AGENT_IMAGE_VERSION = $hostedDigest
+    Push-Location $repoRoot
+    try {
+      & azd env set HOSTED_AGENT_IMAGE_VERSION $hostedDigest --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
+    } finally {
+      Pop-Location
+    }
+  }
+
   if (Test-Path -LiteralPath $dotAzure) {
     Copy-Item $dotAzure $hostedProject -Recurse -Force -Container
   }

--- a/scripts/preDeploy.sh
+++ b/scripts/preDeploy.sh
@@ -147,6 +147,39 @@ if [[ "$hosted_mode" =~ ^(1|true|t|yes|y)$ ]]; then
   [[ "$hosted_scope" == */.default ]] || { red "Hosted mode requires HOSTED_AGENT_RESOURCE_SCOPE as an explicit data-plane scope ending in '/.default'."; exit 1; }
   [ -n "$project_endpoint" ] && [ -n "$project_resource_id" ] || { red "Hosted mode requires AZURE_AI_PROJECT_ENDPOINT and AZURE_AI_PROJECT_RESOURCE_ID from provisioning."; exit 1; }
 
+  # The Foundry "Create Agent" API for container-mode hosted agents only reads the
+  # image field; startupCommand (in azure.yaml) never reaches the real wire request,
+  # so whatever CMD is baked into the published orchestrator image is what actually
+  # runs (the classic Container App entrypoint, not the hosted one). When
+  # HOSTED_AGENT_AUTO_BUILD_IMAGE=true, build a small derivative image (same
+  # digest-pinned base, CMD overridden to the hosted entrypoint) via ACR Tasks --
+  # honoring the same agent pool used for every other NETWORK_ISOLATION=true build --
+  # and point HOSTED_AGENT_IMAGE_VERSION at its digest before deploying. Defaults to
+  # false to preserve today's behavior for operators who already publish a
+  # correctly-configured hosted image themselves.
+  hosted_auto_build_image="$(get_azd_value "$repo_root" "HOSTED_AGENT_AUTO_BUILD_IMAGE" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$hosted_auto_build_image" =~ ^(1|true|t|yes|y)$ ]]; then
+    acr_endpoint="$(get_azd_value "$repo_root" "AZURE_CONTAINER_REGISTRY_ENDPOINT")"
+    [ -n "$acr_endpoint" ] || { red "HOSTED_AGENT_AUTO_BUILD_IMAGE=true requires AZURE_CONTAINER_REGISTRY_ENDPOINT from provisioning."; exit 1; }
+    acr_name="${acr_endpoint%%.*}"
+    hosted_image_name="$(get_azd_value "$repo_root" "HOSTED_AGENT_IMAGE")"
+    hosted_image_name="${hosted_image_name:-gpt-rag-orchestrator}"
+    base_image_digest="$(get_azd_value "$repo_root" "HOSTED_AGENT_IMAGE_VERSION")"
+    base_image_ref="$acr_endpoint/$hosted_image_name@$base_image_digest"
+    hosted_image_tag="hosted-${base_image_digest#sha256:}"
+    hosted_image_tag="${hosted_image_tag:0:19}"
+    echo "Building hosted-agent derivative image via ACR Tasks (base: $base_image_ref)..."
+    build_args=(-m config.deployment.hosted_image --registry "$acr_name" --base-image-ref "$base_image_ref" --image-name "$hosted_image_name" --image-tag "$hosted_image_tag")
+    if [ -n "$acr_task_agent_pool" ]; then
+      build_args+=(--agent-pool "$acr_task_agent_pool")
+    fi
+    hosted_agent_digest="$(cd "$repo_root" && python3 "${build_args[@]}")" || { red "Failed to build the hosted-agent derivative image."; exit 1; }
+    [ -n "$hosted_agent_digest" ] || { red "Failed to build the hosted-agent derivative image."; exit 1; }
+    echo "Hosted-agent derivative image built: $hosted_agent_digest"
+    export HOSTED_AGENT_IMAGE_VERSION="$hosted_agent_digest"
+    (cd "$repo_root" && azd env set HOSTED_AGENT_IMAGE_VERSION "$hosted_agent_digest" --environment "$environment_name" --no-prompt >/dev/null)
+  fi
+
   copy_dot_azure "$dot_azure" "$hosted_project"
   (
     cd "$hosted_project"

--- a/tests/test_hosted_image.py
+++ b/tests/test_hosted_image.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+from config.deployment.hosted_image import (
+    HOSTED_PORT_DEFAULT,
+    HOSTED_STARTUP_COMMAND_DEFAULT,
+    build_acr_build_args,
+    build_hosted_image,
+    parse_digest_from_build_output,
+    render_hosted_dockerfile,
+    resolve_pushed_digest,
+)
+
+
+BASE_DIGEST = "sha256:" + ("a" * 64)
+BASE_IMAGE_REF = f"myregistry.azurecr.io/gpt-rag-orchestrator@{BASE_DIGEST}"
+
+
+class RenderHostedDockerfileTests(unittest.TestCase):
+    def test_defaults_produce_hosted_entrypoint_cmd(self) -> None:
+        content = render_hosted_dockerfile(BASE_IMAGE_REF)
+
+        self.assertEqual(
+            (
+                f"FROM {BASE_IMAGE_REF}\n"
+                f"EXPOSE {HOSTED_PORT_DEFAULT}\n"
+                '''CMD ["uvicorn", "src.api.hosted_entrypoint:app", '''
+                '''"--host", "0.0.0.0", "--port", "8088"]\n'''
+            ),
+            content,
+        )
+        self.assertIn(HOSTED_STARTUP_COMMAND_DEFAULT.split()[0], content)
+
+    def test_custom_startup_command_and_port(self) -> None:
+        content = render_hosted_dockerfile(
+            BASE_IMAGE_REF,
+            startup_command="python -m custom_entry --port 9000",
+            port=9000,
+        )
+
+        self.assertIn("EXPOSE 9000\n", content)
+        self.assertIn('"python", "-m", "custom_entry", "--port", "9000"', content)
+
+    def test_rejects_mutable_tag_only_base_image(self) -> None:
+        with self.assertRaises(ValueError):
+            render_hosted_dockerfile("myregistry.azurecr.io/gpt-rag-orchestrator:v3.9.0")
+
+    def test_rejects_empty_startup_command(self) -> None:
+        with self.assertRaises(ValueError):
+            render_hosted_dockerfile(BASE_IMAGE_REF, startup_command="   ")
+
+
+class BuildAcrBuildArgsTests(unittest.TestCase):
+    def test_builds_expected_argv_without_agent_pool(self) -> None:
+        args = build_acr_build_args(
+            registry="myregistry",
+            image_name="gpt-rag-orchestrator",
+            image_tag="v3.9.0-hosted",
+            dockerfile_path="/tmp/x/Dockerfile",
+            context_dir="/tmp/x",
+        )
+
+        self.assertEqual(
+            [
+                "az",
+                "acr",
+                "build",
+                "--registry",
+                "myregistry",
+                "--image",
+                "gpt-rag-orchestrator:v3.9.0-hosted",
+                "--file",
+                "/tmp/x/Dockerfile",
+                "/tmp/x",
+            ],
+            args,
+        )
+
+    def test_appends_agent_pool_when_provided(self) -> None:
+        args = build_acr_build_args(
+            registry="myregistry",
+            image_name="gpt-rag-orchestrator",
+            image_tag="v3.9.0-hosted",
+            dockerfile_path="/tmp/x/Dockerfile",
+            context_dir="/tmp/x",
+            agent_pool="build-pool",
+        )
+
+        self.assertEqual(args[-2:], ["--agent-pool", "build-pool"])
+
+    def test_requires_registry_image_name_and_tag(self) -> None:
+        base_kwargs = dict(
+            registry="myregistry",
+            image_name="gpt-rag-orchestrator",
+            image_tag="v3.9.0-hosted",
+            dockerfile_path="/tmp/x/Dockerfile",
+            context_dir="/tmp/x",
+        )
+        for missing in ("registry", "image_name", "image_tag"):
+            kwargs = dict(base_kwargs)
+            kwargs[missing] = ""
+            with self.assertRaises(ValueError):
+                build_acr_build_args(**kwargs)
+
+
+class ParseDigestFromBuildOutputTests(unittest.TestCase):
+    def test_extracts_digest_when_present(self) -> None:
+        output = f"Run ID: dt9 was successful ... digest: {BASE_DIGEST}\n"
+        self.assertEqual(BASE_DIGEST, parse_digest_from_build_output(output))
+
+    def test_returns_none_when_absent(self) -> None:
+        self.assertIsNone(parse_digest_from_build_output("no digest here"))
+
+
+class ResolvePushedDigestTests(unittest.TestCase):
+    @patch("config.deployment.hosted_image.subprocess.run")
+    def test_returns_digest_from_az_cli(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=f"{BASE_DIGEST}\n", stderr=""
+        )
+
+        digest = resolve_pushed_digest(
+            registry="myregistry",
+            image_name="gpt-rag-orchestrator",
+            image_tag="v3.9.0-hosted",
+        )
+
+        self.assertEqual(BASE_DIGEST, digest)
+        mock_run.assert_called_once()
+        called_args = mock_run.call_args.args[0]
+        self.assertEqual(
+            [
+                "az",
+                "acr",
+                "repository",
+                "show",
+                "--name",
+                "myregistry",
+                "--image",
+                "gpt-rag-orchestrator:v3.9.0-hosted",
+                "--query",
+                "digest",
+                "-o",
+                "tsv",
+            ],
+            called_args,
+        )
+
+    @patch("config.deployment.hosted_image.subprocess.run")
+    def test_raises_on_unexpected_output(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="not-a-digest\n", stderr=""
+        )
+
+        with self.assertRaises(RuntimeError):
+            resolve_pushed_digest(
+                registry="myregistry",
+                image_name="gpt-rag-orchestrator",
+                image_tag="v3.9.0-hosted",
+            )
+
+
+class BuildHostedImageTests(unittest.TestCase):
+    @patch("config.deployment.hosted_image.resolve_pushed_digest")
+    @patch("config.deployment.hosted_image.subprocess.run")
+    def test_builds_then_resolves_digest(
+        self, mock_run: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+        mock_resolve.return_value = BASE_DIGEST
+
+        digest = build_hosted_image(
+            registry="myregistry",
+            base_image_ref=BASE_IMAGE_REF,
+            image_name="gpt-rag-orchestrator",
+            image_tag="v3.9.0-hosted",
+            agent_pool="build-pool",
+        )
+
+        self.assertEqual(BASE_DIGEST, digest)
+        mock_run.assert_called_once()
+        build_args = mock_run.call_args.args[0]
+        self.assertEqual(build_args[0:3], ["az", "acr", "build"])
+        self.assertIn("--agent-pool", build_args)
+        self.assertIn("build-pool", build_args)
+        mock_resolve.assert_called_once_with(
+            registry="myregistry",
+            image_name="gpt-rag-orchestrator",
+            image_tag="v3.9.0-hosted",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem (Defect B, found during #592/#597 NETWORK_ISOLATION=true validation)

Foundry's container-mode hosted-agent "Create Agent" API deploys whatever `CMD`/`ENTRYPOINT` is baked into the image; it never reads `hosted-agent/azure.yaml`'s `startupCommand` for this deploy target (confirmed by reading the `azure.ai.agent` azd extension's Go source: `ContainerConfigurationAPI` only has an `Image` field, no command override anywhere in the real REST schema — `startupCommand` is only used for the separate local `azd ai agent run` dev-testing flow).

The published `gpt-rag-orchestrator` image's baked-in `CMD` is the classic Container Apps entrypoint (`uvicorn main:app --host 0.0.0.0 --port 8080`). Pointing `HOSTED_AGENT_IMAGE_VERSION` straight at that digest starts the wrong process for the hosted agent, which needs `uvicorn src.api.hosted_entrypoint:app --host 0.0.0.0 --port 8088`. Reproduced live: agent creation succeeds (`status: active`), but invocation fails because the container is serving the classic app on the wrong port/module.

ADR-0001 already anticipated operators must supply a custom-built image (since the orchestrator release ships source but no immutable hosted-specific image), but no tooling existed anywhere in the repo to build one correctly.

## Fix

New opt-in flag `HOSTED_AGENT_AUTO_BUILD_IMAGE` (default `false` — no behavior change for existing operators who already publish a correctly configured hosted image).

When `true`, `scripts/preDeploy.ps1`/`.sh` now derive a small hosted-specific image before calling `azd deploy orchestrator-agent`:
- `config/deployment/hosted_image.py` builds via **ACR Tasks** (`az acr build`, with optional `--agent-pool`) — same private registry/agent pool as every other `NETWORK_ISOLATION=true` build, no public registry, no Docker daemon required.
- The generated Dockerfile is minimal: `FROM <pinned classic image digest>` + `EXPOSE 8088` + `CMD [...hosted entrypoint...]`.
- The pushed derivative image's digest is resolved and `HOSTED_AGENT_IMAGE_VERSION` is re-pinned to it before the real deploy call.

## Changes
- `config/deployment/hosted_image.py` (new): pure/testable Dockerfile render, `az acr build` argv construction, digest resolution, orchestration + CLI.
- `tests/test_hosted_image.py` (new): 12 unit tests, `subprocess.run` mocked — no real Azure calls.
- `scripts/preDeploy.ps1` / `scripts/preDeploy.sh`: wire the new opt-in step into both hosted-mode branches, before `azd deploy orchestrator-agent`.
- `docs/adr/ADR-0001-hosted-agents.md`, `config/deployment/composition.py`: document the gap and the new flag; clarify the Bicep-recorded `hostedAgent.version` digest is informational (provision-time parameter document only) and may legitimately differ from the digest actually deployed at `azd deploy` time when auto-build is used.

## Testing
- `python -m pytest tests/ -q` → 32 passed (4 subtests), no regressions.
- PowerShell/bash syntax validated (`Parser::ParseFile`, `bash -n` equivalent via git-bash).
- Live re-validation of the built image running correctly as a Foundry hosted agent in the disposable `NETWORK_ISOLATION=true` validation environment is currently blocked by an unrelated, fully diagnosed external Landing Zone defect (VNet-injected ACR Tasks agent pool provisioning failures — reported separately to `Azure/bicep-ptn-aiml-landing-zone`). The creation-gate and rollback/digest-pin portions of #592/#597 were validated independently of this fix using pre-existing image digests.

Related: #592, #597

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>