### PR TITLE
Fix hosted migration review blockers

### DIFF
--- a/config/deployment/appconfig.py
+++ b/config/deployment/appconfig.py
@@ -11,6 +11,8 @@ from typing import Mapping
 from config.deployment.composition import (
     APP_CONFIG_LABEL,
     DeploymentMode,
+    effective_runtime_mode,
+    is_truthy,
     resolve_mode,
     validate_hosted_prerequisites,
 )
@@ -84,6 +86,34 @@ def build_settings(
     hosted = mode is not DeploymentMode.CLASSIC
     resource_group = _required(environment, "AZURE_RESOURCE_GROUP")
     resource_token = _required(environment, "RESOURCE_TOKEN")
+    hosted_base_url = (environment.get("HOSTED_AGENT_BASE_URL") or "").strip()
+    hosted_scope = (environment.get("HOSTED_AGENT_RESOURCE_SCOPE") or "").strip()
+    hosted_image_version = (
+        environment.get("HOSTED_AGENT_IMAGE_VERSION") or ""
+    ).strip()
+    deploy_hosted = is_truthy(environment.get("DEPLOY_HOSTED_AGENT"))
+
+    if hosted:
+        validate_hosted_prerequisites(
+            environment,
+            require_image_digest=require_hosted_endpoint,
+        )
+    if hosted and require_hosted_endpoint:
+        if not hosted_base_url:
+            raise ValueError(
+                "Hosted deployment completed without HOSTED_AGENT_BASE_URL."
+            )
+        if not deploy_hosted:
+            raise ValueError(
+                "Hosted deployment completed without DEPLOY_HOSTED_AGENT=true."
+            )
+
+    runtime_mode = effective_runtime_mode(
+        mode,
+        environment,
+        deploy_hosted=deploy_hosted,
+    )
+    runtime_hosted = runtime_mode is not DeploymentMode.CLASSIC
 
     app_names = {
         "frontend": f"ca-{resource_token}-frontend",
@@ -100,25 +130,9 @@ def build_settings(
         _container_app(
             resource_group, app_names["orchestrator"], required=True
         )
-        if mode is DeploymentMode.CLASSIC
+        if runtime_mode is DeploymentMode.CLASSIC
         else {"fqdn": "", "principalId": ""}
     )
-
-    hosted_base_url = (environment.get("HOSTED_AGENT_BASE_URL") or "").strip()
-    hosted_scope = (environment.get("HOSTED_AGENT_RESOURCE_SCOPE") or "").strip()
-    hosted_image_version = (
-        environment.get("HOSTED_AGENT_IMAGE_VERSION") or ""
-    ).strip()
-    if hosted:
-        validate_hosted_prerequisites(
-            environment,
-            require_image_digest=False,
-        )
-    if hosted and require_hosted_endpoint:
-        if not hosted_base_url:
-            raise ValueError(
-                "Hosted deployment completed without HOSTED_AGENT_BASE_URL."
-            )
 
     container_apps = [
         {
@@ -136,7 +150,7 @@ def build_settings(
             "fqdn": dataingest["fqdn"],
         },
     ]
-    if mode is DeploymentMode.CLASSIC:
+    if runtime_mode is DeploymentMode.CLASSIC:
         container_apps.insert(
             0,
             {
@@ -149,19 +163,17 @@ def build_settings(
         )
 
     return {
-        "DEPLOY_HOSTED_AGENT_ORCHESTRATION": str(hosted).lower(),
-        "PREPARE_HOSTED_AGENT": str(hosted).lower(),
-        "DEPLOY_HOSTED_AGENT": (
-            environment.get("DEPLOY_HOSTED_AGENT") or "false"
-        ).strip().lower(),
-        "HOSTED_AGENT_PREPARED": (
-            environment.get("HOSTED_AGENT_PREPARED") or str(hosted)
-        ).strip().lower(),
-        "DEPLOY_ADMINISTRATIVE_PANEL": str(
-            mode is DeploymentMode.HOSTED_PANEL
+        "DEPLOY_HOSTED_AGENT_ORCHESTRATION": str(runtime_hosted).lower(),
+        "PREPARE_HOSTED_AGENT": str(runtime_hosted).lower(),
+        "DEPLOY_HOSTED_AGENT": str(
+            deploy_hosted and runtime_hosted
         ).lower(),
-        "DEPLOYMENT_TOPOLOGY": mode.value,
-        "CHAT_BACKEND": "hosted_agent" if hosted else "orchestrator",
+        "HOSTED_AGENT_PREPARED": str(runtime_hosted).lower(),
+        "DEPLOY_ADMINISTRATIVE_PANEL": str(
+            runtime_mode is DeploymentMode.HOSTED_PANEL
+        ).lower(),
+        "DEPLOYMENT_TOPOLOGY": runtime_mode.value,
+        "CHAT_BACKEND": "hosted_agent" if runtime_hosted else "orchestrator",
         "ORCHESTRATOR_BASE_URL": (
             f"https://{orchestrator['fqdn']}" if orchestrator["fqdn"] else ""
         ),
@@ -169,7 +181,7 @@ def build_settings(
         "HOSTED_AGENT_BASE_URL": hosted_base_url,
         "HOSTED_AGENT_RESOURCE_SCOPE": hosted_scope,
         "HOSTED_AGENT_IMAGE_VERSION": (
-            hosted_image_version if hosted else ""
+            hosted_image_version if runtime_hosted else ""
         ),
         "HOSTED_AGENT_SSE_IDLE_TIMEOUT_SECONDS": (
             environment.get("HOSTED_AGENT_SSE_IDLE_TIMEOUT_SECONDS") or "60"
@@ -181,7 +193,7 @@ def build_settings(
         "DATA_INGEST_APP_ENDPOINT": f"https://{dataingest['fqdn']}",
         "ORCHESTRATOR_APP_NAME": (
             app_names["orchestrator"]
-            if mode is DeploymentMode.CLASSIC
+            if runtime_mode is DeploymentMode.CLASSIC
             else ""
         ),
         "FRONTEND_APP_NAME": app_names["frontend"],

--- a/config/deployment/composition.py
+++ b/config/deployment/composition.py
@@ -336,6 +336,31 @@ def selected_components(mode: DeploymentMode) -> tuple[str, ...]:
     return ("gpt-rag-ui", "gpt-rag-ingestion")
 
 
+def effective_runtime_mode(
+    mode: DeploymentMode,
+    environment: Mapping[str, str],
+    *,
+    deploy_hosted: bool,
+) -> DeploymentMode:
+    """Keep an existing classic runtime until hosted cutover is materialized."""
+    if mode is DeploymentMode.CLASSIC:
+        return mode
+
+    backend = (environment.get("CHAT_BACKEND") or "").strip().lower()
+    if backend not in {"", "orchestrator", "hosted_agent"}:
+        raise DeploymentTopologyError(
+            f"Unknown CHAT_BACKEND={backend!r}; expected 'orchestrator' or "
+            "'hosted_agent'."
+        )
+    if backend != "orchestrator":
+        return mode
+
+    endpoint = (environment.get("HOSTED_AGENT_BASE_URL") or "").strip()
+    if deploy_hosted and endpoint:
+        return mode
+    return DeploymentMode.CLASSIC
+
+
 def _setting(name: str, value: str) -> dict[str, str]:
     return {
         "name": name,
@@ -358,13 +383,19 @@ def compose_parameters(
 
     mode = resolve_mode(environment)
     hosted = mode is not DeploymentMode.CLASSIC
-    panel = mode is not DeploymentMode.HOSTED_NO_PANEL
 
     digest = (environment.get("HOSTED_AGENT_IMAGE_VERSION") or "").strip()
     generated_source_commit = (
         environment.get("HOSTED_AGENT_IMAGE_SOURCE_COMMIT") or ""
     ).strip()
     deploy_hosted = hosted and bool(digest)
+    runtime_mode = effective_runtime_mode(
+        mode,
+        environment,
+        deploy_hosted=deploy_hosted,
+    )
+    runtime_hosted = runtime_mode is not DeploymentMode.CLASSIC
+    runtime_panel = runtime_mode is DeploymentMode.HOSTED_PANEL
 
     if deploy_hosted:
         validate_hosted_prerequisites(environment)
@@ -389,7 +420,11 @@ def compose_parameters(
 
     parameters["prepareHostedAgent"] = {"value": hosted}
     parameters["deployHostedAgent"] = {"value": deploy_hosted}
-    parameters["deployCosmosDb"] = {"value": panel}
+    parameters["deployCosmosDb"] = {
+        "value": runtime_mode is DeploymentMode.CLASSIC or runtime_panel
+    }
+    if hosted and is_truthy(environment.get("NETWORK_ISOLATION")):
+        parameters["deployAcrTaskAgentPool"] = {"value": True}
 
     if hosted:
         parameters["hostedAgent"] = {
@@ -443,13 +478,13 @@ def compose_parameters(
         raise ValueError("containerAppsList must contain an array value.")
 
     apps = apps_parameter["value"]
-    if hosted:
+    if runtime_hosted:
         apps = [
             app
             for app in apps
             if isinstance(app, dict) and app.get("service_name") != "orchestrator"
         ]
-    if mode is DeploymentMode.HOSTED_NO_PANEL:
+    if runtime_mode is DeploymentMode.HOSTED_NO_PANEL:
         for app in apps:
             if app.get("service_name") == "dataingest":
                 app["roles"] = [
@@ -459,35 +494,53 @@ def compose_parameters(
                 ]
     parameters["containerAppsList"] = {"value": apps}
 
-    if mode is DeploymentMode.HOSTED_NO_PANEL:
+    if runtime_mode is DeploymentMode.HOSTED_NO_PANEL:
         parameters["databaseContainersList"] = {"value": []}
 
     parameters["additionalAppConfigurationSettings"] = {
         "value": [
             _setting(
                 "DEPLOY_HOSTED_AGENT_ORCHESTRATION",
-                str(hosted).lower(),
+                str(runtime_hosted).lower(),
             ),
-            _setting("PREPARE_HOSTED_AGENT", str(hosted).lower()),
-            _setting("DEPLOY_HOSTED_AGENT", str(deploy_hosted).lower()),
-            _setting("HOSTED_AGENT_PREPARED", str(hosted).lower()),
+            _setting("PREPARE_HOSTED_AGENT", str(runtime_hosted).lower()),
+            _setting(
+                "DEPLOY_HOSTED_AGENT",
+                str(deploy_hosted and runtime_hosted).lower(),
+            ),
+            _setting("HOSTED_AGENT_PREPARED", str(runtime_hosted).lower()),
             _setting(
                 "DEPLOY_ADMINISTRATIVE_PANEL",
-                str(panel and hosted).lower(),
+                str(runtime_panel).lower(),
             ),
-            _setting("DEPLOYMENT_TOPOLOGY", mode.value),
-            _setting("CHAT_BACKEND", "hosted_agent" if hosted else "orchestrator"),
+            _setting("DEPLOYMENT_TOPOLOGY", runtime_mode.value),
+            _setting(
+                "CHAT_BACKEND",
+                "hosted_agent" if runtime_hosted else "orchestrator",
+            ),
             _setting(
                 "HOSTED_AGENT_BASE_URL",
-                environment.get("HOSTED_AGENT_BASE_URL", ""),
+                (
+                    environment.get("HOSTED_AGENT_BASE_URL", "")
+                    if runtime_hosted
+                    else ""
+                ),
             ),
             _setting(
                 "HOSTED_AGENT_RESOURCE_SCOPE",
-                environment.get("HOSTED_AGENT_RESOURCE_SCOPE", ""),
+                (
+                    environment.get("HOSTED_AGENT_RESOURCE_SCOPE", "")
+                    if runtime_hosted
+                    else ""
+                ),
             ),
             _setting(
                 "HOSTED_AGENT_IMAGE_VERSION",
-                environment.get("HOSTED_AGENT_IMAGE_VERSION", ""),
+                (
+                    environment.get("HOSTED_AGENT_IMAGE_VERSION", "")
+                    if runtime_hosted
+                    else ""
+                ),
             ),
             _setting(
                 "HOSTED_AGENT_SSE_IDLE_TIMEOUT_SECONDS",

--- a/config/deployment/topology.py
+++ b/config/deployment/topology.py
@@ -27,6 +27,8 @@ from config.deployment.composition import (
     DeploymentMode,
     DeploymentTopologyError,
     describe_mode,
+    effective_runtime_mode,
+    is_truthy,
     materialized_settings,
     resolve_explicit_topology,
     resolve_mode,
@@ -153,20 +155,69 @@ def resolve_environment_topology(
     on, or be delayed by, being able to reach Azure to classify the
     environment as fresh or existing.
     """
-    if resolve_explicit_topology(environment) is not None:
-        return resolve_topology(environment, resource_group_exists=None)
+    return resolve_environment_contract(
+        environment,
+        resource_group_name=resource_group_name,
+        subscription_id=subscription_id,
+        app_config_endpoint=app_config_endpoint,
+    )[0]
+
+
+def resolve_environment_contract(
+    environment: Mapping[str, str],
+    *,
+    resource_group_name: str | None = None,
+    subscription_id: str | None = None,
+    app_config_endpoint: str | None = None,
+) -> tuple[DeploymentMode, str]:
+    """Resolve target topology and the runtime backend safe to materialize."""
+    explicit = resolve_explicit_topology(environment)
+    current_backend = (environment.get("CHAT_BACKEND") or "").strip().lower()
+    if current_backend not in {"", "orchestrator", "hosted_agent"}:
+        raise DeploymentTopologyError(
+            f"Unknown CHAT_BACKEND={current_backend!r}; expected 'orchestrator' "
+            "or 'hosted_agent'."
+        )
+
+    if explicit is DeploymentMode.CLASSIC:
+        return explicit, "orchestrator"
+    if explicit is not None and current_backend == "hosted_agent":
+        return explicit, current_backend
+    if explicit is not None:
+        rg_exists = resource_group_exists(resource_group_name, subscription_id)
+        return explicit, "orchestrator" if rg_exists else "hosted_agent"
 
     rg_exists = resource_group_exists(resource_group_name, subscription_id)
     persisted = read_persisted_settings(app_config_endpoint) if rg_exists else {}
-    return resolve_topology(
+    mode = resolve_topology(
         environment,
         resource_group_exists=rg_exists,
         persisted_settings=persisted,
     )
+    return mode, str(describe_mode(mode)["chat_backend"])
 
 
-def _print_materialized(mode: DeploymentMode) -> None:
-    for key, value in materialized_settings(mode).items():
+def _print_materialized(
+    mode: DeploymentMode,
+    *,
+    environment: Mapping[str, str],
+) -> None:
+    settings = materialized_settings(mode)
+    deploy_hosted = (
+        is_truthy(environment.get("DEPLOY_HOSTED_AGENT"))
+        and bool((environment.get("HOSTED_AGENT_IMAGE_VERSION") or "").strip())
+    )
+    runtime_mode = effective_runtime_mode(
+        mode,
+        environment,
+        deploy_hosted=deploy_hosted,
+    )
+    settings["CHAT_BACKEND"] = (
+        "orchestrator"
+        if runtime_mode is DeploymentMode.CLASSIC
+        else "hosted_agent"
+    )
+    for key, value in settings.items():
         print(f"{key}={value}")
 
 
@@ -262,13 +313,18 @@ def main() -> int:
             subscription_id = args.subscription_id or os.environ.get(
                 "AZURE_SUBSCRIPTION_ID"
             )
-            mode = resolve_environment_topology(
+            mode, runtime_backend = resolve_environment_contract(
                 os.environ,
                 resource_group_name=resource_group_name,
                 subscription_id=subscription_id,
                 app_config_endpoint=app_config_endpoint,
             )
-            _print_materialized(mode)
+            materialized_environment = dict(os.environ)
+            materialized_environment["CHAT_BACKEND"] = runtime_backend
+            _print_materialized(
+                mode,
+                environment=materialized_environment,
+            )
     except DeploymentTopologyError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/scripts/postProvision.ps1
+++ b/scripts/postProvision.ps1
@@ -242,10 +242,23 @@ function Set-GptRagAppConfiguration {
         exit 1
     }
     $topologyInfo = ([string]$topologyJson).Trim() | ConvertFrom-Json
-    $hostedMode = [bool]$topologyInfo.deploy_hosted_agent_orchestration
+    $targetHostedMode = [bool]$topologyInfo.deploy_hosted_agent_orchestration
+    $currentChatBackend = (Get-OptionalEnvValue 'CHAT_BACKEND').ToLowerInvariant()
+    $hostedCutoverReady = (
+        (Test-Truthy (Get-OptionalEnvValue 'DEPLOY_HOSTED_AGENT' 'false')) -and
+        -not [string]::IsNullOrWhiteSpace((Get-OptionalEnvValue 'HOSTED_AGENT_IMAGE_VERSION')) -and
+        -not [string]::IsNullOrWhiteSpace((Get-OptionalEnvValue 'HOSTED_AGENT_BASE_URL'))
+    )
+    $hostedMode = $targetHostedMode -and (
+        $currentChatBackend -ne 'orchestrator' -or $hostedCutoverReady
+    )
     $administrativePanel = [bool]$topologyInfo.deploy_administrative_panel
     $cosmosEnabled = (-not $hostedMode) -or $administrativePanel
-    $deploymentTopology = [string]$topologyInfo.topology
+    $deploymentTopology = if ($hostedMode) {
+        [string]$topologyInfo.topology
+    } else {
+        'classic'
+    }
 
     $appConfigName = Get-AppConfigResourceName -Endpoint $Endpoint
     $nameSuffix = $resourceToken

--- a/scripts/preProvision.ps1
+++ b/scripts/preProvision.ps1
@@ -19,58 +19,80 @@ $ErrorActionPreference = 'Stop'
   }
 }
 
-# Initialize infrastructure submodule
+# Materialize the exact infrastructure commit pinned by manifest.json
 $projectRoot = Join-Path $PSScriptRoot ".."
 $infraDir = Join-Path $projectRoot "infra"
 $mainBicep = Join-Path $infraDir "main.bicep"
-
-Write-Host "Initializing infrastructure submodule..." -ForegroundColor Cyan
-git submodule update --init --recursive 2>$null
-
-# Fallback: when the repo was scaffolded via 'azd init' (ZIP download), the git
-# index has no submodule gitlink entries, so 'git submodule update' silently does
-# nothing and infra/ remains empty.  Detect that case and clone the landing-zone
-# repo directly.
-if (-not (Test-Path $mainBicep)) {
-    Write-Host "Submodule content not found. Cloning infra repo directly (azd init scenario)..." -ForegroundColor Cyan
-
-    # Extract infra repo URL and branch from .gitmodules
-    $gitmodulesPath = Join-Path $projectRoot ".gitmodules"
-    $infraUrl = $null
-    $infraRef = "main"  # safe default
-    if (Test-Path $gitmodulesPath) {
-        $urlMatch = Select-String -Path $gitmodulesPath -Pattern 'url\s*=\s*(.+)' | Select-Object -First 1
-        if ($urlMatch) { $infraUrl = $urlMatch.Matches.Groups[1].Value.Trim() }
-        $branchMatch = Select-String -Path $gitmodulesPath -Pattern 'branch\s*=\s*(.+)' | Select-Object -First 1
-        if ($branchMatch) { $infraRef = $branchMatch.Matches.Groups[1].Value.Trim() }
-    }
-    if (-not $infraUrl) {
-        Write-Host "Error: Could not determine infra repository URL from .gitmodules." -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  Infra repo: $infraUrl @ $infraRef (from .gitmodules)" -ForegroundColor Cyan
-
-    # Remove the empty infra directory and clone at the correct tag
-    if (Test-Path $infraDir) { Remove-Item -Path $infraDir -Recurse -Force }
-    git -c advice.detachedHead=false clone --depth 1 --branch $infraRef $infraUrl $infraDir
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "Error: Failed to clone infra repository ($infraUrl @ $infraRef)." -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "Infrastructure submodule cloned successfully." -ForegroundColor Green
-}
-
 $manifestSource = Join-Path $projectRoot "manifest.json"
+$gitmodulesPath = Join-Path $projectRoot ".gitmodules"
+
 if (-not (Test-Path $manifestSource)) {
     Write-Host "Error: manifest.json is required to verify the infrastructure release pin." -ForegroundColor Red
     exit 1
 }
 $expectedInfraCommit = (Get-Content -LiteralPath $manifestSource -Raw | ConvertFrom-Json).ailz_commit
+if (-not $expectedInfraCommit -or $expectedInfraCommit -notmatch '^[0-9a-fA-F]{40}$') {
+    Write-Host "Error: manifest.json must contain a full 40-character ailz_commit." -ForegroundColor Red
+    exit 1
+}
+$urlMatch = Select-String -Path $gitmodulesPath -Pattern 'url\s*=\s*(.+)' | Select-Object -First 1
+$infraUrl = if ($urlMatch) { $urlMatch.Matches.Groups[1].Value.Trim() } else { $null }
+if (-not $infraUrl) {
+    Write-Host "Error: Could not determine infra repository URL from .gitmodules." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Materializing infrastructure commit $expectedInfraCommit..." -ForegroundColor Cyan
+if (-not (Test-Path $infraDir)) {
+    New-Item -ItemType Directory -Path $infraDir | Out-Null
+}
+if (-not (Test-Path (Join-Path $infraDir '.git'))) {
+    & git -C $infraDir init | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Failed to initialize the infra repository." -ForegroundColor Red
+        exit 1
+    }
+}
+& git -C $infraDir remote get-url origin 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    & git -C $infraDir remote set-url origin $infraUrl
+} else {
+    & git -C $infraDir remote add origin $infraUrl
+}
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to configure the infra repository remote." -ForegroundColor Red
+    exit 1
+}
+& git -C $infraDir fetch --depth 1 origin $expectedInfraCommit
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to fetch pinned infra commit $expectedInfraCommit." -ForegroundColor Red
+    exit 1
+}
+& git -C $infraDir -c advice.detachedHead=false checkout --detach --force FETCH_HEAD
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to check out pinned infra commit $expectedInfraCommit." -ForegroundColor Red
+    exit 1
+}
+& git -C $infraDir clean -ffdx
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to clean stale files from the pinned infra checkout." -ForegroundColor Red
+    exit 1
+}
+& git -C $infraDir submodule update --init --recursive
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to initialize nested infrastructure submodules." -ForegroundColor Red
+    exit 1
+}
+
 $actualInfraCommitOutput = & git -C $infraDir rev-parse HEAD 2>$null
 $revParseExitCode = $LASTEXITCODE
 $actualInfraCommit = if ($actualInfraCommitOutput) { "$actualInfraCommitOutput".Trim() } else { '' }
 if ($revParseExitCode -ne 0 -or -not $expectedInfraCommit -or $actualInfraCommit -ne $expectedInfraCommit) {
     Write-Host "Error: infra must resolve to $expectedInfraCommit but is at $actualInfraCommit." -ForegroundColor Red
+    exit 1
+}
+if (-not (Test-Path $mainBicep)) {
+    Write-Host "Error: Pinned infra commit does not contain main.bicep." -ForegroundColor Red
     exit 1
 }
 if (Test-Path $manifestSource) {

--- a/scripts/preProvision.sh
+++ b/scripts/preProvision.sh
@@ -21,53 +21,14 @@ NC='\033[0m' # No Color
 eval "$(azd env get-values 2>/dev/null | sed 's/^/export /')" || true
 
 ###############################################################################
-# Initialize infrastructure submodule
+# Materialize the exact infrastructure commit pinned by manifest.json
 ###############################################################################
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR/.."
 INFRA_DIR="$PROJECT_ROOT/infra"
 MAIN_BICEP="$INFRA_DIR/main.bicep"
-
-echo "${CYAN}Initializing infrastructure submodule...${NC}"
-git submodule update --init --recursive 2>/dev/null
-
-# Fallback: when the repo was scaffolded via 'azd init' (ZIP download), the git
-# index has no submodule gitlink entries, so 'git submodule update' silently does
-# nothing and infra/ remains empty.  Detect that case and clone the landing-zone
-# repo directly.
-if [ ! -f "$MAIN_BICEP" ]; then
-    echo "${CYAN}Submodule content not found. Cloning infra repo directly (azd init scenario)...${NC}"
-
-    # Extract infra repo URL and branch from .gitmodules
-    GITMODULES="$PROJECT_ROOT/.gitmodules"
-    INFRA_URL=""
-    INFRA_REF="main"  # safe default
-    if [ -f "$GITMODULES" ]; then
-        INFRA_URL=$(grep -m1 'url\s*=' "$GITMODULES" | sed 's/.*=\s*//' | xargs)
-        BRANCH=$(grep -m1 'branch\s*=' "$GITMODULES" | sed 's/.*=\s*//' | xargs)
-        if [ -n "$BRANCH" ]; then
-            INFRA_REF="$BRANCH"
-        fi
-    fi
-    if [ -z "$INFRA_URL" ]; then
-        echo "${YELLOW}Error: Could not determine infra repository URL from .gitmodules.${NC}"
-        exit 1
-    fi
-    echo "${CYAN}  Infra repo: $INFRA_URL @ $INFRA_REF (from .gitmodules)${NC}"
-
-    # Remove the empty infra directory and clone at the correct tag
-    rm -rf "$INFRA_DIR"
-    git -c advice.detachedHead=false clone --depth 1 --branch "$INFRA_REF" "$INFRA_URL" "$INFRA_DIR"
-    if [ $? -ne 0 ]; then
-        echo "${YELLOW}Error: Failed to clone infra repository ($INFRA_URL @ $INFRA_REF).${NC}"
-        exit 1
-    fi
-    echo "${GREEN}Infrastructure submodule cloned successfully.${NC}"
-fi
-
-###############################################################################
-# Override submodule files with project-level overrides
-###############################################################################
+GITMODULES="$PROJECT_ROOT/.gitmodules"
+MANIFEST="$PROJECT_ROOT/manifest.json"
 
 PYTHON_CMD=""
 if command -v python3 >/dev/null 2>&1; then
@@ -79,12 +40,67 @@ else
     exit 1
 fi
 
-EXPECTED_INFRA_COMMIT="$("$PYTHON_CMD" -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["ailz_commit"])' "$PROJECT_ROOT/manifest.json")"
+if [ ! -f "$MANIFEST" ]; then
+    echo "${YELLOW}Error: manifest.json is required to verify the infrastructure release pin.${NC}"
+    exit 1
+fi
+EXPECTED_INFRA_COMMIT="$("$PYTHON_CMD" -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["ailz_commit"])' "$MANIFEST")"
+case "$EXPECTED_INFRA_COMMIT" in
+    *[!0-9a-fA-F]*|'') echo "${YELLOW}Error: manifest.json must contain a full 40-character ailz_commit.${NC}"; exit 1 ;;
+esac
+if [ "${#EXPECTED_INFRA_COMMIT}" -ne 40 ]; then
+    echo "${YELLOW}Error: manifest.json must contain a full 40-character ailz_commit.${NC}"
+    exit 1
+fi
+INFRA_URL=$(grep -m1 'url[[:space:]]*=' "$GITMODULES" | sed 's/.*=[[:space:]]*//' | xargs)
+if [ -z "$INFRA_URL" ]; then
+    echo "${YELLOW}Error: Could not determine infra repository URL from .gitmodules.${NC}"
+    exit 1
+fi
+
+echo "${CYAN}Materializing infrastructure commit $EXPECTED_INFRA_COMMIT...${NC}"
+mkdir -p "$INFRA_DIR"
+if [ ! -e "$INFRA_DIR/.git" ]; then
+    git -C "$INFRA_DIR" init >/dev/null || {
+        echo "${YELLOW}Error: Failed to initialize the infra repository.${NC}"
+        exit 1
+    }
+fi
+if git -C "$INFRA_DIR" remote get-url origin >/dev/null 2>&1; then
+    git -C "$INFRA_DIR" remote set-url origin "$INFRA_URL"
+else
+    git -C "$INFRA_DIR" remote add origin "$INFRA_URL"
+fi
+git -C "$INFRA_DIR" fetch --depth 1 origin "$EXPECTED_INFRA_COMMIT" || {
+    echo "${YELLOW}Error: Failed to fetch pinned infra commit $EXPECTED_INFRA_COMMIT.${NC}"
+    exit 1
+}
+git -C "$INFRA_DIR" -c advice.detachedHead=false checkout --detach --force FETCH_HEAD || {
+    echo "${YELLOW}Error: Failed to check out pinned infra commit $EXPECTED_INFRA_COMMIT.${NC}"
+    exit 1
+}
+git -C "$INFRA_DIR" clean -ffdx || {
+    echo "${YELLOW}Error: Failed to clean stale files from the pinned infra checkout.${NC}"
+    exit 1
+}
+git -C "$INFRA_DIR" submodule update --init --recursive || {
+    echo "${YELLOW}Error: Failed to initialize nested infrastructure submodules.${NC}"
+    exit 1
+}
+
 ACTUAL_INFRA_COMMIT="$(git -C "$INFRA_DIR" rev-parse HEAD 2>/dev/null || true)"
 if [ -z "$EXPECTED_INFRA_COMMIT" ] || [ "$ACTUAL_INFRA_COMMIT" != "$EXPECTED_INFRA_COMMIT" ]; then
     echo "${YELLOW}Error: infra must resolve to $EXPECTED_INFRA_COMMIT but is at $ACTUAL_INFRA_COMMIT.${NC}"
     exit 1
 fi
+if [ ! -f "$MAIN_BICEP" ]; then
+    echo "${YELLOW}Error: Pinned infra commit does not contain main.bicep.${NC}"
+    exit 1
+fi
+
+###############################################################################
+# Override submodule files with project-level overrides
+###############################################################################
 
 if [ -f "$PROJECT_ROOT/manifest.json" ]; then
     echo "${CYAN}Applying project manifest.json to infra...${NC}"

--- a/tests/test_deployment_modes.py
+++ b/tests/test_deployment_modes.py
@@ -138,6 +138,95 @@ class DeploymentCompositionTests(unittest.TestCase):
             "",
             composed["parameters"]["hostedAgent"]["value"]["version"],
         )
+        self.assertEqual(
+            ["frontend", "dataingest"],
+            [
+                app["service_name"]
+                for app in composed["parameters"]["containerAppsList"]["value"]
+            ],
+        )
+        self.assertEqual("hosted_agent", settings_by_name(composed)["CHAT_BACKEND"])
+
+    def test_private_hosted_composition_requests_dedicated_acr_agent_pool(
+        self,
+    ) -> None:
+        composed = compose_parameters(
+            source_parameters(),
+            {
+                "DEPLOYMENT_TOPOLOGY": "hosted-no-panel",
+                "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+                "NETWORK_ISOLATION": "true",
+            },
+        )
+
+        self.assertTrue(
+            composed["parameters"]["deployAcrTaskAgentPool"]["value"]
+        )
+
+    def test_classic_composition_does_not_request_acr_agent_pool(self) -> None:
+        composed = compose_parameters(
+            source_parameters(),
+            {
+                "DEPLOYMENT_TOPOLOGY": "classic",
+                "NETWORK_ISOLATION": "true",
+            },
+        )
+
+        self.assertEqual(
+            "${DEPLOY_ACR_TASK_AGENT_POOL=false}",
+            composed["parameters"]["deployAcrTaskAgentPool"]["value"],
+        )
+
+    def test_prepare_only_classic_migration_preserves_runtime(self) -> None:
+        composed = compose_parameters(
+            source_parameters(),
+            {
+                "DEPLOYMENT_TOPOLOGY": "hosted-no-panel",
+                "CHAT_BACKEND": "orchestrator",
+                "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+            },
+        )
+        parameters = composed["parameters"]
+
+        self.assertTrue(parameters["prepareHostedAgent"]["value"])
+        self.assertFalse(parameters["deployHostedAgent"]["value"])
+        self.assertTrue(parameters["deployCosmosDb"]["value"])
+        self.assertEqual(
+            ["orchestrator", "frontend", "dataingest"],
+            [
+                app["service_name"]
+                for app in parameters["containerAppsList"]["value"]
+            ],
+        )
+        settings = settings_by_name(composed)
+        self.assertEqual("classic", settings["DEPLOYMENT_TOPOLOGY"])
+        self.assertEqual("orchestrator", settings["CHAT_BACKEND"])
+        self.assertEqual(
+            "false", settings["DEPLOY_HOSTED_AGENT_ORCHESTRATION"]
+        )
+
+    def test_classic_migration_cuts_over_after_endpoint_materializes(self) -> None:
+        composed = compose_parameters(
+            source_parameters(),
+            {
+                "DEPLOYMENT_TOPOLOGY": "hosted-no-panel",
+                "CHAT_BACKEND": "orchestrator",
+                "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+                "HOSTED_AGENT_IMAGE_VERSION": DIGEST,
+                "HOSTED_AGENT_BASE_URL": "https://agent.example.test/protocols",
+            },
+        )
+
+        self.assertEqual(
+            ["frontend", "dataingest"],
+            [
+                app["service_name"]
+                for app in composed["parameters"]["containerAppsList"]["value"]
+            ],
+        )
+        settings = settings_by_name(composed)
+        self.assertEqual("hosted-no-panel", settings["DEPLOYMENT_TOPOLOGY"])
+        self.assertEqual("hosted_agent", settings["CHAT_BACKEND"])
 
     def test_digest_materializes_deploy_handoff(self) -> None:
         environment = {
@@ -431,6 +520,7 @@ class AppConfigurationContractTests(unittest.TestCase):
                 "HOSTED_AGENT_BASE_URL": "https://agent.example.test/protocols",
                 "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
                 "HOSTED_AGENT_IMAGE_VERSION": DIGEST,
+                "DEPLOY_HOSTED_AGENT": "true",
             },
             require_hosted_endpoint=True,
         )
@@ -442,6 +532,47 @@ class AppConfigurationContractTests(unittest.TestCase):
             settings["HOSTED_AGENT_BASE_URL"],
         )
         self.assertEqual(DIGEST, settings["HOSTED_AGENT_IMAGE_VERSION"])
+        self.assertEqual(2, len(json.loads(settings["CONTAINER_APPS"])))
+
+    @patch("config.deployment.appconfig._container_app", side_effect=_app)
+    def test_prepare_only_migration_publishes_classic_runtime(
+        self, _mock: object
+    ) -> None:
+        settings = appconfig.build_settings(
+            {
+                "AZURE_RESOURCE_GROUP": "rg-test",
+                "RESOURCE_TOKEN": "test",
+                "DEPLOYMENT_TOPOLOGY": "hosted-no-panel",
+                "CHAT_BACKEND": "orchestrator",
+                "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+            }
+        )
+
+        self.assertEqual("classic", settings["DEPLOYMENT_TOPOLOGY"])
+        self.assertEqual("orchestrator", settings["CHAT_BACKEND"])
+        self.assertEqual(
+            "https://ca-test-orchestrator.example.test",
+            settings["ORCHESTRATOR_BASE_URL"],
+        )
+        self.assertEqual(3, len(json.loads(settings["CONTAINER_APPS"])))
+
+    @patch("config.deployment.appconfig._container_app", side_effect=_app)
+    def test_fresh_hosted_runtime_remains_fail_closed_without_endpoint(
+        self, _mock: object
+    ) -> None:
+        settings = appconfig.build_settings(
+            {
+                "AZURE_RESOURCE_GROUP": "rg-test",
+                "RESOURCE_TOKEN": "test",
+                "DEPLOYMENT_TOPOLOGY": "hosted-no-panel",
+                "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+            }
+        )
+
+        self.assertEqual("hosted-no-panel", settings["DEPLOYMENT_TOPOLOGY"])
+        self.assertEqual("hosted_agent", settings["CHAT_BACKEND"])
+        self.assertEqual("", settings["ORCHESTRATOR_BASE_URL"])
+        self.assertEqual("", settings["HOSTED_AGENT_BASE_URL"])
         self.assertEqual(2, len(json.loads(settings["CONTAINER_APPS"])))
 
     @patch("config.deployment.appconfig._container_app", side_effect=_app)
@@ -503,6 +634,8 @@ class AppConfigurationContractTests(unittest.TestCase):
                     "RESOURCE_TOKEN": "test",
                     "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
                     "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+                    "HOSTED_AGENT_IMAGE_VERSION": DIGEST,
+                    "DEPLOY_HOSTED_AGENT": "true",
                 },
                 require_hosted_endpoint=True,
             )

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -276,6 +276,23 @@ class LifecycleParityTests(unittest.TestCase):
             "${DEPLOY_HOSTED_AGENT=false}",
             parameters["deployHostedAgent"]["value"],
         )
+        self.assertEqual(
+            "${DEPLOY_ACR_TASK_AGENT_POOL=false}",
+            parameters["deployAcrTaskAgentPool"]["value"],
+        )
+
+    def test_preprovision_fetches_exact_manifest_infra_commit(self) -> None:
+        scripts = ROOT / "scripts"
+        ps1 = (scripts / "preProvision.ps1").read_text(encoding="utf-8-sig")
+        sh = (scripts / "preProvision.sh").read_text(encoding="utf-8-sig")
+
+        for content in (ps1, sh):
+            with self.subTest(script="powershell" if content is ps1 else "shell"):
+                self.assertIn("ailz_commit", content)
+                self.assertIn("fetch --depth 1 origin", content)
+                self.assertIn("checkout --detach --force FETCH_HEAD", content)
+                self.assertIn("clean -ffdx", content)
+                self.assertNotIn("clone --depth 1 --branch", content)
 
     def test_both_predeploy_hooks_filter_manifest_components_by_topology(
         self,

--- a/tests/test_topology_cli.py
+++ b/tests/test_topology_cli.py
@@ -130,19 +130,61 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
 
     @patch("config.deployment.topology.read_persisted_settings")
     @patch("config.deployment.topology.resource_group_exists")
-    def test_explicit_environment_signal_wins_without_reading_persisted_settings(
+    def test_explicit_environment_signal_with_backend_skips_persisted_settings(
         self, mock_rg_exists: object, mock_read_settings: object
     ) -> None:
         mock_rg_exists.return_value = True
 
         mode = topology.resolve_environment_topology(
-            {"DEPLOYMENT_TOPOLOGY": "hosted-no-panel"},
+            {
+                "DEPLOYMENT_TOPOLOGY": "hosted-no-panel",
+                "CHAT_BACKEND": "hosted_agent",
+            },
             resource_group_name="rg-test",
             app_config_endpoint="https://x",
         )
 
         self.assertEqual(DeploymentMode.HOSTED_NO_PANEL, mode)
         mock_read_settings.assert_not_called()
+
+    @patch(
+        "config.deployment.topology.read_persisted_settings",
+        return_value={},
+    )
+    @patch(
+        "config.deployment.topology.resource_group_exists",
+        return_value=True,
+    )
+    def test_explicit_migration_from_unmarked_existing_environment_is_classic(
+        self, _mock_rg_exists: object, mock_read_settings: object
+    ) -> None:
+        mode, backend = topology.resolve_environment_contract(
+            {"DEPLOYMENT_TOPOLOGY": "hosted-no-panel"},
+            resource_group_name="rg-test",
+            app_config_endpoint="https://x",
+        )
+
+        self.assertEqual(DeploymentMode.HOSTED_NO_PANEL, mode)
+        self.assertEqual("orchestrator", backend)
+        mock_read_settings.assert_not_called()
+
+    @patch(
+        "config.deployment.topology.resource_group_exists",
+        return_value=False,
+    )
+    def test_fresh_hosted_ignores_stale_classic_backend(
+        self, _mock_rg_exists: object
+    ) -> None:
+        mode, backend = topology.resolve_environment_contract(
+            {
+                "DEPLOYMENT_TOPOLOGY": "hosted-no-panel",
+                "CHAT_BACKEND": "orchestrator",
+            },
+            resource_group_name="rg-test",
+        )
+
+        self.assertEqual(DeploymentMode.HOSTED_NO_PANEL, mode)
+        self.assertEqual("hosted_agent", backend)
 
 
 class MainCliTests(unittest.TestCase):
@@ -160,6 +202,35 @@ class MainCliTests(unittest.TestCase):
         printed = "\n".join(call.args[0] for call in mock_print.call_args_list)
         self.assertIn("DEPLOYMENT_TOPOLOGY=hosted-no-panel", printed)
         self.assertIn("CHAT_BACKEND=hosted_agent", printed)
+
+    @patch(
+        "config.deployment.topology.read_persisted_settings",
+        return_value={},
+    )
+    @patch(
+        "config.deployment.topology.resource_group_exists",
+        return_value=True,
+    )
+    def test_prepare_only_migration_preserves_materialized_classic_backend(
+        self,
+        _mock_rg_exists: object,
+        _mock_read_settings: object,
+    ) -> None:
+        argv = ["prog"]
+        env = {
+            "DEPLOYMENT_TOPOLOGY": "hosted-no-panel",
+            "CHAT_BACKEND": "orchestrator",
+            "AZURE_RESOURCE_GROUP": "rg-test",
+            "APP_CONFIG_ENDPOINT": "https://x",
+        }
+        with patch("sys.argv", argv), patch("os.environ", env):
+            with patch("builtins.print") as mock_print:
+                exit_code = topology.main()
+
+        self.assertEqual(0, exit_code)
+        printed = "\n".join(call.args[0] for call in mock_print.call_args_list)
+        self.assertIn("DEPLOYMENT_TOPOLOGY=hosted-no-panel", printed)
+        self.assertIn("CHAT_BACKEND=orchestrator", printed)
 
     def test_describe_mode_prints_json_without_any_azure_cli_call(self) -> None:
         argv = ["prog", "--describe"]


### PR DESCRIPTION
## Summary
- provision the dedicated ACR Task agent pool automatically for private hosted preparation while preserving classic composition
- stage classic-to-hosted migrations without changing runtime/App Configuration until the digest-backed hosted endpoint is materialized
- fetch, clean, check out, and verify the exact manifest-pinned AI Landing Zone commit in both preProvision hooks

## Validation
- `python -m pytest -q` (237 passed, 90 subtests passed)
- targeted hosted/deployment contract tests (85 passed, 14 subtests passed)
- PowerShell parser: changed `.ps1` hooks
- Git Bash `bash -n`: changed `.sh` hooks
- `python -m compileall -q config tests`
- `git diff --check`
- independent final code review: no findings

## Residual risk
- authenticated hosted-agent smoke remains an end-to-end deployment/release gate; this change does not deploy or contact Azure