### PR TITLE
fix: harden hosted topology rollback

### DIFF
--- a/config/deployment/rollback.json
+++ b/config/deployment/rollback.json
@@ -10,6 +10,10 @@
     "gpt-rag-ingestion": "v2.5.0"
   },
   "azd": {
+    "DEPLOYMENT_TOPOLOGY": "classic",
+    "CHAT_BACKEND": "orchestrator",
+    "PRESERVE_CLASSIC_RUNTIME": "false",
+    "HOSTED_CUTOVER_COMPLETE": "false",
     "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "false",
     "PREPARE_HOSTED_AGENT": "false",
     "DEPLOY_HOSTED_AGENT": "false",

--- a/config/deployment/topology.py
+++ b/config/deployment/topology.py
@@ -28,6 +28,7 @@ from config.deployment.composition import (
     DeploymentMode,
     DeploymentTopologyError,
     HOSTED_CUTOVER_COMPLETE,
+    HOSTED_IMAGE_DIGEST_PATTERN,
     PRESERVE_CLASSIC_RUNTIME,
     describe_mode,
     hosted_cutover_ready,
@@ -47,6 +48,13 @@ _PERSISTED_KEYS = (
     "DEPLOY_ADMINISTRATIVE_PANEL",
     "CHAT_BACKEND",
 )
+_LOCAL_RUNTIME_MARKERS = (
+    "CHAT_BACKEND",
+    PRESERVE_CLASSIC_RUNTIME,
+    HOSTED_CUTOVER_COMPLETE,
+    "HOSTED_AGENT_BASE_URL",
+    "HOSTED_AGENT_IMAGE_VERSION",
+)
 
 
 @dataclass(frozen=True)
@@ -63,12 +71,29 @@ def _local_migration_state(
     raw_preserve = environment.get(PRESERVE_CLASSIC_RUNTIME)
     if raw_preserve is None:
         backend = (environment.get("CHAT_BACKEND") or "").strip().lower()
-        if backend == "hosted_agent" or hosted_cutover_ready(environment):
+        legacy_hosted = bool(
+            mode is DeploymentMode.HOSTED_NO_PANEL
+            and is_truthy(
+                environment.get("DEPLOY_HOSTED_AGENT_ORCHESTRATION")
+            )
+            and (environment.get("HOSTED_AGENT_BASE_URL") or "").strip()
+            and HOSTED_IMAGE_DIGEST_PATTERN.fullmatch(
+                (environment.get("HOSTED_AGENT_IMAGE_VERSION") or "").strip()
+            )
+        )
+        if (
+            backend == "hosted_agent"
+            or hosted_cutover_ready(environment)
+            or legacy_hosted
+        ):
             return False
-        # Existing environments without a hosted marker are pre-cutover
-        # classic by ADR-0001. Preserve them without requiring access to a
-        # private App Configuration endpoint from the provisioning client.
-        return mode is not DeploymentMode.CLASSIC
+        if backend == "orchestrator":
+            return mode is not DeploymentMode.CLASSIC
+        # An explicit hosted selection without a durable runtime marker may
+        # be either a classic migration or incomplete hosted state. Resolve
+        # that ambiguity from persisted state and fail closed if it is
+        # unavailable.
+        return None
     normalized_preserve = raw_preserve.strip().lower()
     if normalized_preserve not in {"true", "false"}:
         raise DeploymentTopologyError(
@@ -214,6 +239,17 @@ def resolve_environment_plan(
         return TopologyResolution(explicit)
 
     rg_exists = resource_group_exists(resource_group_name, subscription_id)
+    has_local_runtime_marker = any(
+        (environment.get(key) or "").strip()
+        for key in _LOCAL_RUNTIME_MARKERS
+    )
+    if explicit is None and rg_exists and not has_local_runtime_marker:
+        # ADR-0001 defines an existing environment without any local topology
+        # marker as pre-cutover classic. In particular, do not require a
+        # workstation to reach a network-isolated App Configuration data
+        # plane merely to preserve that safe state.
+        return TopologyResolution(DeploymentMode.CLASSIC)
+
     materialized_preservation = (
         _local_migration_state(environment, explicit)
         if explicit is not None and rg_exists

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -5,6 +5,13 @@ import subprocess
 import unittest
 from pathlib import Path
 
+from config.deployment.composition import (
+    DeploymentMode,
+    compose_parameters,
+    materialized_settings,
+    resolve_mode,
+)
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -89,6 +96,14 @@ class IntegrationPinTests(unittest.TestCase):
         self.assertEqual(
             "false", rollback["azd"]["DEPLOY_ADMINISTRATIVE_PANEL"]
         )
+        self.assertEqual("classic", rollback["azd"]["DEPLOYMENT_TOPOLOGY"])
+        self.assertEqual("orchestrator", rollback["azd"]["CHAT_BACKEND"])
+        self.assertEqual(
+            "false", rollback["azd"]["PRESERVE_CLASSIC_RUNTIME"]
+        )
+        self.assertEqual(
+            "false", rollback["azd"]["HOSTED_CUTOVER_COMPLETE"]
+        )
         self.assertEqual(
             "orchestrator", rollback["appConfiguration"]["CHAT_BACKEND"]
         )
@@ -110,6 +125,50 @@ class IntegrationPinTests(unittest.TestCase):
                 for key, value in rollback["appConfiguration"].items()
                 if key != "label"
             },
+        )
+
+    def test_rollback_overrides_materialized_hosted_state_before_composition(
+        self,
+    ) -> None:
+        rollback = json.loads(
+            (ROOT / "config" / "deployment" / "rollback.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        environment = materialized_settings(
+            DeploymentMode.HOSTED_NO_PANEL,
+            hosted_cutover_complete=True,
+        )
+        environment.update(
+            {
+                "PREPARE_HOSTED_AGENT": "true",
+                "DEPLOY_HOSTED_AGENT": "true",
+                "HOSTED_AGENT_BASE_URL": (
+                    "https://agent.example.test/protocols"
+                ),
+                "HOSTED_AGENT_IMAGE_VERSION": "sha256:" + ("a" * 64),
+                "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+            }
+        )
+
+        environment.update(rollback["azd"])
+        composed = compose_parameters(
+            json.loads(
+                (ROOT / "main.parameters.json").read_text(encoding="utf-8")
+            ),
+            environment,
+        )
+        parameters = composed["parameters"]
+
+        self.assertEqual(DeploymentMode.CLASSIC, resolve_mode(environment))
+        self.assertFalse(parameters["prepareHostedAgent"]["value"])
+        self.assertFalse(parameters["deployHostedAgent"]["value"])
+        self.assertIn(
+            "orchestrator",
+            [
+                app["service_name"]
+                for app in parameters["containerAppsList"]["value"]
+            ],
         )
 
 

--- a/tests/test_topology_cli.py
+++ b/tests/test_topology_cli.py
@@ -115,18 +115,22 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
 
     @patch("config.deployment.topology.read_persisted_settings")
     @patch("config.deployment.topology.resource_group_exists")
-    def test_existing_environment_reads_persisted_settings(
+    def test_unmarked_existing_environment_stays_classic_without_private_lookup(
         self, mock_rg_exists: object, mock_read_settings: object
     ) -> None:
         mock_rg_exists.return_value = True
-        mock_read_settings.return_value = {"DEPLOYMENT_TOPOLOGY": "classic"}
+        mock_read_settings.side_effect = RuntimeError(
+            "private App Configuration is inaccessible"
+        )
 
         mode = topology.resolve_environment_topology(
-            {}, resource_group_name="rg-test", app_config_endpoint="https://x"
+            {},
+            resource_group_name="rg-test",
+            app_config_endpoint="https://private.example.test",
         )
 
         self.assertEqual(DeploymentMode.CLASSIC, mode)
-        mock_read_settings.assert_called_once_with("https://x")
+        mock_read_settings.assert_not_called()
 
     @patch("config.deployment.topology.read_persisted_settings")
     @patch("config.deployment.topology.resource_group_exists")
@@ -178,6 +182,7 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
 
         self.assertEqual(DeploymentMode.HOSTED_NO_PANEL, resolution.mode)
         self.assertTrue(resolution.preserve_classic_runtime)
+        mock_read_settings.assert_called_once_with("https://x")
 
     @patch("config.deployment.topology.read_persisted_settings")
     @patch("config.deployment.topology.resource_group_exists")
@@ -203,10 +208,11 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
 
     @patch("config.deployment.topology.read_persisted_settings")
     @patch("config.deployment.topology.resource_group_exists")
-    def test_unmarked_existing_hosted_request_preserves_classic_without_lookup(
+    def test_ambiguous_existing_hosted_request_preserves_persisted_classic(
         self, mock_rg_exists: object, mock_read_settings: object
     ) -> None:
         mock_rg_exists.return_value = True
+        mock_read_settings.return_value = {}
 
         resolution = topology.resolve_environment_plan(
             {"DEPLOYMENT_TOPOLOGY": "hosted-no-panel"},
@@ -215,6 +221,66 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
         )
 
         self.assertTrue(resolution.preserve_classic_runtime)
+        mock_read_settings.assert_called_once_with(
+            "https://private.example.test"
+        )
+
+    @patch("config.deployment.topology.read_persisted_settings")
+    @patch("config.deployment.topology.resource_group_exists")
+    def test_ambiguous_explicit_hosted_request_fails_when_state_is_inaccessible(
+        self, mock_rg_exists: object, mock_read_settings: object
+    ) -> None:
+        mock_rg_exists.return_value = True
+        mock_read_settings.side_effect = topology.DeploymentTopologyError(
+            "cannot safely continue"
+        )
+
+        with self.assertRaisesRegex(Exception, "cannot safely continue"):
+            topology.resolve_environment_plan(
+                {"DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true"},
+                resource_group_name="rg-test",
+                app_config_endpoint="https://private.example.test",
+            )
+
+    @patch("config.deployment.topology.read_persisted_settings")
+    @patch("config.deployment.topology.resource_group_exists")
+    def test_partial_local_state_fails_when_persisted_state_is_inaccessible(
+        self, mock_rg_exists: object, mock_read_settings: object
+    ) -> None:
+        mock_rg_exists.return_value = True
+        mock_read_settings.side_effect = topology.DeploymentTopologyError(
+            "cannot safely continue"
+        )
+
+        with self.assertRaisesRegex(Exception, "cannot safely continue"):
+            topology.resolve_environment_plan(
+                {"CHAT_BACKEND": "hosted_agent"},
+                resource_group_name="rg-test",
+                app_config_endpoint="https://private.example.test",
+            )
+
+    @patch("config.deployment.topology.read_persisted_settings")
+    @patch("config.deployment.topology.resource_group_exists")
+    def test_legacy_hosted_contract_stays_hosted_without_private_lookup(
+        self, mock_rg_exists: object, mock_read_settings: object
+    ) -> None:
+        mock_rg_exists.return_value = True
+
+        resolution = topology.resolve_environment_plan(
+            {
+                "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
+                "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+                "HOSTED_AGENT_BASE_URL": (
+                    "https://agent.example.test/protocols"
+                ),
+                "HOSTED_AGENT_IMAGE_VERSION": "sha256:" + ("a" * 64),
+            },
+            resource_group_name="rg-test",
+            app_config_endpoint="https://private.example.test",
+        )
+
+        self.assertEqual(DeploymentMode.HOSTED_NO_PANEL, resolution.mode)
+        self.assertFalse(resolution.preserve_classic_runtime)
         mock_read_settings.assert_not_called()
 
     @patch("config.deployment.topology.read_persisted_settings")


### PR DESCRIPTION
## Summary

- recognize durable legacy hosted deployments without requiring the new cutover/backend markers
- preserve truly unmarked existing classic environments without private App Configuration data-plane access while keeping ambiguous hosted paths fail-closed
- reset every canonical topology key in the classic rollback contract and verify rollback disables hosted composition

## Validation

- `python -m pytest tests/test_topology_cli.py tests/test_release_contracts.py tests/test_deployment_modes.py -q` (101 passed, 20 subtests)
- `python -m pytest -q` (265 passed, 96 subtests)
- PowerShell parser validation for `scripts/*.ps1`
- `bash -n scripts/*.sh` via Git Bash
- `python -m compileall -q config tests util`
- `git diff --check`

## Documentation

No published docs reference these internal merge-gate keys or rollback fixture; ADR-0001 already defines the preserved behavior.

## Stack

Base: `placerda-implement-hosted-default` (PR #617), including merged PR #623.