### PR TITLE
docs: refresh unpublished AILZ v2.5.0 state

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,15 +14,19 @@ separate choices.
     UI release PR
     [#94](https://github.com/Azure/gpt-rag-ui/pull/94) merged to `main` as
     [`763fa7e`](https://github.com/Azure/gpt-rag-ui/commit/763fa7eb2135037382673d2eb968421f084941cc),
-    and AI Landing Zone release PR
-    [#131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131) merged
-    to `main` as
+    while AI Landing Zone
+    [PR #131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131)
+    initially stamped and merged the unpublished `v2.5.0` state as
     [`a6ae728`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/a6ae7284d654abb7ec53810cb8765b2975b51baa).
-    However, UI `v2.6.0` and AI Landing Zone `v2.5.0` tags and GitHub Releases
-    are not published, and final umbrella pins, integrated validation, and the
-    GPT-RAG release remain incomplete. The diagrams document the approved
-    target, not shipped behavior. Current published GPT-RAG `v3.7.0` remains
-    classic.
+    [PR #132](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/132)
+    then fixed the local/CI size-gate defaults, and
+    [PR #133](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/133)
+    merged that correction to `main`. AILZ `main` and `develop` now both point
+    to [`cacf418`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/cacf418216ce7381d06263e0dd704a86b8a6f225).
+    No AILZ `v2.5.0` tag or GitHub Release exists; UI `v2.6.0` is also
+    unpublished. Final umbrella pins, integrated validation, and the GPT-RAG
+    release remain incomplete. The diagrams document the approved target, not
+    shipped behavior. Current published GPT-RAG `v3.7.0` remains classic.
 
 ## Full Zero Trust reference
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -62,15 +62,20 @@ only after the release gates below are complete.
     UI release PR
     [#94](https://github.com/Azure/gpt-rag-ui/pull/94) merged to `main` as
     [`763fa7e`](https://github.com/Azure/gpt-rag-ui/commit/763fa7eb2135037382673d2eb968421f084941cc),
-    and AI Landing Zone release PR
-    [#131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131) merged
-    to `main` as
+    while AI Landing Zone
+    [PR #131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131)
+    initially stamped and merged the unpublished `v2.5.0` state as
     [`a6ae728`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/a6ae7284d654abb7ec53810cb8765b2975b51baa).
-    However, UI `v2.6.0` and AI Landing Zone `v2.5.0` tags and GitHub Releases
-    are not published. Final umbrella pins, integrated validation, and a new
-    GPT-RAG release also remain. Current published GPT-RAG `v3.7.0` stays
-    classic. Use this workflow only with the release that explicitly announces
-    the hosted-default contract.
+    [PR #132](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/132)
+    then fixed the local/CI size-gate defaults, and
+    [PR #133](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/133)
+    merged that correction to `main`. AILZ `main` and `develop` now both point
+    to [`cacf418`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/cacf418216ce7381d06263e0dd704a86b8a6f225).
+    No AILZ `v2.5.0` tag or GitHub Release exists; UI `v2.6.0` is also
+    unpublished. Final umbrella pins, integrated validation, and a new GPT-RAG
+    release remain. Current published GPT-RAG `v3.7.0` stays classic. Use this
+    workflow only with the release that explicitly announces the hosted-default
+    contract.
 
 The upcoming release resolves one canonical topology before provisioning and
 materializes the corresponding legacy flags and App Configuration values.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,13 +24,19 @@ and required-vs-configurable deployment table.
     The diagram below is the approved target, not shipped behavior. The
     platform implementation merged in
     [Azure/GPT-RAG PR #617](https://github.com/Azure/GPT-RAG/pull/617). UI
-    release [PR #94](https://github.com/Azure/gpt-rag-ui/pull/94) and AI Landing
-    Zone release
+    release [PR #94](https://github.com/Azure/gpt-rag-ui/pull/94) merged. AI
+    Landing Zone
     [PR #131](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/131)
-    also merged, but UI `v2.6.0` and AI Landing Zone `v2.5.0` tags and GitHub
-    Releases are not published. Final umbrella pins, integrated validation,
-    and a new GPT-RAG release remain. Current published GPT-RAG `v3.7.0` stays
-    classic.
+    initially stamped and merged the unpublished `v2.5.0` state as
+    [`a6ae728`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/a6ae7284d654abb7ec53810cb8765b2975b51baa);
+    [PR #132](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/132)
+    fixed the local/CI size-gate defaults, and
+    [PR #133](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/133)
+    merged the correction to `main`. AILZ `main` and `develop` now both point to
+    [`cacf418`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/cacf418216ce7381d06263e0dd704a86b8a6f225),
+    but no AILZ `v2.5.0` tag or GitHub Release exists. UI `v2.6.0`, final
+    umbrella pins, integrated validation, and a new GPT-RAG release also remain
+    unpublished. Current published GPT-RAG `v3.7.0` stays classic.
 
 ![Chat runtime modes and hosted deployment lifecycle](media/architecture_chat_runtime_modes.svg)
 

--- a/docs/media/architecture_basic_deployment.svg
+++ b/docs/media/architecture_basic_deployment.svg
@@ -28,7 +28,7 @@
   <text x="46" y="72" class="subtitle">Fresh deployments use hosted/no-panel after release gates pass; UI and ingestion remain in Azure Container Apps.</text>
 
   <rect x="46" y="91" width="1188" height="42" rx="12" fill="#fff4ce" stroke="#f7630c" stroke-width="1.5"/>
-  <text x="66" y="117" class="status">Implementation merged but unreleased: component / AILZ tags, final umbrella pins, validation, and GPT-RAG release remain. v3.7.0 stays classic.</text>
+  <text x="66" y="117" class="status">Unreleased target: AILZ correction merged at cacf418; UI and AILZ tags, final pins, validation, and GPT-RAG release remain. v3.7.0 stays classic.</text>
 
   <rect x="46" y="153" width="1188" height="312" rx="22" fill="#ffffff" stroke="#d8e3f5" stroke-width="2"/>
   <text x="70" y="181" class="zone-title">Request path</text>

--- a/docs/media/architecture_chat_runtime_modes.excalidraw
+++ b/docs/media/architecture_chat_runtime_modes.excalidraw
@@ -53,7 +53,7 @@
       "y": 117,
       "width": 1250,
       "height": 60,
-      "text": "Implementation merged but unreleased: component / AILZ tags, final umbrella pins, integrated validation, and GPT-RAG release remain. v3.7.0 stays classic.",
+      "text": "Unreleased target: AILZ correction merged at cacf418; UI and AILZ tags, final pins, validation, and GPT-RAG release remain. v3.7.0 stays classic.",
       "fontSize": 13,
       "fontFamily": 2,
       "strokeColor": "#000000",

--- a/docs/media/architecture_chat_runtime_modes.svg
+++ b/docs/media/architecture_chat_runtime_modes.svg
@@ -31,7 +31,7 @@
   <text x="50" y="75" class="subtitle">A deployment chooses one runtime. Identity, authorization, conversation, and cost semantics never change silently during a request.</text>
 
   <rect x="50" y="94" width="1300" height="44" rx="12" fill="#fff4ce" stroke="#f7630c" stroke-width="1.5"/>
-  <text x="72" y="121" class="status">Implementation merged but unreleased: component / AILZ tags, final umbrella pins, integrated validation, and GPT-RAG release remain. v3.7.0 stays classic.</text>
+  <text x="72" y="121" class="status">Unreleased target: AILZ correction merged at cacf418; UI and AILZ tags, final pins, validation, and GPT-RAG release remain. v3.7.0 stays classic.</text>
 
   <rect x="50" y="162" width="1300" height="108" rx="20" fill="#edf7ff" stroke="#3f7dc7" stroke-width="2"/>
   <text x="74" y="191" class="section-title">Shared entry and topology selection</text>

--- a/docs/media/architecture_modular_layers.svg
+++ b/docs/media/architecture_modular_layers.svg
@@ -20,7 +20,7 @@
   <text x="48" y="80" class="subtitle">The chat runtime is mode-selected inside the baseline: hosted for fresh deployments after release gates, Container Apps as explicit fallback.</text>
 
   <rect x="48" y="101" width="1004" height="42" rx="12" fill="#fff4ce" stroke="#f7630c" stroke-width="1.5"/>
-  <text x="68" y="127" class="note">Implementation merged but unreleased: component / AILZ tags, final umbrella pins, integrated validation, and GPT-RAG release remain.</text>
+  <text x="68" y="127" class="note">Unreleased target: AILZ correction merged at cacf418; UI and AILZ tags, final pins, validation, and GPT-RAG release remain.</text>
 
   <rect x="50" y="161" width="22" height="16" rx="4" fill="#3f7dc7"/>
   <text x="84" y="174" class="legend">Basic baseline</text>


### PR DESCRIPTION
## Summary
- replace AILZ PR #131 / `a6ae728` as the last unpublished `v2.5.0` state with the subsequent size-gate correction history from PRs #132 and #133
- record that AILZ `main` and `develop` both point to `cacf418216ce7381d06263e0dd704a86b8a6f225`
- refresh Architecture, Deployment, Home, SVG, and editable Excalidraw status banners without presenting the hosted-default target as shipped

## Release status
- AILZ PR #131 initially stamped and merged the unpublished `v2.5.0` state.
- AILZ PR #132 corrected local/CI size-gate defaults; PR #133 merged the correction to `main`.
- No AILZ `v2.5.0` tag or GitHub Release exists.
- Current published GPT-RAG `v3.7.0` remains classic. Final pins, integrated validation, and release publication remain gated.

## Validation
- `python -m mkdocs build --strict --clean` — passed
- changed SVG XML and accessibility metadata validation — passed (3 files)
- Excalidraw JSON, unique-ID, text-dimension, black-text, transparent-container, and non-negative-dimension validation — passed (62 elements)
- Markdown media-reference validation — passed (31 local references)
- stale status scan and `git diff --check` — passed

Documentation only. No application code, Azure resources, tags, releases, publication, deployment, or merge is included.