### PR TITLE
fix(deploy): support Windows hosted builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@
 
 ### Fixed
 
+- **Windows jumpbox deployment imports the repository package reliably.**
+  `preDeploy.ps1` now establishes the repository root on `PYTHONPATH` and
+  invokes deployment modules through `runpy`, avoiding Windows Python
+  installations that omit the current directory from `sys.path`. The shell
+  hook now exports the equivalent repository-root import path.
+- **Hosted-image builds resolve the Azure CLI launcher on Windows.**
+  The ACR Tasks helper resolves both `az` and the Windows `az.cmd` shim before
+  calling `subprocess.run`, and fails clearly when Azure CLI is unavailable.
 - **Regional prerequisite checks resolve Azure CLI on Windows.**
   `util.prereqs` now uses the same explicit Azure CLI executable resolution as
   deployment configuration, so the `az.cmd` shim no longer fails with

--- a/config/deployment/hosted_image.py
+++ b/config/deployment/hosted_image.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -36,6 +37,14 @@ HOSTED_STARTUP_COMMAND_DEFAULT = (
 )
 HOSTED_PORT_DEFAULT = 8088
 DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+
+
+def resolve_azure_cli_executable() -> str:
+    """Return the executable path for Azure CLI across native platforms."""
+    executable = shutil.which("az") or shutil.which("az.cmd")
+    if not executable:
+        raise RuntimeError("Azure CLI executable was not found in PATH.")
+    return executable
 
 
 def render_hosted_dockerfile(
@@ -115,7 +124,7 @@ def resolve_pushed_digest(
     """Look up the digest that was just pushed for ``image_name:image_tag``."""
     result = subprocess.run(
         [
-            "az",
+            resolve_azure_cli_executable(),
             "acr",
             "repository",
             "show",
@@ -163,6 +172,7 @@ def build_hosted_image(
             context_dir=tmp,
             agent_pool=agent_pool,
         )
+        args[0] = resolve_azure_cli_executable()
         subprocess.run(args, check=True)
     return resolve_pushed_digest(
         registry=registry, image_name=image_name, image_tag=image_tag

--- a/scripts/preDeploy.ps1
+++ b/scripts/preDeploy.ps1
@@ -89,6 +89,17 @@ $start    = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
 $repoRoot = Find-RepoRoot $start
 if (-not $repoRoot) { Write-Error "Run this from inside a gpt-rag repo."; exit 1 }
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) { Write-Error "Git not found in PATH."; exit 1 }
+$pathSeparator = [IO.Path]::PathSeparator
+$env:PYTHONPATH = if ($env:PYTHONPATH) { "$repoRoot$pathSeparator$($env:PYTHONPATH)" } else { $repoRoot }
+$env:GPT_RAG_REPO_ROOT = $repoRoot
+
+function Invoke-PythonModule {
+  param(
+    [Parameter(Mandatory = $true)][string]$ModuleName,
+    [string[]]$Arguments = @()
+  )
+  & python -c "import os, runpy, sys; sys.path.insert(0, os.environ['GPT_RAG_REPO_ROOT']); sys.argv = ['$ModuleName'] + sys.argv[1:]; runpy.run_module('$ModuleName', run_name='__main__')" @Arguments
+}
 
 $manifestPath = Join-Path $repoRoot 'manifest.json'
 if (-not (Test-Path -LiteralPath $manifestPath)) { Write-Error "manifest.json not found at $manifestPath"; exit 1 }
@@ -183,7 +194,6 @@ if ($hostedMode) {
     Push-Location $repoRoot
     try {
       $buildArgs = @(
-        '-m', 'config.deployment.hosted_image',
         '--registry', $acrName,
         '--base-image-ref', $baseImageRef,
         '--image-name', $hostedImageName,
@@ -192,7 +202,7 @@ if ($hostedMode) {
       if ($globalEnv.ACR_TASK_AGENT_POOL) {
         $buildArgs += @('--agent-pool', "$($globalEnv.ACR_TASK_AGENT_POOL)")
       }
-      $hostedDigest = & python @buildArgs
+      $hostedDigest = Invoke-PythonModule -ModuleName 'config.deployment.hosted_image' -Arguments $buildArgs
       if ($LASTEXITCODE -ne 0 -or -not $hostedDigest) {
         Write-Error "Failed to build the hosted-agent derivative image."
         exit $LASTEXITCODE
@@ -237,7 +247,7 @@ if ($hostedMode) {
   }
   Push-Location $repoRoot
   try {
-    $hostedBaseUrlOutput = & python -m config.deployment.hosted --invocations-endpoint $invocationsEndpoint
+    $hostedBaseUrlOutput = Invoke-PythonModule -ModuleName 'config.deployment.hosted' -Arguments @('--invocations-endpoint', $invocationsEndpoint)
     $hostedExitCode = $LASTEXITCODE
     $hostedBaseUrl = if ($hostedBaseUrlOutput) { "$hostedBaseUrlOutput".Trim() } else { '' }
     if ($hostedExitCode -ne 0 -or -not $hostedBaseUrl) {
@@ -252,7 +262,7 @@ if ($hostedMode) {
   Push-Location $repoRoot
   try {
     & azd env set HOSTED_AGENT_BASE_URL $hostedBaseUrl --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
-    & python -m config.deployment.appconfig --require-hosted-endpoint
+    Invoke-PythonModule -ModuleName 'config.deployment.appconfig' -Arguments @('--require-hosted-endpoint')
     if ($LASTEXITCODE -ne 0) {
       Write-Error "Failed to publish the hosted-agent endpoint contract."
       exit $LASTEXITCODE

--- a/scripts/preDeploy.sh
+++ b/scripts/preDeploy.sh
@@ -83,6 +83,7 @@ fi
 
 repo_root="$(find_repo_root "$start_dir")" || { red "Run this from inside a gpt-rag repo."; exit 1; }
 command -v git >/dev/null 2>&1 || { red "Git not found in PATH."; exit 1; }
+export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
 
 manifest_path="$repo_root/manifest.json"
 [ -f "$manifest_path" ] || { red "manifest.json not found at $manifest_path"; exit 1; }

--- a/tests/test_hosted_image.py
+++ b/tests/test_hosted_image.py
@@ -11,6 +11,7 @@ from config.deployment.hosted_image import (
     build_hosted_image,
     parse_digest_from_build_output,
     render_hosted_dockerfile,
+    resolve_azure_cli_executable,
     resolve_pushed_digest,
 )
 
@@ -116,8 +117,11 @@ class ParseDigestFromBuildOutputTests(unittest.TestCase):
 
 
 class ResolvePushedDigestTests(unittest.TestCase):
+    @patch("config.deployment.hosted_image.resolve_azure_cli_executable", return_value="az")
     @patch("config.deployment.hosted_image.subprocess.run")
-    def test_returns_digest_from_az_cli(self, mock_run: MagicMock) -> None:
+    def test_returns_digest_from_az_cli(
+        self, mock_run: MagicMock, _mock_cli: MagicMock
+    ) -> None:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=f"{BASE_DIGEST}\n", stderr=""
         )
@@ -149,8 +153,11 @@ class ResolvePushedDigestTests(unittest.TestCase):
             called_args,
         )
 
+    @patch("config.deployment.hosted_image.resolve_azure_cli_executable", return_value="az")
     @patch("config.deployment.hosted_image.subprocess.run")
-    def test_raises_on_unexpected_output(self, mock_run: MagicMock) -> None:
+    def test_raises_on_unexpected_output(
+        self, mock_run: MagicMock, _mock_cli: MagicMock
+    ) -> None:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="not-a-digest\n", stderr=""
         )
@@ -164,10 +171,14 @@ class ResolvePushedDigestTests(unittest.TestCase):
 
 
 class BuildHostedImageTests(unittest.TestCase):
+    @patch("config.deployment.hosted_image.resolve_azure_cli_executable", return_value="az")
     @patch("config.deployment.hosted_image.resolve_pushed_digest")
     @patch("config.deployment.hosted_image.subprocess.run")
     def test_builds_then_resolves_digest(
-        self, mock_run: MagicMock, mock_resolve: MagicMock
+        self,
+        mock_run: MagicMock,
+        mock_resolve: MagicMock,
+        _mock_cli: MagicMock,
     ) -> None:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
         mock_resolve.return_value = BASE_DIGEST
@@ -191,6 +202,27 @@ class BuildHostedImageTests(unittest.TestCase):
             image_name="gpt-rag-orchestrator",
             image_tag="v3.9.0-hosted",
         )
+
+
+class ResolveAzureCliExecutableTests(unittest.TestCase):
+    @patch("config.deployment.hosted_image.shutil.which")
+    def test_falls_back_to_az_cmd_for_windows_installations(
+        self, mock_which: MagicMock
+    ) -> None:
+        mock_which.side_effect = [None, r"C:\Program Files\Azure CLI\az.cmd"]
+
+        executable = resolve_azure_cli_executable()
+
+        self.assertEqual(r"C:\Program Files\Azure CLI\az.cmd", executable)
+        self.assertEqual(
+            [unittest.mock.call("az"), unittest.mock.call("az.cmd")],
+            mock_which.call_args_list,
+        )
+
+    @patch("config.deployment.hosted_image.shutil.which", return_value=None)
+    def test_raises_when_azure_cli_is_missing(self, _mock_which: MagicMock) -> None:
+        with self.assertRaisesRegex(RuntimeError, "Azure CLI executable"):
+            resolve_azure_cli_executable()
 
 
 if __name__ == "__main__":

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -140,6 +140,9 @@ class LifecycleParityTests(unittest.TestCase):
                 self.assertIn("gpt-rag-ingestion", content)
                 self.assertIn("gpt-rag-ui", content)
                 self.assertIn("azd deploy orchestrator-agent", content)
+                self.assertIn("PYTHONPATH", content)
+                if name == "preDeploy.ps1":
+                    self.assertIn("runpy.run_module", content)
                 self.assertIn(
                     "AGENT_ORCHESTRATOR_AGENT_INVOCATIONS_ENDPOINT", content
                 )


### PR DESCRIPTION
## Summary
- establish the repository root for Python module imports in both deployment hooks
- resolve the Windows Azure CLI z.cmd launcher before invoking ACR Tasks
- add cross-platform regression tests and changelog evidence

## Validation
- python -m unittest discover -s tests (37 passed)
- independent code review: no findings

Found during the disposable NETWORK_ISOLATION=true validation for #592 and #597.