### PR TITLE
fix(provision): resolve Foundry project exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@
 
 ### Fixed
 
+- **AI Foundry project endpoint discovery.** Windows post-provisioning now
+  resolves project child resources through the generic ARM resource API,
+  validates an explicit `AI_FOUNDRY_PROJECT_NAME` when supplied, and fails
+  closed unless exactly one project is selected. It no longer silently
+  publishes an invalid `aifoundry-default-project` endpoint when the installed
+  Azure CLI lacks the specialized project-list command.
+
 - **Windows jumpbox deployment imports the repository package reliably.**
   `preDeploy.ps1` now establishes the repository root on `PYTHONPATH` and
   invokes deployment modules through `runpy`, avoiding Windows Python

--- a/scripts/postProvision.ps1
+++ b/scripts/postProvision.ps1
@@ -309,15 +309,50 @@ function Set-GptRagAppConfiguration {
         -Type 'Microsoft.CognitiveServices/accounts' `
         -Fallback "aif-$nameSuffix"
 
-    # AI Foundry project (child of foundry account) - resolve via CLI
-    $foundryProjectName = 'aifoundry-default-project'
-    try {
-        $projJson = az cognitiveservices account list-projects -g $resourceGroup -n $foundryName -o json 2>$null
-        if ($LASTEXITCODE -eq 0 -and $projJson) {
-            $projs = $projJson | ConvertFrom-Json
-            if ($projs.Count -ge 1) { $foundryProjectName = $projs[0].name }
+    # Resolve the project through generic ARM discovery because the specialized
+    # project-list command is absent from some supported Azure CLI versions.
+    $requestedFoundryProjectName = Get-OptionalEnvValue 'AI_FOUNDRY_PROJECT_NAME'
+    $foundryAccountResourceId = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroup/providers/Microsoft.CognitiveServices/accounts/$foundryName"
+    $projectJson = Invoke-NativeCommand {
+        & az resource list `
+            --subscription $subscriptionId `
+            --resource-group $resourceGroup `
+            --resource-type 'Microsoft.CognitiveServices/accounts/projects' `
+            -o json 2>$null
+    }
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($projectJson)) {
+        Write-Error "Failed to discover the AI Foundry project under '$foundryName'."
+        exit 1
+    }
+
+    $foundryProjects = @(
+        $projectJson |
+            ConvertFrom-Json |
+            Where-Object {
+                $_.id.StartsWith(
+                    "$foundryAccountResourceId/projects/",
+                    [StringComparison]::OrdinalIgnoreCase
+                )
+            }
+    )
+    if (-not [string]::IsNullOrWhiteSpace($requestedFoundryProjectName)) {
+        $foundryProjects = @(
+            $foundryProjects |
+                Where-Object {
+                    (Split-Path $_.id -Leaf) -eq $requestedFoundryProjectName
+                }
+        )
+    }
+    if ($foundryProjects.Count -ne 1) {
+        $selectionHint = if ([string]::IsNullOrWhiteSpace($requestedFoundryProjectName)) {
+            'Set AI_FOUNDRY_PROJECT_NAME when the account contains more than one project.'
+        } else {
+            "No unique project matched AI_FOUNDRY_PROJECT_NAME='$requestedFoundryProjectName'."
         }
-    } catch { }
+        Write-Error "Expected exactly one AI Foundry project under '$foundryName', found $($foundryProjects.Count). $selectionHint"
+        exit 1
+    }
+    $foundryProjectName = Split-Path $foundryProjects[0].id -Leaf
 
     # Container Registry / Container Apps Env / Log Analytics / App Insights
     $acrName = _resolveResource `

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -290,6 +290,22 @@ class LifecycleParityTests(unittest.TestCase):
             (scripts / "postProvision.sh").read_text(encoding="utf-8-sig"),
         )
 
+    def test_postprovision_fails_closed_when_foundry_project_is_unresolved(
+        self,
+    ) -> None:
+        content = (ROOT / "scripts" / "postProvision.ps1").read_text(
+            encoding="utf-8-sig"
+        )
+
+        self.assertIn(
+            "Microsoft.CognitiveServices/accounts/projects",
+            content,
+        )
+        self.assertIn("$foundryProjects.Count -ne 1", content)
+        self.assertIn("AI_FOUNDRY_PROJECT_NAME", content)
+        self.assertNotIn("aifoundry-default-project", content)
+        self.assertNotIn("cognitiveservices account list-projects", content)
+
     def test_predeploy_hooks_gate_cutover_on_success_marker(self) -> None:
         scripts = ROOT / "scripts"
         for name in ("preDeploy.ps1", "preDeploy.sh"):


### PR DESCRIPTION
## Summary
- resolve AI Foundry child projects through generic ARM discovery supported by current Azure CLI
- validate an explicit project selection and fail closed unless exactly one project matches
- remove the silent invalid default-project endpoint fallback

## Validation
- 277 tests passed, including 96 subtests
- independently reviewed; subscription scoping finding fixed