### PR TITLE
fix: unblock landing-zone pin upgrades

### DIFF
--- a/config/deployment/infra_checkout.py
+++ b/config/deployment/infra_checkout.py
@@ -1,0 +1,116 @@
+"""Prepare the managed infrastructure repository for a pinned checkout."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+MANAGED_OVERRIDE_PATHS = ("main.parameters.json", "manifest.json")
+
+
+class InfraCheckoutError(RuntimeError):
+    """Raised when moving the managed infrastructure repository is unsafe."""
+
+
+def _git(infra_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(infra_dir), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _is_managed_repository(infra_dir: Path) -> bool:
+    result = _git(infra_dir, "rev-parse", "--show-toplevel")
+    if result.returncode != 0:
+        return False
+    return Path(result.stdout.strip()).resolve() == infra_dir.resolve()
+
+
+def prepare_infra_checkout(infra_dir: Path) -> None:
+    """Reset generated overrides and reject all other dirty content."""
+    infra_dir = infra_dir.resolve()
+    if not infra_dir.exists():
+        return
+
+    if not _is_managed_repository(infra_dir):
+        if any(infra_dir.iterdir()):
+            raise InfraCheckoutError(
+                f"{infra_dir} contains content but is not a managed Git repository; "
+                "refusing to remove it."
+            )
+        return
+
+    for relative_path in MANAGED_OVERRIDE_PATHS:
+        tracked = _git(infra_dir, "ls-files", "--error-unmatch", "--", relative_path)
+        if tracked.returncode == 0:
+            restored = _git(
+                infra_dir,
+                "restore",
+                "--source=HEAD",
+                "--staged",
+                "--worktree",
+                "--",
+                relative_path,
+            )
+            if restored.returncode != 0:
+                raise InfraCheckoutError(
+                    f"Failed to restore generated infra override {relative_path}: "
+                    f"{restored.stderr.strip()}"
+                )
+            continue
+
+        override_path = infra_dir / relative_path
+        if override_path.is_symlink() or override_path.is_file():
+            try:
+                override_path.unlink()
+            except OSError as exc:
+                raise InfraCheckoutError(
+                    f"Failed to remove generated infra override {override_path}: {exc}"
+                ) from exc
+        elif override_path.exists():
+            raise InfraCheckoutError(
+                f"Generated infra override path {override_path} is not a file; "
+                "refusing to remove it."
+            )
+
+    status = _git(
+        infra_dir,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--ignore-submodules=none",
+    )
+    if status.returncode != 0:
+        raise InfraCheckoutError(
+            f"Failed to inspect infrastructure repository status: "
+            f"{status.stderr.strip()}"
+        )
+    if status.stdout.strip():
+        raise InfraCheckoutError(
+            "Infrastructure repository has local changes outside the generated "
+            "manifest.json and main.parameters.json overrides. Preserve or remove "
+            f"them before provisioning:\n{status.stdout.rstrip()}"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Safely prepare the managed infra repository for checkout."
+    )
+    parser.add_argument("--infra-dir", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        prepare_infra_checkout(args.infra_dir)
+    except InfraCheckoutError as exc:
+        parser.exit(1, f"Error: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preProvision.ps1
+++ b/scripts/preProvision.ps1
@@ -34,6 +34,19 @@ if (-not $expectedInfraCommit -or $expectedInfraCommit -notmatch '^[0-9a-f]{40}$
     exit 1
 }
 
+# Provisioning owns these generated infra overrides. Restore only those files,
+# then fail closed if any unrelated submodule changes remain.
+Push-Location $projectRoot
+try {
+    & python -m config.deployment.infra_checkout --infra-dir $infraDir
+    $infraCheckoutExitCode = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+if ($infraCheckoutExitCode -ne 0) {
+    exit $infraCheckoutExitCode
+}
+
 Write-Host "Initializing infrastructure submodule..." -ForegroundColor Cyan
 git submodule update --init --recursive 2>$null
 

--- a/scripts/preProvision.sh
+++ b/scripts/preProvision.sh
@@ -48,6 +48,14 @@ if ! printf '%s\n' "$EXPECTED_INFRA_COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
     exit 1
 fi
 
+# Provisioning owns these generated infra overrides. Restore only those files,
+# then fail closed if any unrelated submodule changes remain.
+(cd "$PROJECT_ROOT" && "$PYTHON_CMD" -m config.deployment.infra_checkout --infra-dir "$INFRA_DIR")
+INFRA_CHECKOUT_EXIT=$?
+if [ $INFRA_CHECKOUT_EXIT -ne 0 ]; then
+    exit $INFRA_CHECKOUT_EXIT
+fi
+
 echo "${CYAN}Initializing infrastructure submodule...${NC}"
 git submodule update --init --recursive 2>/dev/null
 

--- a/tests/test_infra_checkout.py
+++ b/tests/test_infra_checkout.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from config.deployment.infra_checkout import (
+    InfraCheckoutError,
+    prepare_infra_checkout,
+)
+
+
+def _git(repository: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repository), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+@pytest.fixture
+def infra_repository(tmp_path: Path) -> tuple[Path, str, str]:
+    repository = tmp_path / "infra"
+    repository.mkdir()
+    _git(repository, "init")
+    _git(repository, "config", "user.name", "GPT-RAG tests")
+    _git(repository, "config", "user.email", "gpt-rag-tests@example.invalid")
+
+    for name, content in (
+        ("main.bicep", "base bicep\n"),
+        ("main.parameters.json", '{"source": "base"}\n'),
+        ("manifest.json", '{"source": "base"}\n'),
+        ("operator.txt", "base operator content\n"),
+    ):
+        (repository / name).write_text(content, encoding="utf-8")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "base")
+    base_commit = _git(repository, "rev-parse", "HEAD")
+
+    (repository / "main.parameters.json").write_text(
+        '{"source": "target"}\n', encoding="utf-8"
+    )
+    (repository / "manifest.json").write_text(
+        '{"source": "target"}\n', encoding="utf-8"
+    )
+    _git(repository, "add", "main.parameters.json", "manifest.json")
+    _git(repository, "commit", "-m", "target")
+    target_commit = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "checkout", "--detach", base_commit)
+    return repository, base_commit, target_commit
+
+
+def test_generated_overrides_do_not_block_pin_upgrade(
+    infra_repository: tuple[Path, str, str],
+) -> None:
+    repository, _, target_commit = infra_repository
+    (repository / "main.parameters.json").write_text(
+        '{"generated": "parameters"}\n', encoding="utf-8"
+    )
+    (repository / "manifest.json").write_text(
+        '{"generated": "manifest"}\n', encoding="utf-8"
+    )
+
+    prepare_infra_checkout(repository)
+    _git(repository, "checkout", "--detach", target_commit)
+
+    assert _git(repository, "rev-parse", "HEAD") == target_commit
+    assert _git(repository, "status", "--porcelain") == ""
+
+
+def test_unrelated_dirty_content_fails_closed_and_is_preserved(
+    infra_repository: tuple[Path, str, str],
+) -> None:
+    repository, base_commit, _ = infra_repository
+    (repository / "manifest.json").write_text(
+        '{"generated": "manifest"}\n', encoding="utf-8"
+    )
+    operator_content = "operator change that must survive\n"
+    (repository / "operator.txt").write_text(operator_content, encoding="utf-8")
+
+    with pytest.raises(InfraCheckoutError, match="local changes outside"):
+        prepare_infra_checkout(repository)
+
+    assert _git(repository, "rev-parse", "HEAD") == base_commit
+    assert (repository / "operator.txt").read_text(encoding="utf-8") == operator_content
+    assert (repository / "manifest.json").read_text(encoding="utf-8") == (
+        '{"source": "base"}\n'
+    )
+
+
+def test_unremovable_generated_override_has_clear_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = tmp_path / "infra"
+    repository.mkdir()
+    _git(repository, "init")
+    override = repository / "manifest.json"
+    override.write_text('{"generated": true}\n', encoding="utf-8")
+
+    def reject_removal(self: Path, missing_ok: bool = False) -> None:
+        raise PermissionError("read-only override")
+
+    monkeypatch.setattr(Path, "unlink", reject_removal)
+
+    with pytest.raises(InfraCheckoutError, match="read-only override"):
+        prepare_infra_checkout(repository)

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -154,6 +154,19 @@ class LifecycleParityTests(unittest.TestCase):
                 self.assertIn("^[0-9a-f]{40}$", content)
                 self.assertNotIn("clone --depth 1 --branch", content)
 
+    def test_preprovision_hooks_prepare_infra_before_moving_the_pin(self) -> None:
+        scripts = ROOT / "scripts"
+        for name in ("preProvision.ps1", "preProvision.sh"):
+            with self.subTest(script=name):
+                content = (scripts / name).read_text(encoding="utf-8-sig")
+                prepare = content.index("config.deployment.infra_checkout")
+                submodule_update = content.index("git submodule update")
+                exact_checkout = content.index("checkout --detach")
+                self.assertLess(prepare, submodule_update)
+                self.assertLess(prepare, exact_checkout)
+        shell = (scripts / "preProvision.sh").read_text(encoding="utf-8-sig")
+        self.assertIn("exit $INFRA_CHECKOUT_EXIT", shell)
+
     def test_postprovision_hooks_delegate_runtime_switch_to_shared_publisher(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- restore only provisioning-owned `infra/manifest.json` and `infra/main.parameters.json` before moving the AILZ checkout
- fail closed when unrelated tracked or untracked infra changes remain
- share the safety behavior across PowerShell and Bash hooks and cover pin upgrades with regression tests

Stacked follow-up to #621.

## Validation
- `python -m pytest tests/test_infra_checkout.py tests/test_release_contracts.py -q` (22 passed, 20 subtests passed)
- `python -m pytest -q` (261 passed, 96 subtests passed)
- PowerShell parser: passed for `scripts/preProvision.ps1`
- `bash -n scripts/preProvision.sh`: passed with Git Bash 5.3.15
- `python -m compileall -q config tests util`: passed
- `git diff --check`: passed

## Documentation
No user-facing contract changed; no documentation update is required.