### PR TITLE
chore(release): pin hosted no-panel components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,12 @@ scope. The deterministic rollback contract in
 set, clears hosted endpoint inputs, resets both mode flags to `false`, and
 restores `CHAT_BACKEND=orchestrator`.
 
-The UI and AI Landing Zone release APIs report `immutable=false`. AI Landing
-Zone `v2.4.1` is additionally protected by active exact-tag ruleset `20050531`
-against deletion and non-fast-forward updates; UI `v2.5.1` remains the
-unmitigated immutable-tag blocker because the maintainer lacks repository
-administration. This unreleased integration does not publish an umbrella
-release or activate hosted mode.
+The UI, orchestrator, and AI Landing Zone release APIs report
+`immutable=false`, but active semantic-version tag rulesets `20396217`,
+`20396972`, and `20396978` prevent deletion and non-fast-forward updates for
+`refs/tags/v*`. AI Landing Zone `v2.4.1` is also protected by exact-tag ruleset
+`20339953`. This unreleased integration does not publish an umbrella release or
+activate hosted mode.
 
 ## [v3.7.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@
 
 ### Changed
 
-- **Released component pins.** The unreleased integration combination pins UI
-  `v2.5.0`, orchestrator `v3.9.0`, ingestion `v2.6.0`, and AI Landing Zone
-  `v2.4.1` at their exact released commits. AI Landing Zone `v2.4.1` adds the
-  network rules and deployment ordering required by a dedicated
-  VNet-connected ACR Tasks agent pool.
+- **Compatible hosted/no-panel component pins.** The unreleased integration
+  combination pins UI `v2.5.1`, orchestrator `v3.10.0`, ingestion `v2.6.0`,
+  and AI Landing Zone `v2.4.1` at their exact released commits. The UI and
+  orchestrator releases provide the delegated identity and Toolbox call-context
+  contracts required by hosted/no-panel mode.
 
 ### Fixed
 
@@ -52,7 +52,7 @@ restores `CHAT_BACKEND=orchestrator`.
 
 The UI and AI Landing Zone release APIs report `immutable=false`. AI Landing
 Zone `v2.4.1` is additionally protected by active exact-tag ruleset `20050531`
-against deletion and non-fast-forward updates; UI `v2.5.0` remains the
+against deletion and non-fast-forward updates; UI `v2.5.1` remains the
 unmitigated immutable-tag blocker because the maintainer lacks repository
 administration. This unreleased integration does not publish an umbrella
 release or activate hosted mode.

--- a/manifest.json
+++ b/manifest.json
@@ -7,14 +7,14 @@
     {
       "name": "gpt-rag-ui",
       "repo": "https://github.com/azure/gpt-rag-ui.git",
-      "tag": "v2.5.0",
-      "commit": "5328ec7e222e47f56b50b077ccf8a51c30f61681"
+      "tag": "v2.5.1",
+      "commit": "971d92a8affd1c859befa4783a26eebc899b425c"
     },
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v3.9.0",
-      "commit": "779b136d4da5d4bdcf9442dc1ec7a6115571f06a"
+      "tag": "v3.10.0",
+      "commit": "eaa787340c27d8df5bb550147e95c5ecd02ad385"
     },
     {
       "name": "gpt-rag-ingestion",

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -21,7 +21,7 @@ class ReleasedPinTests(unittest.TestCase):
             manifest["ailz_commit"],
         )
         self.assertEqual(
-            ("v3.9.0", "779b136d4da5d4bdcf9442dc1ec7a6115571f06a"),
+            ("v3.10.0", "eaa787340c27d8df5bb550147e95c5ecd02ad385"),
             (
                 components["gpt-rag-orchestrator"]["tag"],
                 components["gpt-rag-orchestrator"]["commit"],
@@ -35,7 +35,7 @@ class ReleasedPinTests(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            ("v2.5.0", "5328ec7e222e47f56b50b077ccf8a51c30f61681"),
+            ("v2.5.1", "971d92a8affd1c859befa4783a26eebc899b425c"),
             (
                 components["gpt-rag-ui"]["tag"],
                 components["gpt-rag-ui"]["commit"],


### PR DESCRIPTION
## Purpose

Pin the newly published hosted/no-panel-compatible UI and orchestrator releases at their exact commits while keeping the umbrella manifest unreleased and preserving ingestion and AI Landing Zone pins.

## Contributing guidelines

Please see [Contributing Guidelines](https://azure.github.io/GPT-RAG/contributing) before creating your Pull Request.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other: component release pin update

## Related Backlog Item or Issue

Related: #591

## Is this change disruptive or does it break existing applications?

- [ ] Yes
- [x] No

Classic remains the default. Hosted/no-panel remains opt-in and this PR does not deploy or activate it.

## Cross-Repository Dependencies

- [x] [gpt-rag-orchestrator v3.10.0](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v3.10.0)
- [ ] [gpt-rag-ingestion](https://github.com/azure/gpt-rag-ingestion)
- [x] [gpt-rag-ui v2.5.1](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.5.1)
- [ ] [gpt-rag-mcp](https://github.com/azure/gpt-rag-mcp)

## Does this require changes to project documentation?

- [ ] Yes
- [x] No

## Documentation Link

Hosted/no-panel documentation was already merged in [docs PR #612](https://github.com/Azure/GPT-RAG/pull/612). The component releases complete the documented delegated-identity and Toolbox call-context contracts without introducing a new configuration or deployment surface.

## Validation

- Independently dereferenced UI `v2.5.1` to `971d92a8affd1c859befa4783a26eebc899b425c` and orchestrator `v3.10.0` to `eaa787340c27d8df5bb550147e95c5ecd02ad385` through the GitHub release, tag, and commit APIs.
- `python -m pytest tests/test_release_contracts.py tests/test_deployment_modes.py tests/test_hosted_image.py -q` - 32 passed, 4 subtests passed.
- Ran each component's `validate-agentic-assets.py` from an exact-tag checkout: UI validated 3 agents and 4 skills plus scoped instructions; orchestrator validated 3 agents, 4 skills, and 8 scoped instructions.
- Compared `v2.5.0...v2.5.1` and `v3.9.0...v3.10.0` through the GitHub compare API and reviewed the release implementation diffs.
- JSON parsing, manifest pin invariants, and `git diff --check` passed.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I have tested the new functionality and ensured existing features still work
- [x] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request