### PR TITLE
fix(infra): pin AI Landing Zone v2.4.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "infra"]
 	path = infra
 	url = https://github.com/Azure/bicep-ptn-aiml-landing-zone.git
-	branch = v2.4.0
+	branch = v2.4.1
 	ignore = dirty

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "tag": "unreleased",
   "repo": "https://github.com/azure/gpt-rag.git",
-  "ailz_tag": "v2.4.0",
-  "ailz_commit": "d5c2b5996bbaf91f6282d35de440da6341cb41f6",
+  "ailz_tag": "v2.4.1",
+  "ailz_commit": "fbc5d226543d0fb7a29ccd241c45df5c3caa82ee",
   "components": [
     {
       "name": "gpt-rag-ui",

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -15,9 +15,9 @@ class ReleasedPinTests(unittest.TestCase):
         components = {item["name"]: item for item in manifest["components"]}
 
         self.assertEqual("unreleased", manifest["tag"])
-        self.assertEqual("v2.4.0", manifest["ailz_tag"])
+        self.assertEqual("v2.4.1", manifest["ailz_tag"])
         self.assertEqual(
-            "d5c2b5996bbaf91f6282d35de440da6341cb41f6",
+            "fbc5d226543d0fb7a29ccd241c45df5c3caa82ee",
             manifest["ailz_commit"],
         )
         self.assertEqual(
@@ -44,7 +44,7 @@ class ReleasedPinTests(unittest.TestCase):
 
     def test_gitmodule_and_gitlink_match_landing_zone_release(self) -> None:
         gitmodules = (ROOT / ".gitmodules").read_text(encoding="utf-8")
-        self.assertIn("branch = v2.4.0", gitmodules)
+        self.assertIn("branch = v2.4.1", gitmodules)
 
         completed = subprocess.run(
             ["git", "ls-files", "--stage", "infra"],
@@ -54,7 +54,7 @@ class ReleasedPinTests(unittest.TestCase):
             text=True,
         )
         self.assertIn(
-            "d5c2b5996bbaf91f6282d35de440da6341cb41f6",
+            "fbc5d226543d0fb7a29ccd241c45df5c3caa82ee",
             completed.stdout,
         )
 


### PR DESCRIPTION
## Purpose

Pin GPT-RAG's authoritative AI Landing Zone dependency to `v2.4.1`, which contains the accelerator-neutral fix for VNet-injected ACR Task agent pool provisioning tracked by #597.

The three release-pin surfaces now agree on annotated tag `v2.4.1` and exact commit `fbc5d226543d0fb7a29ccd241c45df5c3caa82ee`:
- `manifest.json` `ailz_tag` / `ailz_commit`
- `.gitmodules` `infra.branch`
- `infra` submodule gitlink

Related to #597.

## Contributing guidelines

Please see [Contributing Guidelines](https://azure.github.io/GPT-RAG/contributing) before creating your Pull Request.

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Related Backlog Item or Issue

- #597
- Upstream fix: Azure/bicep-ptn-aiml-landing-zone#124
- Upstream release: Azure/bicep-ptn-aiml-landing-zone#125

## Is this change disruptive or does it break existing applications?

- [ ] Yes
- [x] No

This is a patch-level landing-zone pin update. It changes the infrastructure consumed by subsequent provision operations but does not publish an umbrella release or alter runtime component pins.

## Cross-Repository Dependencies

- [ ] [gpt-rag-orchestrator](https://github.com/azure/gpt-rag-orchestrator)
- [ ] [gpt-rag-ingestion](https://github.com/azure/gpt-rag-ingestion)
- [ ] [gpt-rag-ui](https://github.com/azure/gpt-rag-ui)
- [ ] [gpt-rag-mcp](https://github.com/azure/gpt-rag-mcp)

Depends on the published AI Landing Zone `v2.4.1` release.

## Does this require changes to project documentation?

- [x] Yes
- [ ] No

The `docs` branch currently names AILZ `v2.4.0` in the unreleased hosted-mode candidate matrix and should be updated in a coordinated docs-branch change before merge/release. Historical `CHANGELOG.md` entries are intentionally untouched, and this PR does not prepare an umbrella release.

## Validation

- Confirmed `v2.4.1` is an annotated tag (`tag` object `646defb4585206be10b908830af217f10b54d398`) and dereferences exactly to `fbc5d226543d0fb7a29ccd241c45df5c3caa82ee`. The tag is annotated but not cryptographically signed.
- Confirmed manifest tag/commit, `.gitmodules` branch, staged gitlink, tag dereference, and submodule HEAD all align exactly.
- `git diff --cached --check` passed.
- `az bicep build --file infra/main.bicep` passed with the existing warnings.
- `az bicep lint --file infra/main.bicep` passed with the existing warnings.
- `infra/tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1` passed all checks, including the five required service tags and firewall rule-collection ordering/gating.
- `python -m unittest tests.test_release_contracts.ReleasedPinTests.test_manifest_contains_exact_released_pins tests.test_release_contracts.ReleasedPinTests.test_gitmodule_and_gitlink_match_landing_zone_release` passed (2/2).

### Upstream live validation evidence

The upstream fix was exercised in a disposable, fully network-isolated non-production environment with the ACR Task agent pool enabled. Before the fix, provisioning reproduced the failure. With `v2.4.1`, the pool reached `Succeeded` on the first attempt; the firewall policy and all rule collection groups also reached `Succeeded`; private DNS and TCP 443 reachability were confirmed from the pool subnet. A second run completed with zero failed operations, and validation resources were removed afterward.

### Transparent residual gates

- The bonus end-to-end `az acr build --agent-pool` execution was blocked by an unrelated `AuthorizationFailed` on `listBuildSourceUploadUrl/action` in the disposable delegated subscription. The same raw ARM operation succeeded with a different principal against the same registry. Therefore this PR claims live provisioning and network reachability, not a newly re-proven build/push/pull operation. The residual release gate is one successful `az acr build --agent-pool` plus image push/pull in a healthy approved non-production subscription/principal.
- No reusable GPT-RAG azd environment is configured in this branch, so no additional live combination deployment was run and no production deployment was attempted.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I have tested the new functionality and ensured existing features still work within the static/contract scope above
- [x] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request