### PR TITLE
fix(preDeploy): correct PowerShell hosted image tag Substring scoping

### DIFF
--- a/scripts/preDeploy.ps1
+++ b/scripts/preDeploy.ps1
@@ -178,7 +178,7 @@ if ($hostedMode) {
     $hostedImageName = if ($globalEnv.HOSTED_AGENT_IMAGE) { "$($globalEnv.HOSTED_AGENT_IMAGE)" } else { 'gpt-rag-orchestrator' }
     $baseImageDigest = "$($globalEnv.HOSTED_AGENT_IMAGE_VERSION)"
     $baseImageRef = "$acrEndpoint/$hostedImageName@$baseImageDigest"
-    $hostedImageTag = "hosted-$($baseImageDigest -replace '^sha256:', '').Substring(0,12)"
+    $hostedImageTag = "hosted-$((($baseImageDigest -replace '^sha256:', '')).Substring(0,12))"
     Write-Host "Building hosted-agent derivative image via ACR Tasks (base: $baseImageRef)..." -ForegroundColor Cyan
     Push-Location $repoRoot
     try {


### PR DESCRIPTION
fix(preDeploy): correct PowerShell hosted image tag Substring scoping

The .Substring(0,12) call was outside the $(...) subexpression in
scripts/preDeploy.ps1, so PowerShell emitted it as literal text instead
of invoking it on the computed digest string. This produced an invalid
87-char ACR tag containing '(', ')', ',' characters instead of the
intended 19-char 'hosted-<12hex>' tag, breaking az acr build on every
Windows/PowerShell invocation of HOSTED_AGENT_AUTO_BUILD_IMAGE=true.

Found by independent code-review agent on PR #604. Fixes parity with
the already-correct bash equivalent in preDeploy.sh.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: ef6a46e2-8746-4b56-84ae-b7e225b01df9
