### PR TITLE
docs: update hosted-default architecture diagrams

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,28 @@
 ## Architecture
 
-GPT-RAG is modular. The full Zero Trust diagram shows a hardened, full-capability reference architecture; it is not the minimum footprint required to evaluate or run the accelerator. Start with the **Basic Deployment** baseline, then add network isolation, enterprise integration, public ingress, or AI capabilities only when the scenario requires them.
+GPT-RAG is modular. The accepted hosted-default architecture makes Microsoft
+Foundry hosted/no-panel the target for genuinely fresh deployments and keeps
+the Container Apps orchestrator as an explicit supported fallback. Existing
+deployments retain their persisted topology during upgrade. Network isolation,
+enterprise integration, public ingress, and optional AI capabilities remain
+separate choices.
+
+!!! warning "Target architecture pending platform and release gates"
+    UI [PR #93](https://github.com/Azure/gpt-rag-ui/pull/93) is merged, but the
+    umbrella implementation in [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617)
+    is not merged and no hosted-default GPT-RAG release has published. The
+    diagrams on this page document the approved target. Until #617 merges and
+    the required component, AI Landing Zone, and umbrella releases publish,
+    current published releases continue to use the classic Container Apps
+    default.
 
 ## Full Zero Trust reference
 
-The existing architecture diagram remains the full network-isolated reference view. Use it when discussing hardened deployments, while the complementary diagrams below explain the baseline and optional layers.
+The existing PNG and Visio remain the full network-isolated reference view.
+Use them when discussing hardened deployments. Maintainers should apply the
+[legacy diagram update handoff](architecture_legacy_diagram_handoff.md) before
+the hosted-default release so those manually maintained assets match the
+focused editable SVG and Excalidraw views below.
 
 ![Zero Trust Architecture](media/architecture_zero_trust.png)
 
@@ -12,14 +30,48 @@ The existing architecture diagram remains the full network-isolated reference vi
 
 ---
 
+## Chat runtime modes
+
+![Chat runtime modes and hosted deployment lifecycle](media/architecture_chat_runtime_modes.svg)
+
+[Edit the chat runtime diagram in Excalidraw](media/architecture_chat_runtime_modes.excalidraw)
+
+The fresh-deployment target sends chat from the Web UI to a Microsoft Foundry
+hosted agent. The UI performs an on-behalf-of exchange for the signed-in user,
+the hosted agent passes only opaque Foundry call context to Toolbox, and
+Foundry IQ or Azure AI Search applies native authorization trimming. Missing
+identity, call context, configuration, authorization, network, protocol, or
+runtime state fails closed. A request never silently switches to the
+Container Apps orchestrator.
+
+The classic runtime remains selectable through an explicit deployment
+operation. Pre-cutover deployments without a topology marker remain classic,
+and any persisted topology stays sticky until an operator deliberately
+migrates it. Hosted/panel is not part of the target default:
+`DEPLOY_ADMINISTRATIVE_PANEL=false` remains required while
+[issue #611](https://github.com/Azure/GPT-RAG/issues/611) is open.
+
+The lower lane in the diagram shows the planned two-phase hosted image flow:
+provision prerequisites, build through public ACR Tasks or the dedicated
+VNet-connected ACR Tasks agent pool, resolve the hosted image to an immutable
+`sha256` digest, provision the digest-backed hosted handoff, and deploy.
+
 ## Complementary modular views
 
 !!! note "How to read these diagrams"
-    The modular view is organized around **Basic Deployment**, **Common platform services**, and **Zero Trust additions**. Solid-color chips are standard resources, dashed orange chips are default-on or BYO-capable parameters, and solid orange chips are opt-in add-ons.
+    The modular view is organized around **Basic Deployment**, **Common
+    platform services**, and **Zero Trust additions**. Hosted chat is a
+    mode-selected baseline runtime, not an optional AI capability. Solid-color
+    chips are standard resources, dashed orange chips are default-on or
+    BYO-capable parameters, and solid orange chips are opt-in add-ons.
 
 ![Basic Deployment architecture](media/architecture_basic_deployment.svg)
 
-The baseline corresponds to the default Container Apps [Basic Deployment](deploy.md#basic-deployment) flow with `NETWORK_ISOLATION=false`, `DEPLOY_HOSTED_AGENT_ORCHESTRATION=false`, and `DEPLOY_ADMINISTRATIVE_PANEL=false`. It focuses on the default application and data path: users access the UI, the orchestrator Container App coordinates AI and retrieval, ingestion indexes enterprise content, and shared platform services provide configuration, secrets, identity, storage, search, and conversation state. The first [hosted-agent preview](deploy.md#chat-runtime-modes-preview) replaces the orchestrator chat runtime with a Microsoft Foundry hosted agent. This preview supports hosted/no-panel only and requires `DEPLOY_ADMINISTRATIVE_PANEL=false`.
+The Basic diagram shows the target [fresh deployment](deploy.md#chat-runtime-modes-upcoming-hosted-default-release)
+with `NETWORK_ISOLATION=false`: Web UI and ingestion remain in Container Apps,
+while hosted/no-panel handles chat through Toolbox and authorization-trimmed
+retrieval. The orchestrator Container App appears only as the explicit
+fallback. The panel is absent and its flag remains `false`.
 
 ![Modular architecture layers](media/architecture_modular_layers.svg)
 
@@ -29,17 +81,17 @@ Use the table below for the deployment parameters behind each layer, and the [De
 
 | Layer | Posture | Controlled by | Include when |
 | --- | --- | --- | --- |
-| UI, chat runtime, ingestion | Mode-selected baseline | `DEPLOY_HOSTED_AGENT_ORCHESTRATION`, `DEPLOY_ADMINISTRATIVE_PANEL`, `manifest.json` components, and `containerAppsList` | Running the default UI/orchestrator/ingestion topology or the hosted/no-panel preview. Hosted/panel is deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611). |
+| UI, chat runtime, ingestion | Mode-selected baseline | Canonical `DEPLOYMENT_TOPOLOGY`; materialized `DEPLOY_HOSTED_AGENT_ORCHESTRATION`, `DEPLOY_ADMINISTRATIVE_PANEL`, `CHAT_BACKEND`; `manifest.json` components; `containerAppsList` | After the gated release, fresh environments select hosted/no-panel, existing topologies stay sticky, and `classic` explicitly selects the Container Apps fallback. Hosted/panel is deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611). |
 | AI Foundry account, project, and model deployments | Required AI control plane | `deployAiFoundry`, `deployAfProject`, `deployAAfAgentSvc`, `modelDeploymentList` | Provisioning Azure AI Foundry / Azure OpenAI and the model deployments used by GPT-RAG. |
 | AI Foundry associated resources | Default-created or BYO-capable | `aiSearchResourceId`, `aiFoundryStorageAccountResourceId`, `aiFoundryCosmosDBAccountResourceId`, `keyVaultResourceId`, `aiFoundryStorageSku` | Letting the AI Foundry module create its required Storage, Search, Cosmos DB, and Key Vault resources, or reusing existing ones. |
-| RAG workload data services | Mode-selected, parameter-controlled | `deploySearchService`, `deployStorageAccount`, `deployCosmosDb`, `storageAccountContainersList`, `databaseContainersList` | Running the indexed-document and file-storage path. The default topology retains conversation and panel Cosmos DB. Hosted/no-panel omits panel-only Cosmos DB. |
-| App Configuration, managed identity / RBAC, Container Apps, Container Registry | Required platform capabilities, topology varies by mode | `deployAppConfig`, `deployContainerApps`, `deployContainerEnv`, `deployContainerRegistry`, `useUAI`, service role lists | Centralizing runtime settings and identities. Hosted/no-panel does not provision an orchestrator Container App and requires `DEPLOY_ADMINISTRATIVE_PANEL=false`. |
+| RAG workload data services | Mode-selected, parameter-controlled | `deploySearchService`, `deployStorageAccount`, `deployCosmosDb`, `storageAccountContainersList`, `databaseContainersList` | Running indexed-document and file-storage paths. Hosted/no-panel uses Foundry managed Conversations and omits panel-only Cosmos DB; classic preserves its existing state path. |
+| App Configuration, identity / RBAC, Container Apps, Container Registry | Required platform capabilities, topology varies by mode | `deployAppConfig`, `deployContainerApps`, `deployContainerEnv`, `deployContainerRegistry`, `useUAI`, service role lists | Publishing the sticky topology and runtime contract, hosting UI/ingestion, and preparing immutable images. Hosted/no-panel does not provision an orchestrator Container App. |
 | Workload Key Vault and observability | Default support, parameter-controlled or reusable | `deployKeyVault`, `deployLogAnalytics`, `deployAppInsights`, `EXISTING_LOG_ANALYTICS_WORKSPACE_RESOURCE_ID`, `EXISTING_APPLICATION_INSIGHTS_RESOURCE_ID`, `EXISTING_APPLICATION_INSIGHTS_CONNECTION_STRING` | Storing workload secrets and capturing telemetry. Application Insights is created or wired only when an effective Log Analytics workspace is available. |
 | Zero Trust private networking | Optional security posture | `networkIsolation`, `allowedIpRanges`, `useExistingVNet`, `deploySubnets`, `policyManagedPrivateDns`, `EXISTING_PRIVATE_DNS_ZONE_*` | Requiring private endpoints, private DNS, VNet integration, NSGs, and internal Container Apps ingress. |
-| Azure Firewall, Jumpbox, Bastion, NAT Gateway, private ACR build pool | Zero Trust operations/build options | `DEPLOY_AZURE_FIREWALL`, `DEPLOY_JUMPBOX`, `DEPLOY_BASTION`, `DEPLOY_NAT_GATEWAY`, `DEPLOY_ACR_TASK_AGENT_POOL`, `EXISTING_JUMPBOX_RESOURCE_ID`, `EXISTING_BASTION_RESOURCE_ID`, `EXISTING_NAT_GATEWAY_RESOURCE_ID` | Operating from inside the VNet, reusing central access/egress resources, or enabling a private ACR Task agent pool. In GPT-RAG, the ACR agent pool defaults to off and is opt-in. |
+| Azure Firewall, Jumpbox, Bastion, NAT Gateway, private ACR build pool | Zero Trust operations/build options | `DEPLOY_AZURE_FIREWALL`, `DEPLOY_JUMPBOX`, `DEPLOY_BASTION`, `DEPLOY_NAT_GATEWAY`, `DEPLOY_ACR_TASK_AGENT_POOL`, `EXISTING_JUMPBOX_RESOURCE_ID`, `EXISTING_BASTION_RESOURCE_ID`, `EXISTING_NAT_GATEWAY_RESOURCE_ID` | Operating inside the VNet or reusing central access/egress resources. The gated hosted flow uses the dedicated VNet-connected ACR Tasks agent pool for private builds; shared ACR Tasks cannot reach a private endpoint. |
 | Application Gateway WAF public ingress | Optional entry layer | `publicIngress.enabled` | Exposing one private Container App through controlled public HTTPS/WAF. See [Application Gateway](howto_app_gateway.md). |
 | Existing platform / AI Landing Zone integration | Optional enterprise integration | `DEPLOYMENT_MODE=ailz-integrated`, `USE_EXISTING_VNET`, `EXISTING_*_RESOURCE_ID`, `HUB_INTEGRATION_*` | Reusing central network, DNS, observability, Bastion, NAT, or hub-spoke resources. |
-| Scenario capabilities | Optional feature add-ons | `DEPLOY_SPEECH_SERVICE`, `DEPLOY_GROUNDING_WITH_BING`, `ENABLE_AGENTIC_RETRIEVAL` | Enabling voice, Bing grounding, or agentic retrieval scenarios. MCP/tool-hosting and NL2SQL application behavior are configured outside the Bicep-deployed infrastructure shown in this diagram. |
+| Scenario capabilities | Optional feature add-ons | `DEPLOY_SPEECH_SERVICE`, `DEPLOY_GROUNDING_WITH_BING`, `ENABLE_AGENTIC_RETRIEVAL` | Enabling voice, Bing grounding, or agentic retrieval scenarios. The hosted runtime is not classified as an optional capability. MCP tool selection and NL2SQL application behavior remain separately configured. |
 
 For data ownership, telemetry, retention, and responsibility boundaries, see
 [Governance and responsible operation](governance_overview.md). The correlated

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,15 +9,20 @@ separate choices.
 
 !!! warning "Implementation merged; release gates remain"
     The hosted-default implementation merged to `develop` in
-    [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617).
+    [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617) as
+    [`b614d0a`](https://github.com/Azure/GPT-RAG/commit/b614d0ad19a66cbc06b34a3ad764b0d94428999f).
     UI release PR
-    [#94](https://github.com/Azure/gpt-rag-ui/pull/94) and AI Landing Zone
-    release PR [#131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131)
-    also merged, but the planned UI `v2.6.0` and AI Landing Zone `v2.5.0` tags
-    and GitHub Releases are not published. The diagrams document the approved
-    target. Current published GPT-RAG `v3.7.0` remains classic until those
-    releases publish and final umbrella pins, integrated validation, and the
-    GPT-RAG release complete.
+    [#94](https://github.com/Azure/gpt-rag-ui/pull/94) merged to `main` as
+    [`763fa7e`](https://github.com/Azure/gpt-rag-ui/commit/763fa7eb2135037382673d2eb968421f084941cc),
+    and AI Landing Zone release PR
+    [#131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131) merged
+    to `main` as
+    [`a6ae728`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/a6ae7284d654abb7ec53810cb8765b2975b51baa).
+    However, UI `v2.6.0` and AI Landing Zone `v2.5.0` tags and GitHub Releases
+    are not published, and final umbrella pins, integrated validation, and the
+    GPT-RAG release remain incomplete. The diagrams document the approved
+    target, not shipped behavior. Current published GPT-RAG `v3.7.0` remains
+    classic.
 
 ## Full Zero Trust reference
 

--- a/docs/architecture_legacy_diagram_handoff.md
+++ b/docs/architecture_legacy_diagram_handoff.md
@@ -1,0 +1,90 @@
+# Legacy architecture diagram update handoff
+
+Use this checklist to manually update `media/GPT-RAG.vsdx`, then export the
+updated full reference view to `media/architecture_zero_trust.png`. The SVG
+diagrams remain the editable source for the focused Basic, modular-layer, and
+chat-runtime views.
+
+!!! warning "Release status"
+    Draw the hosted/no-panel path as the **target fresh-deployment default** and
+    label it **Pending Azure/GPT-RAG #617 + required releases**. Do not label it
+    shipped until the platform PR merges and the component and umbrella
+    releases publish.
+
+## Shapes and labels
+
+Add or update these shapes in the application/runtime area:
+
+| Shape | Exact label | Placement |
+| --- | --- | --- |
+| Existing application host boundary | `Azure Container Apps` | Keep around the Web UI and ingestion services. |
+| Existing UI shape | `Web UI` | Keep in Container Apps at the request-path entry. |
+| Existing ingestion shape | `Ingestion` | Keep in Container Apps and connected to Storage / AI Search indexing. |
+| New primary runtime shape | `Microsoft Foundry Hosted Agent` | Place to the right of Web UI, outside the Container Apps boundary and inside the Microsoft Foundry boundary. |
+| New tool boundary | `Toolbox / MCP tools` | Place to the right of the hosted agent. |
+| New retrieval shape | `Authorization-trimmed retrieval` | Place below Toolbox and connect to Foundry IQ / Azure AI Search. |
+| Fallback runtime shape | `Container Apps orchestrator - explicit fallback` | Place below the primary request path with a dashed border. Keep it inside Container Apps. |
+| Mode annotation | `Fresh target default: hosted-no-panel` | Place above the hosted-agent lane. |
+| Fallback annotation | `Explicit/sticky classic topology` | Place above the orchestrator fallback. |
+| Panel annotation | `Administrative panel absent; DEPLOY_ADMINISTRATIVE_PANEL=false` | Place below the hosted lane. |
+| Release annotation | `Pending Azure/GPT-RAG #617 + required releases` | Place in an amber status banner below the diagram title. |
+
+## Connections and labels
+
+1. Connect `Signed-in user` to `Web UI`.
+2. Connect `Web UI` to `Microsoft Foundry Hosted Agent` and label the connection
+   `delegated user OBO`.
+3. Connect `Microsoft Foundry Hosted Agent` to `Toolbox / MCP tools` and label
+   the connection `opaque x-agent-foundry-call-id`.
+4. Connect `Toolbox / MCP tools` to `Authorization-trimmed retrieval`.
+5. Connect `Authorization-trimmed retrieval` to Foundry IQ / Azure AI Search
+   and label it `native per-user document authorization`.
+6. Keep the ingestion-to-Storage / AI Search indexing connections unchanged.
+7. Draw a dashed connection from `Web UI` to
+   `Container Apps orchestrator - explicit fallback`.
+8. Place a red stop marker between the hosted and fallback lanes with the label
+   `No request-time silent fallback`. Do not connect the lanes as an automatic
+   failover path.
+
+## Hosted image preparation inset
+
+Add a small deployment inset near Container Registry with this left-to-right
+flow:
+
+`azd provision (prerequisites)` -> `ACR build` -> `immutable sha256 digest` ->
+`azd provision (hosted handoff)` -> `azd deploy`
+
+Split `ACR build` into two labeled alternatives:
+
+- `Public: shared ACR Tasks`
+- `Private: dedicated VNet ACR Tasks agent pool`
+
+The two alternatives converge on the same `immutable sha256 digest` shape.
+
+## Legend and visual treatment
+
+- Green solid border/fill: target hosted request path.
+- Blue solid border/fill: shared UI and ingestion services in Container Apps.
+- Gray dashed border: explicit Container Apps fallback.
+- Purple solid border/fill: Toolbox and MCP tools.
+- Orange solid border/fill: build and immutable-image lifecycle.
+- Red stop marker: prohibited request-time cross-backend fallback.
+- Amber banner: unmerged PR or unpublished release dependency.
+- Use black text throughout and preserve the existing typeface, spacing, icon
+  family, title, and accessibility contrast.
+
+## Remove or relabel
+
+- Remove any direct `Web UI -> Orchestrator` connection presented as the fresh
+  default.
+- Remove any label that classifies hosted agents as an optional AI capability.
+- Remove the orchestrator Container App from the primary hosted lane.
+- Remove the administrative panel and panel-only Cosmos DB from hosted/no-panel.
+- Relabel generic `Orchestrator` shapes so the hosted shape and explicit
+  Container Apps fallback cannot be confused.
+- Remove any automatic or request-time failover arrow between hosted and
+  classic modes.
+
+After editing the Visio source, export the full page to
+`architecture_zero_trust.png` at the existing canvas size and verify that all
+labels remain readable at the published documentation width.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -47,62 +47,111 @@ azd deploy
 
 Some transient Azure capacity failures are not exposed by reliable pre-create APIs. For example, Cosmos DB can still fail later with regional high-demand `ServiceUnavailable`; the preflight reports this limitation explicitly. Use `GPT_RAG_REGIONAL_PREFLIGHT_SKIP=true` only to bypass GPT-RAG regional checks, or `PREFLIGHT_SKIP=true` to bypass all preflight hooks.
 
-For the basic flow, the `postProvision` hook runs locally after `azd provision` and configures GPT-RAG data-plane resources such as App Configuration and search setup. With the default Container Apps topology, `azd deploy` then deploys the UI, orchestrator, and ingestion services.
+For current published releases, the `postProvision` hook runs locally after
+`azd provision`, and `azd deploy` deploys the UI, orchestrator, and ingestion
+services in the classic Container Apps topology. The approved target changes
+the fresh-deployment default only after the platform and release gates below
+are complete.
 
-### Chat runtime modes (preview)
+### Chat runtime modes (upcoming hosted-default release)
 
-!!! warning "The first hosted preview is no-panel only"
-    The first Microsoft Foundry hosted-agent preview supports hosted/no-panel only and requires `DEPLOY_ADMINISTRATIVE_PANEL=false`. Hosted/panel is not supported or promoted in this preview because the managed Foundry Conversation history integration and panel frontend are incomplete. Follow [issue #611](https://github.com/Azure/GPT-RAG/issues/611) for that work.
+!!! warning "Do not treat the target default as shipped"
+    UI [PR #93](https://github.com/Azure/gpt-rag-ui/pull/93) is merged. The
+    umbrella implementation in [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617)
+    is not merged, and the required component, AI Landing Zone, and GPT-RAG
+    umbrella releases have not published. Current published releases remain
+    classic. Use the workflow in this section only with the release that
+    explicitly announces the hosted-default contract.
 
-`DEPLOY_HOSTED_AGENT_ORCHESTRATION` and `DEPLOY_ADMINISTRATIVE_PANEL` both default to `false`. Both false values preserve the default Container Apps topology, which remains the supported default and fallback. Set `DEPLOY_HOSTED_AGENT_ORCHESTRATION=true` only to evaluate the hosted/no-panel preview. Keep `DEPLOY_ADMINISTRATIVE_PANEL=false`.
+The upcoming release resolves one canonical topology before provisioning and
+materializes the corresponding legacy flags and App Configuration values.
+Topology never changes automatically during a chat request.
 
-| Mode | Required settings | Resulting topology |
+| Environment or operator choice | Resolved settings | Resulting topology |
 | --- | --- | --- |
-| Classic (default) | `DEPLOY_HOSTED_AGENT_ORCHESTRATION=false`, `DEPLOY_ADMINISTRATIVE_PANEL=false`, `CHAT_BACKEND=orchestrator` | The UI routes chat to the orchestrator Container App. The existing administrative surfaces and Cosmos DB dependencies remain. |
-| Hosted, no panel (preview) | `DEPLOY_HOSTED_AGENT_ORCHESTRATION=true`, `DEPLOY_ADMINISTRATIVE_PANEL=false`, `CHAT_BACKEND=hosted_agent` | The UI routes chat to the Microsoft Foundry hosted agent. No orchestrator Container App or panel-only Cosmos DB dependency is provisioned. |
+| Genuinely fresh environment after the gated release | `DEPLOYMENT_TOPOLOGY=hosted-no-panel`, `DEPLOY_HOSTED_AGENT_ORCHESTRATION=true`, `DEPLOY_ADMINISTRATIVE_PANEL=false`, `CHAT_BACKEND=hosted_agent` | Web UI and ingestion remain in Container Apps. Chat runs in a Microsoft Foundry hosted agent. No orchestrator Container App or panel-only Cosmos DB is provisioned. |
+| Existing environment with persisted topology | Existing topology and `CHAT_BACKEND` stay sticky. An unmarked pre-cutover environment resolves to `classic`. | Upgrade does not implicitly migrate identity, conversation, authorization, or cost semantics. |
+| Explicit Container Apps fallback | `DEPLOYMENT_TOPOLOGY=classic`, materialized hosted and panel flags `false`, `CHAT_BACKEND=orchestrator` | UI routes chat to the orchestrator Container App. Classic history and panel data remain available. |
+| Explicit migration to hosted/no-panel | `DEPLOYMENT_TOPOLOGY=hosted-no-panel`, delegated hosted scope configured, panel `false` | Runs the two-phase hosted lifecycle below, then validates the hosted request path before the classic chat path is removed or deactivated. |
 
-Do not set `DEPLOY_ADMINISTRATIVE_PANEL=true` for this preview. The hosted/panel topology and its user-facing history, feedback, curation, and dashboard workflows are deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611). Draft ingestion behavior does not make those workflows available.
+Do not select `hosted-panel`. Hosted/panel history, feedback, curation, and
+dashboard workflows remain blocked by
+[issue #611](https://github.com/Azure/GPT-RAG/issues/611), and
+`DEPLOY_ADMINISTRATIVE_PANEL=false` remains required.
 
-The deployment hooks publish the shared runtime contract under the App Configuration label `gpt-rag`:
+The deployment hooks publish the shared runtime contract under the App
+Configuration label `gpt-rag`:
 
 | Setting | Operator contract |
 | --- | --- |
-| `CHAT_BACKEND` | Valid values are `orchestrator` (default) and `hosted_agent`. Invalid values fail startup. Hosted mode never silently falls back to classic. |
-| `ORCHESTRATOR_BASE_URL` | Classic service root. The UI calls the `/orchestrator` route on this endpoint when `CHAT_BACKEND=orchestrator`. |
-| `HOSTED_AGENT_BASE_URL` | Hosted service root. The UI sends `POST /invocations` to this endpoint when `CHAT_BACKEND=hosted_agent`. |
-| `HOSTED_AGENT_RESOURCE_SCOPE` | Required explicit hosted data-plane Entra scope ending in `/.default`, for example `api://<application-id>/.default`. Do not use the Azure Resource Manager scope. |
-| `HOSTED_AGENT_SSE_IDLE_TIMEOUT_SECONDS` | Finite positive wait for the next SSE event. The UI default is `60`. Never configure an infinite timeout. |
+| `DEPLOYMENT_TOPOLOGY` | Canonical deployment choice: `hosted-no-panel` or `classic`. `hosted-panel` fails closed while #611 is open. |
+| `CHAT_BACKEND` | The upcoming UI release treats missing or blank as `hosted_agent`; the umbrella deployment always publishes the resolved sticky value. `orchestrator` is the explicit fallback. Unknown values fail startup. Environment configuration takes precedence over App Configuration. |
+| `ORCHESTRATOR_BASE_URL` | Classic service root, used only when `CHAT_BACKEND=orchestrator`. |
+| `HOSTED_AGENT_BASE_URL` | Required HTTPS hosted service root. The UI sends `POST /invocations` when `CHAT_BACKEND=hosted_agent`. |
+| `HOSTED_AGENT_RESOURCE_SCOPE` | Required explicit non-ARM hosted data-plane Entra scope ending in `/.default`, for example `api://<application-id>/.default`. |
+| `HOSTED_AGENT_AUTH_MODE` | `user_delegated` is the default and required release path. The UI exchanges the signed-in user's token on behalf of the user. `service_identity` is an explicit reviewed exception, never an implicit fallback. |
+| `HOSTED_AGENT_SSE_IDLE_TIMEOUT_SECONDS` | Finite positive wait for the next SSE event. The UI default is `60`; an infinite timeout is rejected. |
+| `HOSTED_AGENT_IMAGE_VERSION` | Canonical lowercase immutable digest in `sha256:<64-hex-characters>` form. Mutable tags are rejected. |
 
-For a hosted deployment, `HOSTED_AGENT_IMAGE_VERSION` is also required before provisioning. Set it to the immutable image digest in the form `sha256:<64-hex-characters>`. A mutable tag such as `latest` or `v3.9.0` is not accepted.
+Hosted configuration, authentication, connection, timeout, protocol, and
+runtime failures are terminal for startup or the affected request. The UI does
+not silently switch to the orchestrator or to managed identity. Foundry passes
+opaque `x-agent-foundry-call-id` context to Toolbox; user and delegated bearer
+tokens are not copied into tool payloads or client-defined identity headers.
+
+#### Two-phase hosted deployment
+
+For a fresh hosted deployment, configure the delegated data-plane scope before
+the first provision:
 
 ```powershell
-azd env set DEPLOY_HOSTED_AGENT_ORCHESTRATION true
-azd env set DEPLOY_ADMINISTRATIVE_PANEL false # required for this preview
-azd env set HOSTED_AGENT_IMAGE_VERSION "sha256:<64-hex-characters>"
 azd env set HOSTED_AGENT_RESOURCE_SCOPE "api://<application-id>/.default"
 azd env set HOSTED_AGENT_SSE_IDLE_TIMEOUT_SECONDS 60
+azd provision
+pwsh scripts/prepareHostedDeployment.ps1
+azd provision
+azd deploy
 ```
 
-Treat these exact pins as one hosted/no-panel preview candidate. Do not mix versions:
+On POSIX systems, use `scripts/prepareHostedDeployment.sh` for the preparation
+step. For an explicit migration, set
+`DEPLOYMENT_TOPOLOGY=hosted-no-panel` before the first `azd provision`.
 
-| Component | Candidate pin |
-| --- | --- |
-| GPT-RAG UI | `v2.5.0` |
-| GPT-RAG orchestrator | `v3.9.0` |
-| GPT-RAG ingestion | `v2.6.0` |
-| AI Landing Zone (AILZ) | `v2.4.1` |
+The first provision creates hosted prerequisites with image preparation
+enabled but hosted deployment disabled. The preparation command clones and
+verifies the manifest-pinned orchestrator source, builds the standard image and
+the hosted-entrypoint derivative, resolves the pushed manifest to an immutable
+digest, and persists that digest and source provenance. The second provision
+materializes the digest-backed hosted handoff; `azd deploy` then deploys the
+hosted agent.
 
-The GitHub release APIs for UI `v2.5.0` and AILZ `v2.4.1` currently report `immutable=false`. AILZ `v2.4.1` is nevertheless protected by active exact-tag ruleset `20339953`, which blocks deletion and non-fast-forward updates to `refs/tags/v2.4.1`. UI `v2.5.0` has no equivalent mitigation and remains the immutable-tag release blocker because repository-admin permission is unavailable. Neither API metadata nor the AILZ tag ruleset implies that this combination has an Azure/GPT-RAG umbrella release. The ingestion pin also does not make the deferred hosted/panel workflows available.
+Public deployments use shared ACR Tasks. Network-isolated deployments use the
+dedicated VNet-connected ACR Tasks agent pool; shared ACR Tasks cannot reach a
+private endpoint. Operators may pass an already-built immutable
+`sha256:<64-hex-characters>` digest to the preparation command to skip builds.
+No lifecycle hook recursively invokes `azd provision`.
 
-AILZ `v2.4.1` fixes provisioning of the optional VNet-injected ACR Tasks agent pool under `NETWORK_ISOLATION=true` by adding the required Azure Firewall network rules and ordering them after firewall provisioning. The pool supports private builds for the UI, orchestrator, ingestion, and hosted-agent derivative images.
+#### Explicit fallback after the hosted-default release
 
-With AILZ `v2.4.1`, the dedicated VNet-connected ACR Tasks agent pool is a valid private build route for all images, including the hosted-agent derivative image. Shared ACR Tasks run outside that private network boundary and cannot reach a private endpoint.
+Fallback is a deployment operation, not a request-time retry:
 
-#### Roll back to the v3.7.0 classic release
+```powershell
+azd env set DEPLOYMENT_TOPOLOGY classic
+azd provision
+azd deploy
+```
 
-Roll back the entire GPT-RAG `v3.7.0` release as a unit, rather than changing only `CHAT_BACKEND` while leaving candidate manifests, hooks, or infrastructure in place. The complete classic pin set is UI `v2.3.13`, orchestrator `v3.8.0`, ingestion `v2.5.0`, and AILZ `v2.3.0`.
+This restores the orchestrator Container App and publishes
+`CHAT_BACKEND=orchestrator` without deleting hosted Conversations or existing
+classic panel data.
 
-Restore the `v3.7.0` manifest, infrastructure gitlink and `.gitmodules`, lifecycle hooks, parameters, and `azure.yaml`. Set both deployment flags to `false`, publish `CHAT_BACKEND=orchestrator` and the classic `ORCHESTRATOR_BASE_URL` under the `gpt-rag` label, then run `azd provision` and `azd deploy`. This restores the full known classic configuration instead of a hybrid rollback.
+#### Current classic release
+
+GPT-RAG `v3.7.0` remains the latest published umbrella release at the time this
+target architecture was documented. Its classic pin set is UI `v2.3.13`,
+orchestrator `v3.8.0`, ingestion `v2.5.0`, and AI Landing Zone `v2.3.0`.
+Do not combine the upcoming topology contract with those released hooks or
+manifests.
 
 ### Retrieval backend
 
@@ -393,7 +442,12 @@ cd gpt-rag-orchestrator
 
 ## Permissions
 
-The role tables below describe the default Container Apps topology. Hosted/no-panel omits the orchestrator Container App assignments. The hosted-agent identity receives its own Foundry data-plane and immutable-image pull assignments during hosted deployment. Hosted/panel remains unsupported in this preview and is tracked by [issue #611](https://github.com/Azure/GPT-RAG/issues/611).
+The role tables below describe the currently released classic Container Apps
+topology. The upcoming hosted/no-panel target omits the orchestrator Container
+App assignments and adds Foundry data-plane, delegated-user, Toolbox, and
+immutable-image pull assignments. It still depends on platform PR #617 and new
+releases. Hosted/panel remains unsupported and is tracked by
+[issue #611](https://github.com/Azure/GPT-RAG/issues/611).
 
 **Microsoft Foundry Role and AI Search Assignments**
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,15 +57,20 @@ only after the release gates below are complete.
 
 !!! warning "Do not treat the target default as shipped"
     The umbrella implementation merged to `develop` in
-    [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617).
+    [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617) as
+    [`b614d0a`](https://github.com/Azure/GPT-RAG/commit/b614d0ad19a66cbc06b34a3ad764b0d94428999f).
     UI release PR
-    [#94](https://github.com/Azure/gpt-rag-ui/pull/94) and AI Landing Zone
-    release PR [#131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131)
-    merged to their main branches, but the planned UI `v2.6.0` and AI Landing
-    Zone `v2.5.0` tags and GitHub Releases are not published. Final umbrella
-    pins, integrated validation, and a new GPT-RAG release also remain. Current
-    published GPT-RAG `v3.7.0` stays classic. Use this workflow only with the
-    release that explicitly announces the hosted-default contract.
+    [#94](https://github.com/Azure/gpt-rag-ui/pull/94) merged to `main` as
+    [`763fa7e`](https://github.com/Azure/gpt-rag-ui/commit/763fa7eb2135037382673d2eb968421f084941cc),
+    and AI Landing Zone release PR
+    [#131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131) merged
+    to `main` as
+    [`a6ae728`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/a6ae7284d654abb7ec53810cb8765b2975b51baa).
+    However, UI `v2.6.0` and AI Landing Zone `v2.5.0` tags and GitHub Releases
+    are not published. Final umbrella pins, integrated validation, and a new
+    GPT-RAG release also remain. Current published GPT-RAG `v3.7.0` stays
+    classic. Use this workflow only with the release that explicitly announces
+    the hosted-default contract.
 
 The upcoming release resolves one canonical topology before provisioning and
 materializes the corresponding legacy flags and App Configuration values.
@@ -90,7 +95,7 @@ Configuration label `gpt-rag`:
 | --- | --- |
 | `DEPLOYMENT_TOPOLOGY` | Canonical deployment choice: `hosted-no-panel` or `classic`. `hosted-panel` fails closed while #611 is open. |
 | `CHAT_BACKEND` | The upcoming UI release treats missing or blank as `hosted_agent`; the umbrella deployment always publishes the resolved sticky value. `orchestrator` is the explicit fallback. Unknown values fail startup. Environment configuration takes precedence over App Configuration. |
-| `ORCHESTRATOR_BASE_URL` | Classic service root, used only when `CHAT_BACKEND=orchestrator`. |
+| `ORCHESTRATOR_BASE_URL` | Classic service root, used only when `CHAT_BACKEND=orchestrator`. The UI calls the `/orchestrator` route on this endpoint. |
 | `HOSTED_AGENT_BASE_URL` | Required HTTPS hosted service root. The UI sends canonical Responses protocol v2 requests to `POST /responses` when `CHAT_BACKEND=hosted_agent`. The separate `POST /invocations` endpoint retains the legacy messages-based invocation contract. |
 | `HOSTED_AGENT_RESOURCE_SCOPE` | Required explicit non-ARM hosted data-plane Entra scope ending in `/.default`, for example `api://<application-id>/.default`. |
 | `HOSTED_AGENT_AUTH_MODE` | `user_delegated` is the default and required release path. The UI exchanges the signed-in user's token on behalf of the user. `service_identity` is an explicit reviewed exception, never an implicit fallback. |

--- a/docs/howto_authentication.md
+++ b/docs/howto_authentication.md
@@ -286,7 +286,19 @@ Examples of how to populate `metadata_security_user_ids` and `metadata_security_
 
 ## Admin Access for the Operator Dashboards
 
-In the default Container Apps topology, the orchestrator and ingestion service each ship a small operator dashboard. The orchestrator dashboard is mounted at `/dashboard` on the orchestrator Container App and the ingestion dashboard is mounted at `/dashboard` on the ingestion Container App. Both surfaces let an operator inspect runs, conversations, and a curated set of runtime settings, and the ingestion dashboard also lets an operator trigger a scheduled job on demand. The first [hosted-agent preview](deploy.md#chat-runtime-modes-preview) supports hosted/no-panel only, omits these administrative surfaces, and requires `DEPLOY_ADMINISTRATIVE_PANEL=false`. Hosted/panel is deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611).
+In the currently released classic Container Apps topology, the orchestrator
+and ingestion service each ship a small operator dashboard. The orchestrator
+dashboard is mounted at `/dashboard` on the orchestrator Container App and the
+ingestion dashboard is mounted at `/dashboard` on the ingestion Container App.
+Both surfaces let an operator inspect runs, conversations, and a curated set of
+runtime settings, and the ingestion dashboard also lets an operator trigger a
+scheduled job on demand. The
+[upcoming hosted-default topology](deploy.md#chat-runtime-modes-upcoming-hosted-default-release)
+is hosted/no-panel, omits these administrative surfaces, and requires
+`DEPLOY_ADMINISTRATIVE_PANEL=false`. That default still depends on
+[Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617) and new
+releases. Hosted/panel is deferred to
+[issue #611](https://github.com/Azure/GPT-RAG/issues/611).
 
 Admin access is enforced through an **Entra ID App Role named `Admin`** added to the same App Registration you created for user sign-in. The token the caller presents to `/api/dashboard/*` (or the ingestion equivalents) must carry `Admin` in its `roles` claim.
 

--- a/docs/howto_dashboard_signin.md
+++ b/docs/howto_dashboard_signin.md
@@ -4,7 +4,14 @@ The orchestrator admin dashboard at `/dashboard` signs the operator in with Micr
 
 If you are looking for the wider authentication picture (chat UI sign-in, On-Behalf-Of, document-level access control), see [Authentication and Document-Level Security](howto_authentication.md). This page is scoped to the operator dashboard.
 
-This procedure applies to the orchestrator dashboard in the default Container Apps topology. The first [hosted-agent preview](deploy.md#chat-runtime-modes-preview) supports hosted/no-panel only, does not deploy this dashboard, and requires `DEPLOY_ADMINISTRATIVE_PANEL=false`. Hosted/panel is deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611).
+This procedure applies to the orchestrator dashboard in the currently released
+classic Container Apps topology and in the explicit classic fallback. The
+[upcoming hosted-default topology](deploy.md#chat-runtime-modes-upcoming-hosted-default-release)
+is hosted/no-panel, does not deploy this dashboard, and requires
+`DEPLOY_ADMINISTRATIVE_PANEL=false`. It still depends on
+[Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617) and new
+releases. Hosted/panel is deferred to
+[issue #611](https://github.com/Azure/GPT-RAG/issues/611).
 
 ## What this is
 

--- a/docs/howto_userfeedback.md
+++ b/docs/howto_userfeedback.md
@@ -1,6 +1,15 @@
 # User Feedback Configuration
 
-GPT-RAG includes a **User Feedback Loop** feature that lets users evaluate assistant responses through the UI. In the default Container Apps topology, feedback is processed by the orchestrator and stored in **Cosmos DB**. The first [hosted-agent preview](deploy.md#chat-runtime-modes-preview) supports hosted/no-panel only and does not include this feedback path. Keep `DEPLOY_ADMINISTRATIVE_PANEL=false`. Hosted feedback and panel workflows are deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611).
+GPT-RAG includes a **User Feedback Loop** feature that lets users evaluate
+assistant responses through the UI. In the currently released classic
+Container Apps topology and the explicit classic fallback, feedback is
+processed by the orchestrator and stored in **Cosmos DB**. The
+[upcoming hosted-default topology](deploy.md#chat-runtime-modes-upcoming-hosted-default-release)
+is hosted/no-panel and does not include this feedback path. It still depends on
+[Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617) and new
+releases. Keep `DEPLOY_ADMINISTRATIVE_PANEL=false`; hosted feedback and panel
+workflows are deferred to
+[issue #611](https://github.com/Azure/GPT-RAG/issues/611).
 
 ![Feedback stored in Cosmos DB](media/feedback_stored_in_cosmos_db.png)
 <br>*User feedback stored in Cosmos DB*

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,14 +13,28 @@ Designed with Zero-Trust security and Infrastructure as Code (IaC) principles fr
 
 ## Architecture at a glance
 
-GPT-RAG can start as a basic deployment and expand into Zero Trust, public ingress, existing-platform integration, or optional AI capabilities as needed. See the [Architecture](architecture.md) page for the required-vs-configurable deployment table.
+GPT-RAG can start as a Basic deployment and expand into Zero Trust, public
+ingress, existing-platform integration, or optional AI capabilities. The
+approved target makes Microsoft Foundry hosted/no-panel the fresh-deployment
+chat runtime and retains the Container Apps orchestrator as an explicit
+fallback. See the [Architecture](architecture.md) page for the mode contract
+and required-vs-configurable deployment table.
 
-![Zero Trust Architecture](media/architecture_zero_trust.png)
-*Full Zero Trust reference architecture. This is the complete network-isolated view, not the minimum basic deployment.*
+!!! warning "Hosted-default release dependency"
+    The diagram below is the approved target, not shipped behavior. UI
+    [PR #93](https://github.com/Azure/gpt-rag-ui/pull/93) is merged, but
+    [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617) and the
+    required component and umbrella releases are still pending. Current
+    published releases remain classic.
 
-The complementary modular view below separates the basic deployment from optional add-on layers.
+![Chat runtime modes and hosted deployment lifecycle](media/architecture_chat_runtime_modes.svg)
 
 ![Modular architecture layers](media/architecture_modular_layers.svg)
+
+![Zero Trust Architecture](media/architecture_zero_trust.png)
+*Full Zero Trust reference architecture. This is the complete network-isolated
+view, not the minimum Basic deployment. The focused SVG above is the source of
+truth for the pending hosted-default runtime update.*
 
 ## Governance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,11 +23,14 @@ and required-vs-configurable deployment table.
 !!! warning "Hosted-default release dependency"
     The diagram below is the approved target, not shipped behavior. The
     platform implementation merged in
-    [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617), and the
-    UI and AI Landing Zone release PRs merged, but their planned tags and
-    GitHub Releases are not published. Final umbrella pins, integrated
-    validation, and a new GPT-RAG release remain. Current published GPT-RAG
-    `v3.7.0` stays classic.
+    [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617). UI
+    release [PR #94](https://github.com/Azure/gpt-rag-ui/pull/94) and AI Landing
+    Zone release
+    [PR #131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131)
+    also merged, but UI `v2.6.0` and AI Landing Zone `v2.5.0` tags and GitHub
+    Releases are not published. Final umbrella pins, integrated validation,
+    and a new GPT-RAG release remain. Current published GPT-RAG `v3.7.0` stays
+    classic.
 
 ![Chat runtime modes and hosted deployment lifecycle](media/architecture_chat_runtime_modes.svg)
 

--- a/docs/media/architecture_basic_deployment.svg
+++ b/docs/media/architecture_basic_deployment.svg
@@ -1,96 +1,116 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
-  <title id="title">GPT-RAG Basic Deployment architecture</title>
-  <desc id="desc">Baseline GPT-RAG architecture for NETWORK_ISOLATION=false showing frontend, orchestrator, ingestion, AI Foundry, search, storage, Cosmos DB, App Configuration, Key Vault, identity, observability, Container Apps, and Container Registry.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="820" viewBox="0 0 1280 820" role="img" aria-labelledby="title desc">
+  <title id="title">GPT-RAG hosted-default Basic Deployment target architecture</title>
+  <desc id="desc">Target fresh-deployment architecture, pending platform pull request 617 and new releases. Users access the Web UI in Azure Container Apps. The UI uses delegated on-behalf-of authorization to call a Microsoft Foundry hosted agent, which passes opaque call context to Toolbox and MCP tools for authorization-trimmed retrieval. Ingestion remains in Container Apps. The orchestrator Container App is shown only as an explicit deployment fallback, with no request-time silent fallback. The administrative panel is absent.</desc>
   <defs>
     <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
       <path d="M2,2 L10,6 L2,10 Z" fill="#385a8d"/>
     </marker>
+    <marker id="arrow-green" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#107c10"/>
+    </marker>
     <style>
-      .title { font: 700 28px 'Segoe UI', Arial, sans-serif; fill: #14345f; }
-      .subtitle { font: 400 16px 'Segoe UI', Arial, sans-serif; fill: #4c607a; }
-      .zone-title { font: 700 16px 'Segoe UI', Arial, sans-serif; fill: #14345f; }
-      .box-title { font: 700 15px 'Segoe UI', Arial, sans-serif; fill: #12385f; }
-      .box-text { font: 400 12px 'Segoe UI', Arial, sans-serif; fill: #43536b; }
-      .note { font: 600 13px 'Segoe UI', Arial, sans-serif; fill: #7a4a00; }
+      .title { font: 700 27px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .subtitle { font: 400 15px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .zone-title { font: 700 16px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .box-title { font: 700 14px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .box-text { font: 400 12px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .small { font: 600 11px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .status { font: 600 12px 'Segoe UI', Arial, sans-serif; fill: #000000; }
       .arrow { stroke: #385a8d; stroke-width: 2.5; fill: none; marker-end: url(#arrow); }
-      .soft-arrow { stroke: #6f7f99; stroke-width: 2; stroke-dasharray: 6 5; fill: none; marker-end: url(#arrow); }
+      .hosted-arrow { stroke: #107c10; stroke-width: 2.7; fill: none; marker-end: url(#arrow-green); }
+      .fallback-arrow { stroke: #6f7f99; stroke-width: 2.2; stroke-dasharray: 7 5; fill: none; marker-end: url(#arrow); }
+      .data-arrow { stroke: #7a4a00; stroke-width: 2.2; fill: none; marker-end: url(#arrow); }
     </style>
   </defs>
-  <rect width="1280" height="720" fill="#f7faff"/>
-  <text x="50" y="55" class="title">Basic Deployment baseline</text>
-  <text x="50" y="82" class="subtitle">Default evaluation/runtime view with NETWORK_ISOLATION=false. Optional Zero Trust networking is not shown in this baseline.</text>
 
-  <rect x="48" y="112" width="1184" height="560" rx="24" fill="#ffffff" stroke="#d8e3f5" stroke-width="2"/>
+  <rect width="1280" height="820" fill="#f7faff"/>
+  <text x="46" y="46" class="title">Basic Deployment: hosted-default target</text>
+  <text x="46" y="72" class="subtitle">Fresh deployments use hosted/no-panel after release gates pass; UI and ingestion remain in Azure Container Apps.</text>
 
-  <rect x="82" y="148" width="200" height="116" rx="18" fill="#eaf3ff" stroke="#4d89d8" stroke-width="2"/>
-  <text x="112" y="185" class="box-title">Users</text>
-  <text x="112" y="211" class="box-text">Browser or client</text>
-  <text x="112" y="233" class="box-text">Chat and uploads</text>
+  <rect x="46" y="91" width="1188" height="42" rx="12" fill="#fff4ce" stroke="#f7630c" stroke-width="1.5"/>
+  <text x="66" y="117" class="status">Release dependency: Azure/GPT-RAG #617 must merge and required component / umbrella releases must publish. Current published releases remain classic.</text>
 
-  <rect x="350" y="132" width="530" height="170" rx="20" fill="#edf7ff" stroke="#3f7dc7" stroke-width="2"/>
-  <text x="378" y="163" class="zone-title">Application runtime - Azure Container Apps</text>
-  <rect x="380" y="188" width="135" height="76" rx="14" fill="#ffffff" stroke="#4d89d8" stroke-width="2"/>
-  <text x="405" y="218" class="box-title">Frontend</text>
-  <text x="403" y="242" class="box-text">Web UI</text>
-  <rect x="560" y="188" width="145" height="76" rx="14" fill="#ffffff" stroke="#4d89d8" stroke-width="2"/>
-  <text x="586" y="218" class="box-title">Orchestrator</text>
-  <text x="582" y="242" class="box-text">Agent workflow</text>
-  <rect x="750" y="188" width="105" height="76" rx="14" fill="#ffffff" stroke="#4d89d8" stroke-width="2"/>
-  <text x="772" y="218" class="box-title">Ingestion</text>
-  <text x="772" y="242" class="box-text">Indexing</text>
+  <rect x="46" y="153" width="1188" height="312" rx="22" fill="#ffffff" stroke="#d8e3f5" stroke-width="2"/>
+  <text x="70" y="181" class="zone-title">Request path</text>
 
-  <rect x="940" y="148" width="230" height="116" rx="18" fill="#eef8f2" stroke="#4a9f6f" stroke-width="2"/>
-  <text x="970" y="185" class="box-title">Container Registry</text>
-  <text x="970" y="211" class="box-text">Service images</text>
-  <text x="970" y="233" class="box-text">Used by deploy scripts</text>
+  <rect x="70" y="205" width="150" height="100" rx="16" fill="#eaf3ff" stroke="#4d89d8" stroke-width="2"/>
+  <text x="108" y="239" class="box-title">Signed-in user</text>
+  <text x="96" y="263" class="box-text">Browser or client</text>
+  <text x="93" y="284" class="box-text">Chat and uploads</text>
 
-  <path class="arrow" d="M282 206 C310 206, 330 226, 377 226"/>
-  <path class="arrow" d="M515 226 L558 226"/>
-  <path class="arrow" d="M705 226 L748 226"/>
-  <path class="soft-arrow" d="M940 206 C906 206, 890 226, 856 226"/>
+  <rect x="270" y="192" width="350" height="126" rx="18" fill="#edf7ff" stroke="#3f7dc7" stroke-width="2"/>
+  <text x="292" y="218" class="zone-title">Azure Container Apps</text>
+  <rect x="292" y="235" width="132" height="62" rx="12" fill="#ffffff" stroke="#4d89d8" stroke-width="1.7"/>
+  <text x="328" y="262" class="box-title">Web UI</text>
+  <text x="309" y="283" class="box-text">Chat BFF + OBO</text>
+  <rect x="447" y="235" width="150" height="62" rx="12" fill="#ffffff" stroke="#4d89d8" stroke-width="1.7"/>
+  <text x="486" y="262" class="box-title">Ingestion</text>
+  <text x="466" y="283" class="box-text">Indexes content</text>
 
-  <rect x="82" y="344" width="330" height="236" rx="20" fill="#f2f7ff" stroke="#94b8e8" stroke-width="2"/>
-  <text x="112" y="378" class="zone-title">Configuration and security</text>
-  <rect x="112" y="405" width="125" height="64" rx="12" fill="#ffffff" stroke="#86aee5"/>
-  <text x="129" y="433" class="box-title">App Config</text>
-  <text x="127" y="454" class="box-text">Runtime settings</text>
-  <rect x="260" y="405" width="125" height="64" rx="12" fill="#ffffff" stroke="#86aee5"/>
-  <text x="283" y="433" class="box-title">Key Vault</text>
-  <text x="286" y="454" class="box-text">Secrets</text>
-  <rect x="112" y="490" width="273" height="64" rx="12" fill="#ffffff" stroke="#86aee5"/>
-  <text x="151" y="518" class="box-title">Managed identity and RBAC</text>
-  <text x="163" y="539" class="box-text">No credentials hard-coded in services</text>
+  <rect x="675" y="192" width="250" height="126" rx="18" fill="#dff6dd" stroke="#107c10" stroke-width="2.5"/>
+  <text x="700" y="219" class="zone-title">Microsoft Foundry</text>
+  <text x="704" y="248" class="box-title">Hosted Agent</text>
+  <text x="704" y="270" class="box-text">Fresh-deployment target</text>
+  <text x="704" y="291" class="box-text">Managed Conversations</text>
 
-  <rect x="464" y="344" width="365" height="236" rx="20" fill="#fff7ec" stroke="#dfaa57" stroke-width="2"/>
-  <text x="494" y="378" class="zone-title">Data and AI baseline</text>
-  <rect x="494" y="405" width="145" height="64" rx="12" fill="#ffffff" stroke="#dfaa57"/>
-  <text x="518" y="433" class="box-title">AI Foundry</text>
-  <text x="516" y="454" class="box-text">Models / OpenAI</text>
-  <rect x="660" y="405" width="140" height="64" rx="12" fill="#ffffff" stroke="#dfaa57"/>
-  <text x="690" y="433" class="box-title">AI Search</text>
-  <text x="684" y="454" class="box-text">Indexes</text>
-  <rect x="494" y="490" width="145" height="64" rx="12" fill="#ffffff" stroke="#dfaa57"/>
-  <text x="532" y="518" class="box-title">Storage</text>
-  <text x="521" y="539" class="box-text">Documents</text>
-  <rect x="660" y="490" width="140" height="64" rx="12" fill="#ffffff" stroke="#dfaa57"/>
-  <text x="692" y="518" class="box-title">Cosmos DB</text>
-  <text x="679" y="539" class="box-text">State / metadata</text>
+  <rect x="980" y="192" width="220" height="126" rx="18" fill="#e8daef" stroke="#5c2d91" stroke-width="2"/>
+  <text x="1003" y="219" class="zone-title">Toolbox / MCP tools</text>
+  <text x="1003" y="248" class="box-text">Opaque Foundry call context</text>
+  <text x="1003" y="270" class="box-text">Identity-aware tool calls</text>
+  <text x="1003" y="291" class="box-text">No bearer token in payload</text>
 
-  <rect x="880" y="344" width="290" height="236" rx="20" fill="#eef8f2" stroke="#68ad82" stroke-width="2"/>
-  <text x="910" y="378" class="zone-title">Recommended support</text>
-  <rect x="910" y="405" width="230" height="64" rx="12" fill="#ffffff" stroke="#68ad82"/>
-  <text x="950" y="433" class="box-title">Application Insights</text>
-  <text x="953" y="454" class="box-text">Application telemetry</text>
-  <rect x="910" y="490" width="230" height="64" rx="12" fill="#ffffff" stroke="#68ad82"/>
-  <text x="958" y="518" class="box-title">Log Analytics</text>
-  <text x="957" y="539" class="box-text">Central diagnostics</text>
+  <path class="arrow" d="M220 255 L290 255"/>
+  <path class="hosted-arrow" d="M424 255 L672 255"/>
+  <text x="477" y="239" class="small">delegated user OBO</text>
+  <path class="hosted-arrow" d="M925 255 L977 255"/>
+  <text x="931" y="238" class="small">opaque context</text>
 
-  <path class="soft-arrow" d="M620 302 C600 325, 585 357, 567 405"/>
-  <path class="soft-arrow" d="M800 264 C775 310, 740 352, 730 405"/>
-  <path class="soft-arrow" d="M632 264 C620 310, 620 350, 620 405"/>
-  <path class="soft-arrow" d="M560 264 C490 308, 390 356, 322 405"/>
-  <path class="soft-arrow" d="M704 264 C790 318, 900 350, 1024 405"/>
+  <rect x="270" y="350" width="655" height="82" rx="16" fill="#f3f2f1" stroke="#605e5c" stroke-width="2" stroke-dasharray="8 5"/>
+  <text x="292" y="378" class="box-title">Explicit fallback: orchestrator in Azure Container Apps</text>
+  <text x="292" y="401" class="box-text">Selected only by deployment topology / CHAT_BACKEND=orchestrator; existing classic deployments remain sticky.</text>
+  <text x="292" y="420" class="box-text">No request-time switch from hosted to classic after configuration, authentication, network, protocol, or runtime failure.</text>
+  <path class="fallback-arrow" d="M358 297 C358 325, 380 337, 430 348"/>
+  <path class="fallback-arrow" d="M925 391 C975 391, 1000 335, 1050 318"/>
 
-  <rect x="82" y="606" width="1088" height="42" rx="14" fill="#fff4db" stroke="#e6b24f"/>
-  <text x="112" y="632" class="note">Not in this baseline view: private endpoints, Private DNS, Azure Firewall, jumpbox/Bastion, NAT Gateway, ACR private build pool, and Application Gateway WAF.</text>
+  <rect x="46" y="493" width="378" height="238" rx="20" fill="#f2f7ff" stroke="#94b8e8" stroke-width="2"/>
+  <text x="70" y="523" class="zone-title">Configuration and security</text>
+  <rect x="70" y="545" width="145" height="62" rx="12" fill="#ffffff" stroke="#86aee5"/>
+  <text x="91" y="571" class="box-title">App Configuration</text>
+  <text x="93" y="592" class="box-text">Sticky topology</text>
+  <rect x="235" y="545" width="165" height="62" rx="12" fill="#ffffff" stroke="#86aee5"/>
+  <text x="273" y="571" class="box-title">Key Vault</text>
+  <text x="255" y="592" class="box-text">Secrets / OBO config</text>
+  <rect x="70" y="628" width="330" height="70" rx="12" fill="#ffffff" stroke="#86aee5"/>
+  <text x="135" y="655" class="box-title">Managed identity, delegated identity, and RBAC</text>
+  <text x="113" y="678" class="box-text">Explicit scopes; fail closed on missing authorization context</text>
+
+  <rect x="450" y="493" width="474" height="238" rx="20" fill="#fff7ec" stroke="#dfaa57" stroke-width="2"/>
+  <text x="474" y="523" class="zone-title">Authorization-trimmed data and AI path</text>
+  <rect x="474" y="545" width="190" height="62" rx="12" fill="#ffffff" stroke="#dfaa57"/>
+  <text x="516" y="571" class="box-title">Foundry IQ / AI Search</text>
+  <text x="500" y="592" class="box-text">Per-user document trimming</text>
+  <rect x="687" y="545" width="213" height="62" rx="12" fill="#ffffff" stroke="#dfaa57"/>
+  <text x="739" y="571" class="box-title">Model deployments</text>
+  <text x="723" y="592" class="box-text">Responses and grounding</text>
+  <rect x="474" y="628" width="190" height="70" rx="12" fill="#ffffff" stroke="#dfaa57"/>
+  <text x="536" y="655" class="box-title">Storage</text>
+  <text x="505" y="678" class="box-text">Documents and artifacts</text>
+  <rect x="687" y="628" width="213" height="70" rx="12" fill="#ffffff" stroke="#dfaa57"/>
+  <text x="747" y="655" class="box-title">Conversation state</text>
+  <text x="708" y="678" class="box-text">Foundry managed; no panel-only DB</text>
+
+  <path class="data-arrow" d="M1090 318 C1090 470, 800 470, 620 544"/>
+  <path class="data-arrow" d="M522 297 C522 430, 540 475, 569 543"/>
+
+  <rect x="950" y="493" width="284" height="238" rx="20" fill="#eef8f2" stroke="#68ad82" stroke-width="2"/>
+  <text x="974" y="523" class="zone-title">Platform support</text>
+  <rect x="974" y="545" width="236" height="62" rx="12" fill="#ffffff" stroke="#68ad82"/>
+  <text x="1024" y="571" class="box-title">Container Registry</text>
+  <text x="1001" y="592" class="box-text">Immutable service image digests</text>
+  <rect x="974" y="628" width="236" height="70" rx="12" fill="#ffffff" stroke="#68ad82"/>
+  <text x="1018" y="655" class="box-title">Application Insights</text>
+  <text x="1028" y="678" class="box-text">Logs and diagnostics</text>
+
+  <rect x="46" y="757" width="1188" height="40" rx="12" fill="#fde7e9" stroke="#d13438"/>
+  <text x="68" y="782" class="status">Administrative panel is absent in hosted/no-panel and DEPLOY_ADMINISTRATIVE_PANEL remains false. Hosted/panel stays blocked by issue #611.</text>
 </svg>

--- a/docs/media/architecture_chat_runtime_modes.excalidraw
+++ b/docs/media/architecture_chat_runtime_modes.excalidraw
@@ -1,0 +1,974 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "github-copilot",
+  "elements": [
+    {
+      "type": "text",
+      "id": "title-text",
+      "x": 50,
+      "y": 30,
+      "width": 780,
+      "height": 75,
+      "text": "Chat runtime modes and hosted deployment lifecycle",
+      "fontSize": 28,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "text",
+      "id": "subtitle-text",
+      "x": 50,
+      "y": 70,
+      "width": 1250,
+      "height": 40,
+      "text": "A deployment chooses one runtime. Identity, authorization, conversation, and cost semantics never change silently during a request.",
+      "fontSize": 15,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "rectangle",
+      "id": "status-box",
+      "x": 50,
+      "y": 105,
+      "width": 1300,
+      "height": 48,
+      "strokeColor": "#F7630C",
+      "backgroundColor": "#FFF4CE",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "status-text",
+      "x": 72,
+      "y": 117,
+      "width": 1250,
+      "height": 60,
+      "text": "Target contract: UI #93 is merged; platform #617 is not merged; new component and umbrella releases are still required before this is the supported default.",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "rectangle",
+      "id": "shared-container",
+      "x": 50,
+      "y": 175,
+      "width": 1300,
+      "height": 120,
+      "strokeColor": "#0078D4",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "shared-title",
+      "x": 75,
+      "y": 188,
+      "width": 420,
+      "height": 50,
+      "text": "Shared entry and topology selection",
+      "fontSize": 18,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "rectangle",
+      "id": "user-box",
+      "x": 82,
+      "y": 230,
+      "width": 170,
+      "height": 46,
+      "strokeColor": "#0078D4",
+      "backgroundColor": "#CFE4FA",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "user-text",
+      "x": 105,
+      "y": 240,
+      "width": 130,
+      "height": 40,
+      "text": "Signed-in user",
+      "fontSize": 14,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "ui-box",
+      "x": 302,
+      "y": 230,
+      "width": 220,
+      "height": 46,
+      "strokeColor": "#0078D4",
+      "backgroundColor": "#CFE4FA",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "ui-text",
+      "x": 326,
+      "y": 240,
+      "width": 175,
+      "height": 40,
+      "text": "Web UI - Container Apps",
+      "fontSize": 14,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "selector-box",
+      "x": 572,
+      "y": 220,
+      "width": 350,
+      "height": 66,
+      "strokeColor": "#0078D4",
+      "backgroundColor": "#CFE4FA",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "selector-text",
+      "x": 594,
+      "y": 230,
+      "width": 306,
+      "height": 70,
+      "text": "Resolved deployment topology\nfresh: hosted-no-panel | explicit/sticky: classic",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "ingestion-box",
+      "x": 972,
+      "y": 230,
+      "width": 330,
+      "height": 46,
+      "strokeColor": "#0078D4",
+      "backgroundColor": "#CFE4FA",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "ingestion-text",
+      "x": 996,
+      "y": 240,
+      "width": 280,
+      "height": 40,
+      "text": "Ingestion remains in Container Apps",
+      "fontSize": 14,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "arrow",
+      "id": "user-ui-arrow",
+      "x": 252,
+      "y": 253,
+      "width": 47,
+      "height": 0,
+      "strokeColor": "#0078D4",
+      "strokeWidth": 2,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          47,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "arrow",
+      "id": "ui-selector-arrow",
+      "x": 522,
+      "y": 253,
+      "width": 47,
+      "height": 0,
+      "strokeColor": "#0078D4",
+      "strokeWidth": 2,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          47,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "rectangle",
+      "id": "hosted-container",
+      "x": 50,
+      "y": 320,
+      "width": 840,
+      "height": 390,
+      "strokeColor": "#107C10",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 3,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "hosted-title",
+      "x": 76,
+      "y": 335,
+      "width": 700,
+      "height": 50,
+      "text": "Hosted/no-panel - target default for fresh deployments",
+      "fontSize": 18,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "text",
+      "id": "hosted-contract",
+      "x": 76,
+      "y": 365,
+      "width": 760,
+      "height": 40,
+      "text": "DEPLOYMENT_TOPOLOGY=hosted-no-panel | CHAT_BACKEND=hosted_agent | DEPLOY_ADMINISTRATIVE_PANEL=false",
+      "fontSize": 12,
+      "fontFamily": 3,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "rectangle",
+      "id": "obo-box",
+      "x": 82,
+      "y": 410,
+      "width": 204,
+      "height": 86,
+      "strokeColor": "#107C10",
+      "backgroundColor": "#DFF6DD",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "obo-text",
+      "x": 98,
+      "y": 422,
+      "width": 170,
+      "height": 100,
+      "text": "UI OBO exchange\nSigned-in user token\nto delegated data-plane token",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "foundry-box",
+      "x": 342,
+      "y": 410,
+      "width": 220,
+      "height": 86,
+      "strokeColor": "#107C10",
+      "backgroundColor": "#DFF6DD",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "foundry-text",
+      "x": 362,
+      "y": 422,
+      "width": 180,
+      "height": 100,
+      "text": "Foundry Hosted Agent\nResponses / Invocations\nManaged Conversations",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "toolbox-box",
+      "x": 618,
+      "y": 410,
+      "width": 224,
+      "height": 86,
+      "strokeColor": "#5C2D91",
+      "backgroundColor": "#E8DAEF",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "toolbox-text",
+      "x": 638,
+      "y": 422,
+      "width": 184,
+      "height": 100,
+      "text": "Toolbox / MCP tools\nOpaque Foundry call context\nNo bearer token in payload",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "arrow",
+      "id": "obo-foundry-arrow",
+      "x": 286,
+      "y": 453,
+      "width": 53,
+      "height": 0,
+      "strokeColor": "#107C10",
+      "strokeWidth": 3,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          53,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "text",
+      "id": "delegated-label",
+      "x": 284,
+      "y": 427,
+      "width": 70,
+      "height": 35,
+      "text": "delegated\nbearer",
+      "fontSize": 10,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "arrow",
+      "id": "foundry-toolbox-arrow",
+      "x": 562,
+      "y": 453,
+      "width": 53,
+      "height": 0,
+      "strokeColor": "#107C10",
+      "strokeWidth": 3,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          53,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "text",
+      "id": "context-label",
+      "x": 552,
+      "y": 427,
+      "width": 76,
+      "height": 35,
+      "text": "opaque\ncall context",
+      "fontSize": 10,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "rectangle",
+      "id": "retrieval-box",
+      "x": 180,
+      "y": 548,
+      "width": 570,
+      "height": 118,
+      "strokeColor": "#D97706",
+      "backgroundColor": "#FFF4CE",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "retrieval-text",
+      "x": 205,
+      "y": 565,
+      "width": 520,
+      "height": 130,
+      "text": "Authorization-trimmed retrieval\nToolbox resolves opaque call context to delegated user identity.\nFoundry IQ / Azure AI Search enforce native document access.\nMissing or malformed context fails closed before retrieval.",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "arrow",
+      "id": "toolbox-retrieval-arrow",
+      "x": 730,
+      "y": 496,
+      "width": 80,
+      "height": 49,
+      "strokeColor": "#D97706",
+      "strokeWidth": 3,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -80,
+          49
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "rectangle",
+      "id": "hosted-note-box",
+      "x": 76,
+      "y": 675,
+      "width": 788,
+      "height": 24,
+      "strokeColor": "#D13438",
+      "backgroundColor": "#FDE7E9",
+      "fillStyle": "solid",
+      "strokeWidth": 1,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "hosted-note-text",
+      "x": 92,
+      "y": 678,
+      "width": 756,
+      "height": 30,
+      "text": "No orchestrator Container App and no panel-only Cosmos DB. Hosted failure is terminal; rollback is an explicit deployment.",
+      "fontSize": 11,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "classic-container",
+      "x": 920,
+      "y": 320,
+      "width": 430,
+      "height": 390,
+      "strokeColor": "#605E5C",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 3,
+      "strokeStyle": "dashed",
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "classic-title",
+      "x": 946,
+      "y": 335,
+      "width": 350,
+      "height": 50,
+      "text": "Explicit Container Apps fallback",
+      "fontSize": 18,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "text",
+      "id": "classic-contract",
+      "x": 946,
+      "y": 365,
+      "width": 360,
+      "height": 55,
+      "text": "DEPLOYMENT_TOPOLOGY=classic\nCHAT_BACKEND=orchestrator",
+      "fontSize": 12,
+      "fontFamily": 3,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "rectangle",
+      "id": "orchestrator-box",
+      "x": 974,
+      "y": 410,
+      "width": 322,
+      "height": 86,
+      "strokeColor": "#605E5C",
+      "backgroundColor": "#F3F2F1",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "orchestrator-text",
+      "x": 996,
+      "y": 422,
+      "width": 278,
+      "height": 100,
+      "text": "Orchestrator Container App\nSupported classic runtime\nSelected before provision/deploy",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "classic-retrieval-box",
+      "x": 974,
+      "y": 548,
+      "width": 322,
+      "height": 118,
+      "strokeColor": "#605E5C",
+      "backgroundColor": "#F3F2F1",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "classic-retrieval-text",
+      "x": 994,
+      "y": 565,
+      "width": 282,
+      "height": 130,
+      "text": "Classic authorized retrieval\nExisting classic deployments stay sticky.\nFallback preserves classic history/panel data.\nMigration and rollback are operator actions.",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "arrow",
+      "id": "classic-retrieval-arrow",
+      "x": 1135,
+      "y": 496,
+      "width": 0,
+      "height": 49,
+      "strokeColor": "#605E5C",
+      "strokeWidth": 3,
+      "strokeStyle": "dashed",
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          0,
+          49
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "rectangle",
+      "id": "no-fallback-box",
+      "x": 893,
+      "y": 446,
+      "width": 16,
+      "height": 96,
+      "strokeColor": "#D13438",
+      "backgroundColor": "#FDE7E9",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "no-fallback-text",
+      "x": 852,
+      "y": 548,
+      "width": 100,
+      "height": 55,
+      "text": "NO REQUEST-TIME\nSILENT FALLBACK",
+      "fontSize": 11,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "rectangle",
+      "id": "build-container",
+      "x": 50,
+      "y": 735,
+      "width": 1300,
+      "height": 235,
+      "strokeColor": "#D97706",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 3,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "build-title",
+      "x": 76,
+      "y": 750,
+      "width": 700,
+      "height": 50,
+      "text": "Two-phase hosted image preparation and deployment",
+      "fontSize": 18,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "text",
+      "id": "build-subtitle",
+      "x": 76,
+      "y": 780,
+      "width": 1180,
+      "height": 40,
+      "text": "Build activity happens between two provision operations; request processing never triggers an image build or topology switch.",
+      "fontSize": 12,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    },
+    {
+      "type": "rectangle",
+      "id": "provision-one-box",
+      "x": 78,
+      "y": 835,
+      "width": 170,
+      "height": 78,
+      "strokeColor": "#D97706",
+      "backgroundColor": "#FFF4CE",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "provision-one-text",
+      "x": 94,
+      "y": 850,
+      "width": 138,
+      "height": 75,
+      "text": "1. azd provision\nPrepare prerequisites",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "prepare-image-box",
+      "x": 294,
+      "y": 823,
+      "width": 280,
+      "height": 102,
+      "strokeColor": "#D97706",
+      "backgroundColor": "#FFF4CE",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "prepare-image-text",
+      "x": 314,
+      "y": 835,
+      "width": 240,
+      "height": 125,
+      "text": "2. Prepare hosted image\nPublic: shared ACR Tasks\nPrivate: dedicated VNet agent pool\nPinned source + hosted entrypoint",
+      "fontSize": 12,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "digest-box",
+      "x": 620,
+      "y": 835,
+      "width": 180,
+      "height": 78,
+      "strokeColor": "#D97706",
+      "backgroundColor": "#FFF4CE",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "digest-text",
+      "x": 638,
+      "y": 850,
+      "width": 144,
+      "height": 75,
+      "text": "Immutable digest\nsha256:<64 hex>",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "provision-two-box",
+      "x": 846,
+      "y": 835,
+      "width": 174,
+      "height": 78,
+      "strokeColor": "#D97706",
+      "backgroundColor": "#FFF4CE",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "provision-two-text",
+      "x": 862,
+      "y": 850,
+      "width": 142,
+      "height": 75,
+      "text": "3. azd provision\nMaterialize handoff",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "rectangle",
+      "id": "deploy-box",
+      "x": 1066,
+      "y": 835,
+      "width": 250,
+      "height": 78,
+      "strokeColor": "#107C10",
+      "backgroundColor": "#DFF6DD",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "roundness": {
+        "type": 3
+      }
+    },
+    {
+      "type": "text",
+      "id": "deploy-text",
+      "x": 1086,
+      "y": 850,
+      "width": 210,
+      "height": 75,
+      "text": "4. azd deploy\nDigest-backed hosted agent",
+      "fontSize": 13,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "center",
+      "verticalAlign": "middle"
+    },
+    {
+      "type": "arrow",
+      "id": "build-arrow-one",
+      "x": 248,
+      "y": 874,
+      "width": 43,
+      "height": 0,
+      "strokeColor": "#D97706",
+      "strokeWidth": 3,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          43,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "arrow",
+      "id": "build-arrow-two",
+      "x": 574,
+      "y": 874,
+      "width": 43,
+      "height": 0,
+      "strokeColor": "#D97706",
+      "strokeWidth": 3,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          43,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "arrow",
+      "id": "build-arrow-three",
+      "x": 800,
+      "y": 874,
+      "width": 43,
+      "height": 0,
+      "strokeColor": "#D97706",
+      "strokeWidth": 3,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          43,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "arrow",
+      "id": "build-arrow-four",
+      "x": 1020,
+      "y": 874,
+      "width": 43,
+      "height": 0,
+      "strokeColor": "#D97706",
+      "strokeWidth": 3,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          43,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow"
+    },
+    {
+      "type": "text",
+      "id": "panel-note",
+      "x": 76,
+      "y": 938,
+      "width": 1170,
+      "height": 35,
+      "text": "Hosted/panel is not a supported mode: issue #611 remains open and DEPLOY_ADMINISTRATIVE_PANEL stays false.",
+      "fontSize": 11,
+      "fontFamily": 2,
+      "strokeColor": "#000000",
+      "textAlign": "left",
+      "verticalAlign": "top"
+    }
+  ],
+  "appState": {
+    "viewBackgroundColor": "#f7faff",
+    "gridSize": 20
+  },
+  "files": {}
+}

--- a/docs/media/architecture_chat_runtime_modes.svg
+++ b/docs/media/architecture_chat_runtime_modes.svg
@@ -1,0 +1,136 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1000" viewBox="0 0 1400 1000" role="img" aria-labelledby="title desc">
+  <title id="title">GPT-RAG chat runtime modes and hosted image preparation</title>
+  <desc id="desc">Comparison of the target hosted-no-panel default for fresh deployments and the explicit Container Apps fallback. The hosted path exchanges the signed-in user token on behalf of the user, calls the Foundry hosted agent with a delegated token, passes only opaque Foundry call context to Toolbox, and returns authorization-trimmed retrieval. Runtime failures do not silently switch modes. A separate two-phase deployment flow builds through public ACR Tasks or a dedicated private VNet agent pool, resolves an immutable digest, and then deploys the hosted handoff.</desc>
+  <defs>
+    <marker id="arrow-blue" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#385a8d"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#107c10"/>
+    </marker>
+    <marker id="arrow-orange" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#d97706"/>
+    </marker>
+    <style>
+      .title { font: 700 29px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .subtitle { font: 400 15px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .section-title { font: 700 18px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .box-title { font: 700 14px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .box-text { font: 400 12px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .small { font: 600 11px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .status { font: 600 12px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .blue-arrow { stroke: #385a8d; stroke-width: 2.4; fill: none; marker-end: url(#arrow-blue); }
+      .green-arrow { stroke: #107c10; stroke-width: 2.6; fill: none; marker-end: url(#arrow-green); }
+      .orange-arrow { stroke: #d97706; stroke-width: 2.4; fill: none; marker-end: url(#arrow-orange); }
+      .fallback-arrow { stroke: #605e5c; stroke-width: 2.3; stroke-dasharray: 8 5; fill: none; marker-end: url(#arrow-blue); }
+    </style>
+  </defs>
+
+  <rect width="1400" height="1000" fill="#f7faff"/>
+  <text x="50" y="48" class="title">Chat runtime modes and hosted deployment lifecycle</text>
+  <text x="50" y="75" class="subtitle">A deployment chooses one runtime. Identity, authorization, conversation, and cost semantics never change silently during a request.</text>
+
+  <rect x="50" y="94" width="1300" height="44" rx="12" fill="#fff4ce" stroke="#f7630c" stroke-width="1.5"/>
+  <text x="72" y="121" class="status">Target contract: UI #93 is merged; platform #617 is not merged; new component and umbrella releases are still required before this is the supported default.</text>
+
+  <rect x="50" y="162" width="1300" height="108" rx="20" fill="#edf7ff" stroke="#3f7dc7" stroke-width="2"/>
+  <text x="74" y="191" class="section-title">Shared entry and topology selection</text>
+  <rect x="82" y="208" width="170" height="44" rx="11" fill="#ffffff" stroke="#4d89d8"/>
+  <text x="116" y="235" class="box-title">Signed-in user</text>
+  <rect x="302" y="208" width="220" height="44" rx="11" fill="#ffffff" stroke="#4d89d8"/>
+  <text x="351" y="235" class="box-title">Web UI - Container Apps</text>
+  <rect x="572" y="199" width="350" height="62" rx="12" fill="#ffffff" stroke="#4d89d8"/>
+  <text x="610" y="224" class="box-title">Resolved deployment topology</text>
+  <text x="601" y="245" class="box-text">fresh: hosted-no-panel | explicit/sticky: classic</text>
+  <rect x="972" y="208" width="330" height="44" rx="11" fill="#ffffff" stroke="#4d89d8"/>
+  <text x="1013" y="235" class="box-title">Ingestion remains in Container Apps</text>
+  <path class="blue-arrow" d="M252 230 L299 230"/>
+  <path class="blue-arrow" d="M522 230 L569 230"/>
+
+  <rect x="50" y="295" width="840" height="390" rx="22" fill="#eef8f2" stroke="#107c10" stroke-width="2.5"/>
+  <text x="76" y="328" class="section-title">Hosted/no-panel - target default for fresh deployments</text>
+  <text x="76" y="351" class="box-text">DEPLOYMENT_TOPOLOGY=hosted-no-panel | CHAT_BACKEND=hosted_agent | DEPLOY_ADMINISTRATIVE_PANEL=false</text>
+
+  <rect x="82" y="382" width="204" height="82" rx="14" fill="#ffffff" stroke="#68ad82"/>
+  <text x="111" y="409" class="box-title">UI OBO exchange</text>
+  <text x="102" y="431" class="box-text">Signed-in user token</text>
+  <text x="98" y="451" class="box-text">to delegated data-plane token</text>
+
+  <rect x="342" y="382" width="220" height="82" rx="14" fill="#dff6dd" stroke="#107c10" stroke-width="2"/>
+  <text x="375" y="409" class="box-title">Foundry Hosted Agent</text>
+  <text x="371" y="431" class="box-text">Responses / Invocations</text>
+  <text x="372" y="451" class="box-text">Managed Conversations</text>
+
+  <rect x="618" y="382" width="224" height="82" rx="14" fill="#e8daef" stroke="#5c2d91" stroke-width="2"/>
+  <text x="655" y="409" class="box-title">Toolbox / MCP tools</text>
+  <text x="641" y="431" class="box-text">Receives opaque Foundry</text>
+  <text x="646" y="451" class="box-text">call context, not tokens</text>
+
+  <path class="green-arrow" d="M286 423 L339 423"/>
+  <text x="292" y="407" class="small">delegated bearer</text>
+  <path class="green-arrow" d="M562 423 L615 423"/>
+  <text x="568" y="407" class="small">x-agent-foundry-call-id</text>
+
+  <rect x="180" y="516" width="570" height="112" rx="16" fill="#fff7ec" stroke="#dfaa57" stroke-width="2"/>
+  <text x="314" y="546" class="box-title">Authorization-trimmed retrieval</text>
+  <text x="213" y="570" class="box-text">Toolbox resolves the opaque call context to the delegated user identity.</text>
+  <text x="220" y="592" class="box-text">Foundry IQ / Azure AI Search enforce native per-user document access.</text>
+  <text x="264" y="614" class="box-text">Missing or malformed context fails closed before retrieval.</text>
+  <path class="orange-arrow" d="M730 464 C730 490, 690 501, 650 514"/>
+
+  <rect x="76" y="648" width="788" height="24" rx="10" fill="#fde7e9" stroke="#d13438"/>
+  <text x="98" y="665" class="small">No orchestrator Container App and no panel-only Cosmos DB. Hosted failure is terminal; rollback is an explicit deployment.</text>
+
+  <rect x="920" y="295" width="430" height="390" rx="22" fill="#f3f2f1" stroke="#605e5c" stroke-width="2.5" stroke-dasharray="9 6"/>
+  <text x="946" y="328" class="section-title">Explicit Container Apps fallback</text>
+  <text x="946" y="351" class="box-text">DEPLOYMENT_TOPOLOGY=classic | CHAT_BACKEND=orchestrator</text>
+  <rect x="974" y="382" width="322" height="82" rx="14" fill="#ffffff" stroke="#605e5c"/>
+  <text x="1031" y="409" class="box-title">Orchestrator Container App</text>
+  <text x="1036" y="431" class="box-text">Supported classic runtime</text>
+  <text x="1009" y="451" class="box-text">Selected before provision/deploy</text>
+  <rect x="974" y="516" width="322" height="112" rx="16" fill="#ffffff" stroke="#605e5c"/>
+  <text x="1020" y="545" class="box-title">Classic authorized retrieval</text>
+  <text x="1002" y="570" class="box-text">Existing classic deployments stay sticky.</text>
+  <text x="1000" y="592" class="box-text">Fallback preserves classic history/panel data.</text>
+  <text x="1002" y="614" class="box-text">Migration and rollback are operator actions.</text>
+  <path class="fallback-arrow" d="M1135 464 L1135 513"/>
+
+  <rect x="877" y="446" width="30" height="88" rx="8" fill="#fde7e9" stroke="#d13438" stroke-width="2"/>
+  <line x1="884" y1="455" x2="900" y2="525" stroke="#d13438" stroke-width="3"/>
+  <line x1="900" y1="455" x2="884" y2="525" stroke="#d13438" stroke-width="3"/>
+  <text x="846" y="552" class="small" transform="rotate(-90 846 552)">NO SILENT FALLBACK</text>
+
+  <rect x="50" y="714" width="1300" height="236" rx="22" fill="#fff7ec" stroke="#d97706" stroke-width="2.5"/>
+  <text x="76" y="747" class="section-title">Two-phase hosted image preparation and deployment</text>
+  <text x="76" y="770" class="box-text">Build activity happens between two provision operations; request processing never triggers an image build or topology switch.</text>
+
+  <rect x="78" y="808" width="170" height="76" rx="13" fill="#ffffff" stroke="#dfaa57"/>
+  <text x="108" y="837" class="box-title">1. azd provision</text>
+  <text x="96" y="860" class="box-text">Prepare prerequisites</text>
+
+  <rect x="294" y="795" width="280" height="102" rx="13" fill="#fff4ce" stroke="#d97706" stroke-width="2"/>
+  <text x="339" y="824" class="box-title">2. Prepare hosted image</text>
+  <text x="321" y="847" class="box-text">Public: shared ACR Tasks</text>
+  <text x="315" y="869" class="box-text">Private: dedicated VNet agent pool</text>
+  <text x="326" y="889" class="small">Pinned source + hosted entrypoint</text>
+
+  <rect x="620" y="808" width="180" height="76" rx="13" fill="#ffffff" stroke="#dfaa57"/>
+  <text x="648" y="837" class="box-title">Immutable digest</text>
+  <text x="645" y="860" class="box-text">sha256:&lt;64 hex&gt;</text>
+
+  <rect x="846" y="808" width="174" height="76" rx="13" fill="#ffffff" stroke="#dfaa57"/>
+  <text x="872" y="837" class="box-title">3. azd provision</text>
+  <text x="868" y="860" class="box-text">Materialize handoff</text>
+
+  <rect x="1066" y="808" width="250" height="76" rx="13" fill="#dff6dd" stroke="#107c10" stroke-width="2"/>
+  <text x="1125" y="837" class="box-title">4. azd deploy</text>
+  <text x="1094" y="860" class="box-text">Deploy digest-backed hosted agent</text>
+
+  <path class="orange-arrow" d="M248 846 L291 846"/>
+  <path class="orange-arrow" d="M574 846 L617 846"/>
+  <path class="orange-arrow" d="M800 846 L843 846"/>
+  <path class="orange-arrow" d="M1020 846 L1063 846"/>
+
+  <rect x="50" y="968" width="1300" height="20" rx="9" fill="#ffffff" stroke="#d8e3f5"/>
+  <text x="72" y="982" class="small">Hosted/panel is not shown as a supported mode: issue #611 remains open and DEPLOY_ADMINISTRATIVE_PANEL stays false.</text>
+</svg>

--- a/docs/media/architecture_modular_layers.svg
+++ b/docs/media/architecture_modular_layers.svg
@@ -1,137 +1,132 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="1160" viewBox="0 0 1100 1160" role="img" aria-labelledby="title desc">
-  <title id="title">GPT-RAG Basic and Zero Trust deployment layers</title>
-  <desc id="desc">Comparison of standard Basic deployment resources, common platform resources, Zero Trust private networking additions, default-on configurable resources, and opt-in add-ons.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="1220" viewBox="0 0 1100 1220" role="img" aria-labelledby="title desc">
+  <title id="title">GPT-RAG modular deployment layers with mode-selected chat runtime</title>
+  <desc id="desc">Modular architecture layers showing the target fresh-deployment baseline after release gates. Web UI and ingestion run in Container Apps. The mode-selected chat runtime uses Microsoft Foundry hosted agent for fresh deployments and an orchestrator Container App only as an explicit fallback. Hosted runtime is part of the baseline, not an optional AI capability. Zero Trust and scenario add-ons remain separate layers.</desc>
   <defs>
     <style>
-      .title { font: 700 30px 'Segoe UI', Arial, sans-serif; fill: #14345f; }
-      .subtitle { font: 400 17px 'Segoe UI', Arial, sans-serif; fill: #4c607a; }
-      .section-title { font: 700 22px 'Segoe UI', Arial, sans-serif; fill: #14345f; }
-      .section-text { font: 400 15px 'Segoe UI', Arial, sans-serif; fill: #485a72; }
-      .label { font: 700 15px 'Segoe UI', Arial, sans-serif; fill: #ffffff; }
-      .chip { font: 700 13px 'Segoe UI', Arial, sans-serif; }
-      .card-title { font: 700 15px 'Segoe UI', Arial, sans-serif; fill: #14345f; }
-      .legend { font: 600 13px 'Segoe UI', Arial, sans-serif; fill: #33465f; }
-      .note { font: 600 12px 'Segoe UI', Arial, sans-serif; fill: #5b4a23; }
+      .title { font: 700 29px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .subtitle { font: 400 16px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .section-title { font: 700 21px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .section-text { font: 400 14px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .label { font: 700 14px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .chip { font: 700 12px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .card-title { font: 700 14px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .legend { font: 600 12px 'Segoe UI', Arial, sans-serif; fill: #000000; }
+      .note { font: 600 11px 'Segoe UI', Arial, sans-serif; fill: #000000; }
     </style>
   </defs>
 
-  <rect width="1100" height="1160" fill="#f7faff"/>
-  <text x="48" y="58" class="title">Basic vs Zero Trust deployment layers</text>
-  <text x="48" y="88" class="subtitle">Basic deploys the standard RAG runtime; Zero Trust adds private networking and controlled access paths.</text>
+  <rect width="1100" height="1220" fill="#f7faff"/>
+  <text x="48" y="52" class="title">Basic, Zero Trust, and scenario layers</text>
+  <text x="48" y="80" class="subtitle">The chat runtime is mode-selected inside the baseline: hosted for fresh deployments after release gates, Container Apps as explicit fallback.</text>
 
-  <rect x="50" y="116" width="22" height="16" rx="4" fill="#3f7dc7"/>
-  <text x="84" y="130" class="legend">Basic baseline</text>
-  <rect x="230" y="116" width="22" height="16" rx="4" fill="#4a9f6f"/>
-  <text x="264" y="130" class="legend">Common platform</text>
-  <rect x="426" y="116" width="22" height="16" rx="4" fill="#7b5fc7"/>
-  <text x="460" y="130" class="legend">Zero Trust additions</text>
-  <rect x="660" y="113" width="28" height="20" rx="6" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="700" y="130" class="legend">Default-on / BYO configurable</text>
-  <rect x="910" y="113" width="28" height="20" rx="6" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
-  <text x="950" y="130" class="legend">Opt-in add-on</text>
+  <rect x="48" y="101" width="1004" height="42" rx="12" fill="#fff4ce" stroke="#f7630c" stroke-width="1.5"/>
+  <text x="68" y="127" class="note">Target architecture only: platform PR #617 and required component / umbrella releases must publish before hosted becomes the supported default.</text>
 
-  <rect x="60" y="158" width="980" height="356" rx="22" fill="#eaf3ff" stroke="#3f7dc7" stroke-width="2.5"/>
-  <rect x="86" y="184" width="136" height="34" rx="17" fill="#3f7dc7"/>
-  <text x="122" y="207" class="label">Basic</text>
-  <text x="250" y="207" class="section-title">Basic deployment</text>
-  <text x="250" y="236" class="section-text">Default public deployment for the standard GPT-RAG evaluation and runtime path.</text>
+  <rect x="50" y="161" width="22" height="16" rx="4" fill="#3f7dc7"/>
+  <text x="84" y="174" class="legend">Basic baseline</text>
+  <rect x="230" y="161" width="22" height="16" rx="4" fill="#4a9f6f"/>
+  <text x="264" y="174" class="legend">Common platform</text>
+  <rect x="426" y="161" width="22" height="16" rx="4" fill="#7b5fc7"/>
+  <text x="460" y="174" class="legend">Zero Trust additions</text>
+  <rect x="660" y="158" width="28" height="20" rx="6" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="700" y="174" class="legend">Default-on / BYO configurable</text>
+  <rect x="910" y="158" width="28" height="20" rx="6" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
+  <text x="950" y="174" class="legend">Opt-in add-on</text>
 
-  <rect x="90" y="260" width="360" height="82" rx="16" fill="#ffffff" stroke="#9ebff0"/>
-  <text x="114" y="286" class="card-title">Runtime apps</text>
-  <rect x="114" y="300" width="86" height="30" rx="10" fill="#f8fbff" stroke="#87aee7"/>
-  <text x="132" y="320" class="chip" fill="#14345f">Frontend</text>
-  <rect x="214" y="300" width="116" height="30" rx="10" fill="#f8fbff" stroke="#87aee7"/>
-  <text x="234" y="320" class="chip" fill="#14345f">Orchestrator</text>
-  <rect x="344" y="300" width="94" height="30" rx="10" fill="#f8fbff" stroke="#87aee7"/>
-  <text x="362" y="320" class="chip" fill="#14345f">Ingestion</text>
+  <rect x="60" y="201" width="980" height="390" rx="22" fill="#eaf3ff" stroke="#3f7dc7" stroke-width="2.5"/>
+  <rect x="86" y="225" width="136" height="34" rx="17" fill="#3f7dc7"/>
+  <text x="122" y="248" class="label">Basic</text>
+  <text x="250" y="248" class="section-title">Basic deployment baseline</text>
+  <text x="250" y="275" class="section-text">UI and ingestion stay in Container Apps; one explicit topology selects the chat runtime.</text>
 
-  <rect x="470" y="260" width="540" height="82" rx="16" fill="#ffffff" stroke="#9ebff0"/>
-  <text x="494" y="286" class="card-title">RAG workload data path</text>
-  <rect x="494" y="300" width="116" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="513" y="320" class="chip" fill="#7a4300">RAG AI Search</text>
-  <rect x="624" y="300" width="112" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="644" y="320" class="chip" fill="#7a4300">RAG Storage</text>
-  <rect x="750" y="300" width="126" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="768" y="320" class="chip" fill="#7a4300">App Cosmos DB</text>
+  <rect x="90" y="298" width="920" height="124" rx="16" fill="#ffffff" stroke="#9ebff0"/>
+  <text x="114" y="323" class="card-title">Runtime apps and selected chat runtime</text>
+  <rect x="114" y="340" width="142" height="58" rx="11" fill="#f8fbff" stroke="#87aee7"/>
+  <text x="146" y="364" class="chip">Web UI</text>
+  <text x="127" y="384" class="note">Container Apps</text>
+  <rect x="277" y="332" width="278" height="74" rx="12" fill="#dff6dd" stroke="#107c10" stroke-width="2"/>
+  <text x="312" y="357" class="chip">Microsoft Foundry Hosted Agent</text>
+  <text x="315" y="378" class="note">Fresh target default after release gates</text>
+  <text x="330" y="397" class="note">Hosted/no-panel; no silent fallback</text>
+  <rect x="576" y="332" width="260" height="74" rx="12" fill="#f3f2f1" stroke="#605e5c" stroke-width="2" stroke-dasharray="7 5"/>
+  <text x="612" y="357" class="chip">Container Apps orchestrator</text>
+  <text x="621" y="378" class="note">Explicit fallback / sticky upgrade</text>
+  <text x="638" y="397" class="note">Selected by deployment operation</text>
+  <rect x="857" y="340" width="129" height="58" rx="11" fill="#f8fbff" stroke="#87aee7"/>
+  <text x="885" y="364" class="chip">Ingestion</text>
+  <text x="869" y="384" class="note">Container Apps</text>
 
-  <rect x="90" y="364" width="920" height="112" rx="16" fill="#ffffff" stroke="#9ebff0"/>
-  <text x="114" y="390" class="card-title">AI Foundry and associated resources</text>
-  <rect x="114" y="404" width="150" height="30" rx="10" fill="#f8fbff" stroke="#87aee7"/>
-  <text x="132" y="424" class="chip" fill="#14345f">AI Foundry account</text>
-  <rect x="278" y="404" width="106" height="30" rx="10" fill="#f8fbff" stroke="#87aee7"/>
-  <text x="298" y="424" class="chip" fill="#14345f">AI Project</text>
-  <rect x="398" y="404" width="140" height="30" rx="10" fill="#f8fbff" stroke="#87aee7"/>
-  <text x="416" y="424" class="chip" fill="#14345f">Model deployments</text>
-  <rect x="552" y="404" width="154" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="570" y="424" class="chip" fill="#7a4300">Foundry Storage</text>
-  <rect x="720" y="404" width="148" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="738" y="424" class="chip" fill="#7a4300">Foundry Search</text>
-  <rect x="114" y="442" width="164" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="132" y="462" class="chip" fill="#7a4300">Foundry Cosmos DB</text>
-  <rect x="292" y="442" width="152" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="310" y="462" class="chip" fill="#7a4300">Foundry Key Vault</text>
+  <rect x="90" y="442" width="450" height="60" rx="14" fill="#ffffff" stroke="#9ebff0"/>
+  <text x="114" y="468" class="card-title">Authorized retrieval path</text>
+  <text x="114" y="489" class="note">Toolbox / MCP + Foundry IQ / AI Search document trimming</text>
+  <rect x="560" y="442" width="450" height="60" rx="14" fill="#ffffff" stroke="#9ebff0"/>
+  <text x="584" y="468" class="card-title">RAG workload data</text>
+  <text x="584" y="489" class="note">Search, Storage, and mode-appropriate conversation state</text>
 
-  <rect x="60" y="542" width="980" height="190" rx="22" fill="#eef8f2" stroke="#4a9f6f" stroke-width="2.5"/>
-  <rect x="86" y="568" width="136" height="34" rx="17" fill="#4a9f6f"/>
-  <text x="120" y="591" class="label">Common</text>
-  <text x="250" y="591" class="section-title">Common platform services for Basic and Zero Trust</text>
-  <text x="250" y="620" class="section-text">Configuration, identity, hosting, images, secrets, and telemetry shared by both deployment modes.</text>
-  <rect x="250" y="640" width="144" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
-  <text x="268" y="660" class="chip" fill="#14345f">App Configuration</text>
-  <rect x="408" y="640" width="178" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
-  <text x="426" y="660" class="chip" fill="#14345f">Managed identity/RBAC</text>
-  <rect x="600" y="640" width="166" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
-  <text x="618" y="660" class="chip" fill="#14345f">Container Apps Env</text>
-  <rect x="780" y="640" width="128" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
-  <text x="798" y="660" class="chip" fill="#14345f">Container Apps</text>
-  <rect x="250" y="678" width="148" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
-  <text x="268" y="698" class="chip" fill="#14345f">Container Registry</text>
-  <rect x="412" y="678" width="132" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="430" y="698" class="chip" fill="#7a4300">Workload KV</text>
-  <rect x="558" y="678" width="204" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="576" y="698" class="chip" fill="#7a4300">Log Analytics + App Insights</text>
-  <rect x="776" y="678" width="154" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="794" y="698" class="chip" fill="#7a4300">BYO observability</text>
+  <rect x="90" y="522" width="920" height="46" rx="14" fill="#ffffff" stroke="#9ebff0"/>
+  <text x="114" y="550" class="card-title">AI Foundry account, project, hosted runtime, model deployments, and associated resources</text>
 
-  <rect x="60" y="760" width="980" height="210" rx="22" fill="#f3efff" stroke="#7b5fc7" stroke-width="2.5"/>
-  <rect x="86" y="786" width="136" height="34" rx="17" fill="#7b5fc7"/>
-  <text x="113" y="809" class="label">Zero Trust</text>
-  <text x="250" y="809" class="section-title">Zero Trust private networking</text>
-  <text x="250" y="838" class="section-text">Adds private service access, private DNS, internal app ingress, and controlled network paths.</text>
-  <rect x="250" y="858" width="116" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
-  <text x="268" y="878" class="chip" fill="#14345f">VNet/Subnets</text>
-  <rect x="380" y="858" width="142" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
-  <text x="398" y="878" class="chip" fill="#14345f">Private endpoints</text>
-  <rect x="536" y="858" width="118" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
-  <text x="554" y="878" class="chip" fill="#14345f">Private DNS</text>
-  <rect x="668" y="858" width="68" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
-  <text x="687" y="878" class="chip" fill="#14345f">NSGs</text>
-  <rect x="750" y="858" width="166" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
-  <text x="768" y="878" class="chip" fill="#14345f">Internal app ingress</text>
-  <rect x="250" y="896" width="118" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="268" y="916" class="chip" fill="#7a4300">Azure Firewall</text>
-  <rect x="382" y="896" width="198" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
-  <text x="400" y="916" class="chip" fill="#7a4300">Jumpbox / Bastion / NAT</text>
-  <rect x="594" y="896" width="178" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
-  <text x="612" y="916" class="chip" fill="#7a4300">Private ACR build pool</text>
-  <rect x="786" y="896" width="146" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
-  <text x="804" y="916" class="chip" fill="#7a4300">App Gateway WAF</text>
-  <rect x="250" y="934" width="188" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
-  <text x="268" y="954" class="chip" fill="#7a4300">BYO VNet / DNS zones</text>
-  <rect x="452" y="934" width="142" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
-  <text x="470" y="954" class="chip" fill="#7a4300">Hub-spoke</text>
+  <rect x="60" y="618" width="980" height="184" rx="22" fill="#eef8f2" stroke="#4a9f6f" stroke-width="2.5"/>
+  <rect x="86" y="642" width="136" height="34" rx="17" fill="#4a9f6f"/>
+  <text x="120" y="665" class="label">Common</text>
+  <text x="250" y="665" class="section-title">Common platform services</text>
+  <text x="250" y="692" class="section-text">Configuration, identity, UI/ingestion hosting, images, secrets, and telemetry shared across modes.</text>
+  <rect x="250" y="712" width="144" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
+  <text x="268" y="732" class="chip">App Configuration</text>
+  <rect x="408" y="712" width="178" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
+  <text x="426" y="732" class="chip">Managed identity / RBAC</text>
+  <rect x="600" y="712" width="166" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
+  <text x="618" y="732" class="chip">Container Apps Env</text>
+  <rect x="780" y="712" width="128" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
+  <text x="798" y="732" class="chip">Container Apps</text>
+  <rect x="250" y="752" width="148" height="30" rx="10" fill="#f7fffa" stroke="#7dbb99"/>
+  <text x="268" y="772" class="chip">Container Registry</text>
+  <rect x="412" y="752" width="132" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="430" y="772" class="chip">Workload KV</text>
+  <rect x="558" y="752" width="204" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="576" y="772" class="chip">Log Analytics + App Insights</text>
+  <rect x="776" y="752" width="154" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="794" y="772" class="chip">BYO observability</text>
 
-  <rect x="60" y="998" width="980" height="118" rx="22" fill="#fff4f0" stroke="#d66f53" stroke-width="2.5"/>
-  <rect x="86" y="1024" width="178" height="34" rx="17" fill="#d66f53"/>
-  <text x="111" y="1047" class="label">Scenario add-ons</text>
-  <text x="286" y="1040" class="section-title">Optional AI capabilities</text>
-  <rect x="286" y="1060" width="80" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
-  <text x="305" y="1080" class="chip" fill="#7a4300">Speech</text>
-  <rect x="380" y="1060" width="136" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
-  <text x="399" y="1080" class="chip" fill="#7a4300">Bing grounding</text>
-  <rect x="530" y="1060" width="146" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
-  <text x="548" y="1080" class="chip" fill="#7a4300">Agentic retrieval</text>
+  <rect x="60" y="829" width="980" height="210" rx="22" fill="#f3efff" stroke="#7b5fc7" stroke-width="2.5"/>
+  <rect x="86" y="853" width="136" height="34" rx="17" fill="#7b5fc7"/>
+  <text x="113" y="876" class="label">Zero Trust</text>
+  <text x="250" y="876" class="section-title">Zero Trust private networking</text>
+  <text x="250" y="903" class="section-text">Adds private service access, private DNS, internal app ingress, and controlled network/build paths.</text>
+  <rect x="250" y="923" width="116" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
+  <text x="268" y="943" class="chip">VNet / Subnets</text>
+  <rect x="380" y="923" width="142" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
+  <text x="398" y="943" class="chip">Private endpoints</text>
+  <rect x="536" y="923" width="118" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
+  <text x="554" y="943" class="chip">Private DNS</text>
+  <rect x="668" y="923" width="68" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
+  <text x="687" y="943" class="chip">NSGs</text>
+  <rect x="750" y="923" width="166" height="30" rx="10" fill="#fbf9ff" stroke="#a790e5"/>
+  <text x="768" y="943" class="chip">Internal app ingress</text>
+  <rect x="250" y="963" width="118" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="268" y="983" class="chip">Azure Firewall</text>
+  <rect x="382" y="963" width="198" height="30" rx="10" fill="#fffaf3" stroke="#d9822b" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="400" y="983" class="chip">Jumpbox / Bastion / NAT</text>
+  <rect x="594" y="963" width="178" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
+  <text x="612" y="983" class="chip">Private ACR build pool</text>
+  <rect x="786" y="963" width="146" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
+  <text x="804" y="983" class="chip">App Gateway WAF</text>
+  <rect x="250" y="1003" width="188" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
+  <text x="268" y="1023" class="chip">BYO VNet / DNS zones</text>
+  <rect x="452" y="1003" width="142" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
+  <text x="470" y="1023" class="chip">Hub-spoke</text>
 
-  <rect x="60" y="1130" width="980" height="20" rx="10" fill="#fff7ec" stroke="#d9822b"/>
-  <text x="82" y="1145" class="note">Dashed orange = default-on or BYO-capable parameter; solid orange = opt-in add-on. Exact parameter names are listed in the Architecture page table.</text>
+  <rect x="60" y="1067" width="980" height="104" rx="22" fill="#fff4f0" stroke="#d66f53" stroke-width="2.5"/>
+  <rect x="86" y="1091" width="178" height="34" rx="17" fill="#d66f53"/>
+  <text x="111" y="1114" class="label">Scenario add-ons</text>
+  <text x="286" y="1107" class="section-title">Optional AI capabilities</text>
+  <rect x="286" y="1127" width="80" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
+  <text x="305" y="1147" class="chip">Speech</text>
+  <rect x="380" y="1127" width="136" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
+  <text x="399" y="1147" class="chip">Bing grounding</text>
+  <rect x="530" y="1127" width="146" height="30" rx="10" fill="#ffe2bc" stroke="#d9822b" stroke-width="2"/>
+  <text x="548" y="1147" class="chip">Agentic retrieval</text>
+
+  <rect x="60" y="1185" width="980" height="23" rx="10" fill="#fff7ec" stroke="#d9822b"/>
+  <text x="78" y="1201" class="note">Hosted chat is a baseline runtime choice, not an optional capability. Dashed orange = default-on/BYO; solid orange = opt-in.</text>
 </svg>

--- a/docs/quickstart_simple_rag.md
+++ b/docs/quickstart_simple_rag.md
@@ -76,7 +76,7 @@ azd provision
   - **Microsoft Foundry** - Foundry Account and project for agent orchestration
   - **OpenAI Models** - GPT-4o and text-embedding-3-large deployments
   - **Container Registry** - Stores Docker images
-  - **Container Apps (4)** - UI, orchestrator, ingestion, MCP. The [hosted/no-panel preview](deploy.md#chat-runtime-modes-preview) uses a different chat topology and requires `DEPLOY_ADMINISTRATIVE_PANEL=false`.
+  - **Container Apps (4)** - UI, orchestrator, ingestion, MCP in the currently released classic topology. The [upcoming hosted-default topology](deploy.md#chat-runtime-modes-upcoming-hosted-default-release) keeps UI and ingestion in Container Apps, removes the orchestrator Container App from the primary chat path, and requires `DEPLOY_ADMINISTRATIVE_PANEL=false` after platform PR #617 and new releases ship.
   - **App Configuration** - Centralized configuration store
   - **Key Vault** - Secrets management
   - **Cosmos DB** - Agent state and metadata

--- a/docs/services_orchestrator.md
+++ b/docs/services_orchestrator.md
@@ -1,13 +1,23 @@
 # 🎯 Orchestrator
 
-The Orchestrator is the core engine of GPT-RAG, an agentic orchestration layer built on the Microsoft Agent Framework and Azure AI Foundry Agent Service. It coordinates agent-based RAG workflows, where each agent has a defined role, to generate accurate, context-aware responses for complex user queries. In the default Container Apps topology it runs as an orchestrator Container App. The first [hosted-agent preview](deploy.md#chat-runtime-modes-preview) packages the same chat runtime as a Microsoft Foundry hosted agent and supports hosted/no-panel only. [GitHub Repository](https://github.com/Azure/gpt-rag-orchestrator).
+The Orchestrator is the core engine of GPT-RAG, an agentic orchestration layer
+built on the Microsoft Agent Framework and Azure AI Foundry Agent Service. It
+coordinates agent-based RAG workflows, where each agent has a defined role, to
+generate accurate, context-aware responses for complex user queries. Current
+published releases run it as an orchestrator Container App. The
+[upcoming hosted-default topology](deploy.md#chat-runtime-modes-upcoming-hosted-default-release)
+packages the same chat runtime as a Microsoft Foundry hosted agent for fresh
+deployments and retains the Container Apps adapter as an explicit fallback.
+That default still depends on
+[Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617) and new
+releases; hosted/panel remains unsupported. [GitHub Repository](https://github.com/Azure/gpt-rag-orchestrator).
 
 ## Key Features
 
 - **Strategy-Based Architecture:** Pluggable orchestration strategies selected via Azure App Configuration (`AGENT_STRATEGY`).
 - **Context Retrieval:** Intelligent retrieval from Azure AI Search or Foundry IQ with citation support and conservative retrieval-needed triage for local MAF strategies.
 - **Microsoft Agent Framework:** Built on the Microsoft Agent Framework.
-- **Conversation Persistence:** The default Container Apps topology maintains conversation history in Cosmos DB. The hosted/no-panel preview uses Foundry managed Conversations for runtime state, but user-facing managed Conversation history and panel integration are deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611). Both chat paths stream responses over SSE.
+- **Conversation Persistence:** The currently released classic Container Apps topology maintains conversation history in Cosmos DB. The upcoming hosted/no-panel target uses Foundry managed Conversations for runtime state after platform PR #617 and new releases ship. User-facing managed Conversation history and panel integration are deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611). Both chat paths stream responses over SSE.
 - **Extensible Design:** Easy to add new strategies by extending `BaseAgentStrategy`.
 
 ## Available Strategies
@@ -45,7 +55,18 @@ and require a signed-in user.
 
 ## Conversation History and Retrieval Controls
 
-In the default Container Apps topology, long-running chats are handled in two places. The model prompt receives only a recent history window, while the Cosmos DB conversation document is compacted before persistence so it keeps useful recent context without growing indefinitely. The hosted/no-panel preview uses Foundry managed Conversations for runtime state. User-facing history and panel integration remain deferred to [issue #611](https://github.com/Azure/GPT-RAG/issues/611). The default `maf_lite` strategy and the `multimodal` strategy also classify each turn as a greeting, retrieval-needed question, or no-retrieval follow-up. Transformations such as "format that answer as a table" or "translate the previous answer" can skip Azure AI Search while still using the recent chat history.
+In the currently released classic Container Apps topology, long-running chats
+are handled in two places. The model prompt receives only a recent history
+window, while the Cosmos DB conversation document is compacted before
+persistence so it keeps useful recent context without growing indefinitely.
+The upcoming hosted/no-panel target uses Foundry managed Conversations for
+runtime state after platform PR #617 and new releases ship. User-facing history
+and panel integration remain deferred to
+[issue #611](https://github.com/Azure/GPT-RAG/issues/611). The default
+`maf_lite` strategy and the `multimodal` strategy also classify each turn as a
+greeting, retrieval-needed question, or no-retrieval follow-up. Transformations
+such as "format that answer as a table" or "translate the previous answer" can
+skip Azure AI Search while still using the recent chat history.
 
 | App Configuration key | Default | Purpose |
 |-----------------------|---------|---------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - NL2SQL: quickstart_nl2sql.md
   - Architecture:
     - Overview: architecture.md
+    - Legacy diagram update handoff: architecture_legacy_diagram_handoff.md
   - Governance:
     - Overview and responsibilities: governance_overview.md
     - Audit Contract v1: governance_audit_contract_v1.md


### PR DESCRIPTION
## Summary
- update the Basic and modular SVG architecture views for the approved hosted/no-panel fresh-deployment target, with Web UI and ingestion retained in Container Apps and the orchestrator shown only as the explicit fallback
- add a focused chat-runtime modes SVG plus editable Excalidraw source covering delegated user OBO, opaque Foundry call context, authorization-trimmed retrieval, no request-time silent fallback, and the two-phase ACR build-to-digest lifecycle
- update Architecture, Deployment, Home, and related published pages, add the exact manual Visio/PNG update handoff, and incorporate the latest canonical `/responses` versus `/invocations` protocol documentation from `docs`

## Release status and remaining gates
This PR documents the approved target architecture; it does **not** claim that the hosted-default release has shipped.

- Platform PR [#617](https://github.com/Azure/GPT-RAG/pull/617) merged to `develop` as `b614d0ad19a66cbc06b34a3ad764b0d94428999f`. The hosted-default topology, sticky upgrades, two-phase preparation, and explicit fallback are implemented but unreleased.
- UI release PR [Azure/gpt-rag-ui#94](https://github.com/Azure/gpt-rag-ui/pull/94) merged to `main` as `763fa7eb2135037382673d2eb968421f084941cc`, but the planned `v2.6.0` tag and GitHub Release are not published.
- AI Landing Zone release PR [#131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131) merged to `main` as `a6ae7284d654abb7ec53810cb8765b2975b51baa`, but the planned `v2.5.0` tag and GitHub Release are not published.
- Final umbrella pins, exact integrated validation, and a new GPT-RAG umbrella release remain required before hosted/no-panel is the supported fresh-deployment default.
- Hosted/panel remains blocked by [#611](https://github.com/Azure/GPT-RAG/issues/611); `DEPLOY_ADMINISTRATIVE_PANEL=false` remains required.
- Current published GPT-RAG release `v3.7.0` remains classic.

Part of #589.

## Validation
- strict MkDocs build
- SVG XML and accessibility metadata validation
- Excalidraw JSON, unique ID, positive text-dimension, black-text, transparent-container, and non-negative-dimension validation
- Markdown media-reference validation
- `git diff --check`

No Azure resources, application code, tags, releases, or published artifacts are changed.