### PR TITLE
docs(adr): publish ADR-0003 hosted conversation continuity and ADR-0004 panel contract

### DIFF
--- a/docs/adr/ADR-0003-hosted-conversation-continuity.md
+++ b/docs/adr/ADR-0003-hosted-conversation-continuity.md
@@ -1,0 +1,639 @@
+# ADR-0003: Multi-turn continuity for the hosted-agent Responses path across compute/version replacement
+
+**Status:** Proposed<br>
+**Date:** 2026-08-07<br>
+**Owners:** GPT-RAG maintainer (Paulo), architecture analysis, with gpt-rag-ui and gpt-rag-orchestrator component owners (revised after independent security review)
+
+> **Revision note (2026-08-07, superseded in part by ADR-0004).** Two points in
+> this ADR are tightened by ADR-0004 after security review, and this ADR is
+> updated to match:
+>
+> 1. **Persistence/replay location.** ADR-0004's approved invariant is that the
+>    hosted **container holds zero managed-Conversations data-plane RBAC (neither
+>    read nor write)**, because the Foundry gateway strips the user token so the
+>    container has no authenticated identity and could only act on forgeable
+>    caller metadata. Therefore the container is **purely stateless** — it
+>    receives a complete ordered input set and returns output — and **all**
+>    managed-Conversation read/append/persist plus continuity move to the
+>    **authenticated UI BFF**. Where this ADR says "inside the hosted agent the
+>    application retrieves/replays/persists," read "**the UI BFF** retrieves,
+>    replays, and persists."
+> 2. **How the logical ID is carried.** The stable logical conversation
+>    identifier is **not** carried as a raw resource ID in request metadata that
+>    a service could act on. It is carried as a **server-issued, signed,
+>    opaque, owner-bound capability** minted by the BFF from the validated user
+>    `oid` (`{oid, conversation_resource_id, issued_at, expiry, key_id}`), so no
+>    caller-selected ID drives a read and a direct caller cannot forge ownership.
+>    The capability requires **no store**, so continuity holds in
+>    **hosted/no-panel with zero Cosmos**. See ADR-0004 for the capability
+>    design, key rotation, replay/theft handling, and the panel-only owner index
+>    used solely for cross-conversation enumeration.
+
+
+## Context
+
+ADR-0001 chose Option 1: package GPT-RAG orchestration as a Microsoft Foundry
+hosted agent, with the Chainlit UI as a thin BFF speaking Responses, and made
+the orchestrator Container Apps optional. ADR-0001 froze two relevant
+contracts: hosted modes use **Foundry managed Conversations** as chat history
+system of record (no Cosmos in hosted/no-panel), and hosted versions are
+**immutable, one version serves 100% of traffic, update = publish new version +
+switch, rollback = revert version**.
+
+The canonical Foundry Responses v2 path is implemented in
+`Azure/gpt-rag-orchestrator` `develop` (through PR #304). The hosted agent
+container explicitly persists user and assistant items into Foundry managed
+Conversations.
+
+### Observed blocker (evidence)
+
+In a real `NETWORK_ISOLATION=true` deployment using an immutable image digest:
+
+- Turn 1 works. The managed Conversation Items remain readable through the
+  Conversations data API after the hosted compute/version is replaced.
+- When the same **top-level Responses `conversation` ID** is reused on the
+  replacement version, the Foundry hosted `/responses` gateway returns
+  **HTTP 404**. It also 404s after routing back to the original version.
+- A fresh request (no reuse of the prior top-level `conversation`) succeeds.
+
+Conclusion supported by the evidence: the 404 is **platform pre-routing /
+session-affinity behavior that executes before the application runs**. It is
+not missing persisted data — the managed Conversation Items (the system of
+record) are intact and readable. Two distinct Foundry constructs are being
+conflated:
+
+1. **Managed Conversations** — a durable data-plane store of items. Survives
+   compute/version replacement. Readable. System of record (ADR-0001).
+2. **The `/responses` gateway session binding keyed by the top-level
+   `conversation` parameter** — a control-plane routing/session construct
+   coupled to the serving version/compute session. Does **not** survive
+   immutable-version or compute replacement.
+
+Because ADR-0001's supported update model *is* version replacement, any
+continuity mechanism that depends on construct (2) is structurally broken by
+the platform's own update path.
+
+### Security correction (why this ADR was revised)
+
+A previous revision of this ADR chose an application-managed mechanism that
+carried a **stable logical managed-Conversation ID in request metadata** and
+then had the **hosted agent container** read prior items from managed
+Conversations, replay them, run the turn, and append the new items — all inside
+the container. An independent security review found this **SECURITY-INVALID**
+and it is **withdrawn**:
+
+- The Foundry gateway strips the `Authorization` header, so the **user token
+  never reaches the container** (ADR-0001, "User identity and document-level
+  security"). Any container-side managed-Conversations read is therefore a
+  **service-identity** read.
+- Letting a **caller-supplied logical conversation ID** drive a
+  **service-identity** read is a textbook **confused-deputy / BOLA (IDOR)**:
+  caller A can pass caller B's conversation ID and the hosted service credential
+  would read and replay B's history. Per-user isolation is lost.
+- It also requires granting the container a managed-Conversations data-plane
+  **read** role, breaking the history-blindness invariant reaffirmed in
+  ADR-0004.
+
+The corrected model, decided below, moves **all** authorized managed-Conversation
+create/read/append/delete into the **authenticated UI BFF** (which holds the end
+user's Entra identity and can bind ownership), and reduces the hosted container
+to a **stateless, history-blind** compute that receives complete bounded ordered
+Responses input and returns output. This is consistent with ADR-0004's
+owner-bound, fail-closed contract and its OQ-OWN read-mechanism selector.
+
+### Acceptance criteria (from the task)
+
+- Stable logical multi-turn continuity **across compute/version replacement**.
+- Canonical Responses interoperability (stateless caller-supplies-input mode).
+- **Fail-closed security**: no service-identity read driven by a caller-selected
+  ID; no unauthorized cross-user read; no silent success-shaped fallback; a
+  read/append failure must **not** silently start a fresh thread.
+- **Owner-bound history**: the BFF authenticates the end user and binds
+  conversation ownership before any read; non-owner and missing return
+  **indistinguishable 404**.
+- **History-blind, stateless container**: the hosted container holds **zero**
+  managed-Conversations data-plane RBAC (no create/read/append/delete) and
+  cannot select server-side history; direct hosted-agent calls stay stateless.
+- No Cosmos chat content in hosted/no-panel; if an owner index is needed (Option
+  A), only owner-binding **metadata** is stored, never content.
+- Delegated OBO / Toolbox retrieval authorization preserved **separately** from
+  history ownership (ADR-0001 INV-002, `POST /retrieve` boundary unchanged).
+- Managed Conversation items remain the system of record; the BFF reads/appends,
+  the container only generates output.
+
+### Affected repositories
+
+- `Azure/gpt-rag-ui` — thin **BFF** (`orchestrator_client.py`, `hosted_agent`
+  path). **Owner of continuity**: authenticates the end user, binds conversation
+  ownership, reads managed-Conversation history, builds the complete bounded
+  ordered stateless Responses input, calls the hosted agent, and appends the new
+  turns to managed Conversations. Holds the only end-user token in the hosted
+  path.
+- `Azure/gpt-rag-orchestrator` — hosted-agent Responses v2 adapter. Reduced to
+  **stateless generation**: consume the caller-supplied input items, run the
+  turn, return output. **Removes** container-side managed-Conversations
+  read/replay/append. Preserves the Toolbox/OBO retrieval path and the
+  `POST /retrieve` fail-closed boundary unchanged.
+- `Azure/GPT-RAG` (this repo) — App Configuration contract (label `gpt-rag`),
+  ADR record, and the `contracts/` continuity/owner-binding schema. Holds all
+  **GPT-RAG-specific** history policy.
+- `Azure/bicep-ptn-aiml-landing-zone` (**AILZ**) — generic landing-zone infra
+  (consumed via the `infra/` submodule). Stays generic: it must **not** encode
+  GPT-RAG history policy. Its only obligation here is to ensure the hosted-agent
+  identity carries **no** managed-Conversations data-plane role at all — no
+  create, read, append, or delete, and no append-only or write-only variant
+  either. Zero role, full stop; nothing is assumed or carved out. GPT-RAG-specific
+  policy stays in GPT-RAG.
+
+### Prioritized characteristics (measures)
+
+1. **Security fail-closedness / authorization correctness** — no caller-ID-driven
+   service read; no cross-user read; non-owner and missing return an
+   indistinguishable 404; read/append failure fails closed (no fresh-thread
+   masquerade). (Two-user negative tests.)
+2. **Continuity durability** — a turn on logical conversation `C` returns prior
+   context after the serving version/compute is replaced, with no gateway 404.
+   (Binary pass/fail in the isolated topology.)
+3. **Container history-blindness** — the hosted-agent identity holds no
+   Conversations data-plane read role and cannot select server history. (RBAC
+   assertion / infra review; stateless-input contract test.)
+4. **Content confinement** — no Cosmos chat content in hosted/no-panel; any owner
+   index stores metadata only. (Store-inspection tests.)
+5. **Protocol interoperability & operability** — request/response conform to the
+   Responses stateless input-items schema; continuity is independent of which
+   version is serving and is rollback-safe behind one config switch.
+   (Schema conformance + version-swap matrix.)
+
+## Alternatives considered
+
+### Option A: Keep top-level `conversation`; declare a platform blocker
+
+Continue passing the top-level Responses `conversation` ID and document that
+cross-version continuity is unsupported until Foundry changes gateway session
+behavior.
+
+- Benefits: zero code change; strictly uses the platform's canonical
+  server-side threading; honest about the limitation.
+- Costs and risks: **fails acceptance**. In the ADR-0001 model, update = new
+  version, so every routine update breaks continuity with a raw 404. Users lose
+  their thread on ordinary operations, not just incidents.
+- Security and identity: unchanged.
+- Operational consequences: hosted/no-panel is effectively single-version-only
+  for continuity; incompatible with the supported update/rollback path.
+- Component compatibility: no change.
+- Reversibility: n/a (no change).
+
+### Option B: Container-side replay keyed by a caller-supplied logical Conversation ID (WITHDRAWN — security-invalid)
+
+Carry a stable logical managed-Conversation ID in Responses **request metadata**
+and have the **hosted agent container** validate it, read prior items from
+managed Conversations, replay them as input, run the turn, and append the new
+items — all inside the container using the container/service identity.
+
+- **Rejected on security grounds (confused-deputy / BOLA / IDOR).** The gateway
+  strips `Authorization`, so the container has no user token; its
+  managed-Conversations read is necessarily a **service-identity** read. Driving
+  that read from a **caller-selected** conversation ID lets any caller replay any
+  other caller's history. This is the exact anti-pattern ADR-0004 Option C
+  rejects.
+- It also requires granting the container a managed-Conversations **read** role,
+  breaking history-blindness.
+- No append-only-that-cannot-read role is assumed to exist; even if it did, it
+  would not make the caller-ID-driven **read** safe.
+- **Explicit rejection of container replay:** the hosted container must never
+  read or select server-side history. Withdrawn; retained here only to record the
+  correction.
+
+### Option C: BFF-mediated stateless replay with owner-bound history (chosen)
+
+Move all authorized managed-Conversation **create/read/append/delete** into the
+authenticated **gpt-rag-ui BFF**, and make the hosted container **stateless and
+history-blind**. Each turn:
+
+1. The BFF **authenticates the end user** (it holds the Entra token) and
+   **binds conversation ownership** for the logical conversation **before any
+   read**. Ownership is enforced by the mechanism selected under OQ-OWN:
+   **`capability`** (default, safe today, **store-free** — a server-issued,
+   signed, opaque, owner-bound capability whose embedded `oid` the BFF re-checks
+   against the live token before any read; works in **hosted/no-panel with zero
+   Cosmos**) or **`delegated`** (native per-user reads, **inert** until live
+   OQ-OWN evidence proves per-user enforcement for the precise token/call path).
+   A raw caller-selected ID is never accepted. Non-owner, forged/expired
+   capability, and missing all return an **indistinguishable 404**. (The
+   panel-only **owner index** in Cosmos is used solely for cross-conversation
+   *enumeration* when the panel is deployed; it is **not** the continuity
+   binding.)
+2. On an owner hit, the BFF **reads** the ordered managed-Conversation items and
+   builds the **complete, bounded, ordered, stateless Responses input** (bounded
+   by an explicit history policy). A read failure **fails closed** (error to the
+   user) and must **not** silently start a fresh thread.
+3. The BFF calls the hosted agent with a **fresh `/responses` request** carrying
+   the full input items — **no** top-level `conversation` param and **no**
+   `previous_response_id`. The gateway performs no version-bound pre-routing and
+   cannot 404 on a stale session.
+4. The **container generates output statelessly** and returns it. It performs
+   **no** read, replay, or persist.
+5. The BFF **appends** the new user and assistant turns to managed Conversations
+   (the SoR), using an **idempotent client turn ID**, under a **one-in-flight-turn
+   per conversation** constraint initially. An append failure **fails closed**;
+   the turn is not reported as durably persisted.
+
+- Benefits: eliminates the confused-deputy path (no caller-ID-driven service
+  read; ownership bound where the user token exists); continuity depends only on
+  the durable store, which survives version/compute replacement (proven); keeps
+  managed Conversations as SoR; no Cosmos chat content; container stays
+  history-blind and stateless; consistent with ADR-0004.
+- Costs and risks: the BFF owns threading mechanics (owner-binding, read, bounded
+  replay, append), concurrency/idempotency, and a bounded-history policy. Full
+  input per turn costs tokens/latency and needs explicit truncation or
+  summarization. In `capability` mode the BFF signs/verifies a store-free
+  capability (key in Key Vault, rotation via key version, short TTL with rolling
+  re-mint; no fine-grained per-capability revocation in no-panel). The panel-only
+  owner index, when present, is metadata-only and must stay consistent with the
+  SoR (worst case: a 404 or a stale list row, never content disclosure).
+- Security and identity: **three concerns kept separate** — (a) **history
+  ownership** enforced by the BFF before any read; (b) **delegated OBO/Toolbox
+  retrieval authorization** (document-level trimming) carried to Search via the
+  existing passthrough, unchanged and independent of history ownership; (c) the
+  **identity authenticating the Foundry `/responses` endpoint call**. Carried
+  user context (b) is never conflated with the endpoint-call identity (c), and
+  neither is treated as a history-ownership claim (a).
+- Operational consequences: continuity is independent of the serving version;
+  rollback-safe; matches the immutable-version model; **no new always-on compute
+  and no store in hosted/no-panel** (continuity uses the store-free capability;
+  the owner index exists only when the panel/Cosmos is deployed, for enumeration).
+- Component compatibility: coordinated change across gpt-rag-ui (BFF owner) and
+  gpt-rag-orchestrator (adapter reduced to stateless generation); one App
+  Configuration selector and one `contracts/` schema in Azure/GPT-RAG; AILZ stays
+  generic.
+- Reversibility: single App Configuration switch; when continuity is off, the
+  path degrades to safe **single-turn stateless** behavior, never to an
+  unauthorized read.
+
+### Option D: BFF/gateway detects version change and mints a new platform conversation, linking/replaying managed history
+
+Keep the top-level `conversation` for within-version continuity; on detecting a
+version change (or a 404), the BFF creates a **new** platform conversation,
+replays managed history into it, and maintains a logical→(version, platform
+conversation) mapping.
+
+- Benefits: retains the platform's server-side auto-threading within a version.
+- Costs and risks: highest complexity. The BFF must reliably detect version
+  changes, own extra mapping state, and recover from 404 mid-conversation.
+  Still depends on the fragile version-bound session for the common path.
+  Concurrent turns during a version swap create races and duplicate/interleaved
+  platform conversations. More moving parts on a preview control-plane behavior.
+- Security and identity: unchanged, but the added BFF state widens surface.
+- Operational consequences: 404-driven recovery is user-visible latency/retry;
+  hard to test deterministically against a preview platform.
+- Component compatibility: heavier BFF change; adds durable mapping state to a
+  component ADR-0001 wants thin.
+- Reversibility: moderate; the mapping/recovery logic is not a single switch.
+
+### Option E: `previous_response_id` (or another official lifecycle pointer)
+
+Chain turns with `previous_response_id` referencing the prior `resp_...`.
+
+- Benefits: canonical chaining primitive.
+- Costs and risks: same class of failure as Option A. `previous_response_id`
+  points to a response object served by a version/session; it is expected to be
+  version/compute-bound and does not reference the managed Conversation SoR.
+  Does not solve cross-version continuity and arguably worsens SoR alignment.
+- Security/operational/compatibility/reversibility: no advantage over A/C.
+
+### Do not change (Option F)
+
+- Benefits: none beyond deferral.
+- Costs and risks: ships a hosted/no-panel experience that loses the thread on
+  every routine version update; fails acceptance; erodes trust in the mode.
+
+## Decision
+
+Adopt **Option C**. Hosted-mode multi-turn continuity is **BFF-mediated,
+owner-bound, and stateless at the container**. The authenticated **gpt-rag-ui
+BFF** owns authorized managed-Conversation **create/read/append/delete**: it
+authenticates the end user, binds conversation ownership before any read, reads
+the ordered items from **Foundry managed Conversations (system of record)**,
+builds the **complete, bounded, ordered, stateless Responses input**, calls the
+hosted agent with a fresh `/responses` request (no top-level `conversation`, no
+`previous_response_id`), and appends the new turns back to managed Conversations.
+The **hosted container is history-blind and stateless**: it holds **zero**
+managed-Conversations data-plane RBAC and only generates output from the input it
+is given. **Container-side replay and any caller-ID-driven service read are
+prohibited (Option B withdrawn).**
+
+The **owner-binding mechanism is a selector** consistent with ADR-0004,
+defaulting to the safe, **store-free** state so continuity holds in
+hosted/no-panel:
+
+- `capability` (**default**): a server-issued, signed, opaque, owner-bound
+  capability minted by the BFF from the validated user `oid`
+  (`{oid, conversation_resource_id, issued_at, expiry, key_id}`). The BFF
+  re-checks the capability `oid` against the live token before any read. Requires
+  **no store** (signing key in Key Vault, provisioned like `AUDIT-HMAC-KEY`), so
+  it works in **hosted/no-panel with zero Cosmos**. Safe today; no dependency on
+  an unproven platform capability.
+- `delegated` (**target, gated**): native per-user managed-Conversations reads as
+  the user. **Inert** until the live **OQ-OWN** two-user experiment proves actual
+  per-user enforcement for the precise token/call path; only then may it be
+  enabled.
+
+A raw caller-selected conversation ID is **never** accepted as a read key. The
+panel-only **owner index** (Cosmos) exists solely for cross-conversation
+**enumeration** when the panel is deployed and stores **only** owner-binding
+metadata (principal ID, conversation ID, title, timestamps) — **never** message
+content. No Cosmos chat content exists in hosted/no-panel.
+
+### Identity separation (non-negotiable)
+
+Three distinct identities/authorizations must not be conflated:
+
+1. **History ownership** — enforced by the BFF against the authenticated end user
+   before any read; non-owner and missing both return **404**.
+2. **Delegated OBO/Toolbox retrieval authorization** — the user context carried
+   to Foundry IQ/Search for native document-level trimming (ADR-0001 target
+   path). Unchanged by this ADR and independent of history ownership.
+3. **Foundry `/responses` endpoint-call identity** — whatever credential
+   authenticates the BFF→gateway call. Never treated as, or derived from, the
+   carried user context (2) or a history-ownership claim (1).
+
+### App Configuration contract (label `gpt-rag`, owned by Azure/GPT-RAG)
+
+Defaults preserve safe behavior; enabling requires explicit evidence gates.
+These align with ADR-0004's panel keys and the `POST /retrieve` idiom.
+
+- `HOSTED_CONTINUITY_ENABLED` (default `false`) — when `false`, the hosted path
+  is **single-turn stateless** (no server history, safe). When `true`, the BFF
+  performs owner-bound read + bounded replay + append.
+- `HOSTED_CONVERSATION_OWNER_BINDING` (default `capability`; alt `delegated`) —
+  selects the owner-binding mechanism; `delegated` is inert until the validation
+  gate is set. Same key as ADR-0004.
+- `HOSTED_CONVERSATION_CAPABILITY_KEY` / `HOSTED_CONVERSATION_CAPABILITY_KEY_ID` /
+  `HOSTED_CONVERSATION_CAPABILITY_TTL_SECONDS` — Key Vault-referenced signing key
+  (provisioned like `AUDIT-HMAC-KEY`), active key version for rotation, and
+  capability lifetime with rolling re-mint. Present in **all** modes; no store.
+- `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED` (default `false`) — the **OQ-OWN
+  evidence gate**, mirroring `HOSTED_RETRIEVAL_INV_002_VALIDATED`. Continuity in
+  `delegated` mode stays disabled (safe capability/stateless) unless this is
+  `true`.
+- `HOSTED_CONVERSATIONS_TOKEN_AUDIENCE` — managed-Conversations query-token
+  audience for `delegated` mode (analogous to `HOSTED_RETRIEVAL_TOKEN_AUDIENCE`);
+  required only when `delegated`.
+- `HOSTED_HISTORY_MAX_ITEMS` / `HOSTED_HISTORY_MAX_TOKENS` — explicit bounded
+  history policy for the replayed input.
+- `HOSTED_HISTORY_TRUNCATION` (default `drop_oldest`; alt `summarize`) — bound
+  strategy when the policy limit is exceeded.
+
+If a typed field is warranted (the continuity/capability envelope), it is added
+under `contracts/` and byte-pinned like `audit-event-v1`. **AILZ carries no
+GPT-RAG history policy**; it only guarantees the container identity holds no
+Conversations read/write role and no capability signing key.
+
+### Honest scope statement (protocol vs. continuity)
+
+We do **not** invent a platform contract. In the current Foundry preview you
+cannot simultaneously have (a) reliance on the platform's server-side
+`conversation` / `previous_response_id` session threading and (b) stable
+continuity across the platform's own immutable-version replacement. Therefore:
+
+- **Preserved and canonical:** the Responses **request/response wire contract**,
+  specifically the stateless "caller supplies input items" mode, which is a
+  supported canonical usage of Responses. Interoperability of the message shape
+  is intact.
+- **Explicitly out of supported scope (preview / platform-limited):** durable
+  cross-version continuity via the platform's server-side stateful
+  `conversation` auto-loading and `previous_response_id` chaining. These are
+  documented as **not durable across immutable-version replacement** and are not
+  the GPT-RAG continuity mechanism.
+- **Explicitly rejected:** container-side history read/replay of any kind, and
+  any service-identity read driven by a caller-selected conversation ID.
+
+## Consequences
+
+### Positive
+
+- No confused-deputy/BOLA path: the container never reads history, and no
+  caller-selected ID ever drives a service-identity read.
+- Continuity survives compute/version replacement and rollback, matching the
+  ADR-0001 update model, because it depends only on the durable SoR.
+- Managed Conversations stays the single system of record; the BFF reads/appends,
+  the container only generates; no Cosmos chat content in hosted/no-panel.
+- History ownership, delegated retrieval authorization, and endpoint-call
+  identity remain cleanly separated; INV-002 / `POST /retrieve` untouched.
+- Safe under OQ-OWN uncertainty: **store-free `capability`** ships now (works in
+  hosted/no-panel with zero Cosmos); `delegated` is a config flip after live
+  proof. Reversible behind one App Configuration switch.
+
+### Negative or accepted
+
+- The BFF owns threading mechanics (owner-binding, read, bounded replay, append),
+  concurrency/idempotency, and the bounded-history policy — more logic in a
+  component ADR-0001 wants thin.
+- Per-turn token/latency cost of sending full bounded input; requires the
+  explicit truncation/summarization bound.
+- In `capability` mode the BFF signs/verifies a store-free capability (Key
+  Vault-backed key, rotation via key version, short TTL + rolling re-mint); no
+  fine-grained per-capability revocation in no-panel (bounded by TTL + rotation).
+  The panel-only owner index, when present, is metadata-only and must stay
+  consistent with the SoR (at worst a 404 or stale list row, never content
+  disclosure).
+- Gives up the platform's server-side auto-threading convenience while the
+  preview limitation stands.
+- Reconciled with ADR-0004: managed-Conversation create/read/append/delete and
+  ownership belong to the **BFF**, not the container; the container is stateless
+  with zero Conversations RBAC and no signing key.
+
+## Adoption and migration
+
+Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
+
+1. **Azure/GPT-RAG** — freeze the App Configuration contract (label `gpt-rag`):
+   add `HOSTED_CONTINUITY_ENABLED`, `HOSTED_CONVERSATION_OWNER_BINDING`,
+   `HOSTED_CONVERSATION_CAPABILITY_KEY` (Key Vault ref, provisioned like
+   `AUDIT-HMAC-KEY`), `HOSTED_CONVERSATION_CAPABILITY_KEY_ID`,
+   `HOSTED_CONVERSATION_CAPABILITY_TTL_SECONDS`,
+   `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`,
+   `HOSTED_CONVERSATIONS_TOKEN_AUDIENCE`, `HOSTED_HISTORY_MAX_ITEMS`,
+   `HOSTED_HISTORY_MAX_TOKENS`, `HOSTED_HISTORY_TRUNCATION`, all defaulting to the
+   safe state (continuity off, `capability`, validation gate `false`). Add the
+   `contracts/` continuity/capability envelope schema + `.sha256` if a typed field
+   is warranted. Publish this ADR. No runtime behavior change yet.
+2. **gpt-rag-orchestrator** — reduce the hosted-agent Responses v2 adapter to
+   **stateless generation**: consume the caller-supplied bounded ordered input
+   items and return output. **Remove** any container-side managed-Conversations
+   read/replay/append and any dependency on the top-level `conversation` /
+   `previous_response_id` for continuity. Emit `audit-event-v1` for
+   turn-generated and legacy-404-detected (metadata only). No Conversations
+   read/write role and no capability signing key on the container identity.
+3. **gpt-rag-ui** — in the `hosted_agent` BFF path: authenticate the end user;
+   bind conversation ownership (`capability` default — mint on create, verify
+   signature + expiry + `oid` equality) before any read; read ordered items from
+   managed Conversations; build the complete bounded ordered stateless Responses
+   input; call the hosted agent with a fresh `/responses` request (no top-level
+   `conversation`, no `previous_response_id`); append the new user/assistant turns
+   to managed Conversations with an idempotent client turn ID; enforce one
+   in-flight turn per conversation; re-mint a fresh capability on success; fail
+   closed on read or append failure (no fresh-thread masquerade). Non-owner,
+   forged/expired capability, and missing → 404.
+4. **AILZ (`bicep-ptn-aiml-landing-zone`)** — no GPT-RAG history policy. Confirm
+   (infra/RBAC review) the hosted-agent identity carries **no**
+   managed-Conversations data-plane read/write role and **no** capability signing
+   key; Conversations RBAC and the signing key belong to the **BFF identity**
+   only.
+5. Revalidate in both topology classes (Basic and network-isolated with private
+   endpoints/private ACR), run the negative security suite (below) **including
+   no-panel/zero-Cosmos continuity**, then update `manifest.json` pins for
+   gpt-rag-orchestrator and gpt-rag-ui together.
+
+Migration boundaries: no backfill required. Existing managed-Conversation items
+are read by the BFF via owner-bound lookup; only the read/append **owner** and
+the routing mechanism change. Classic mode is unaffected. In `capability` mode a
+conversation without a live capability (e.g., browser/session loss in no-panel)
+starts fresh — an accepted, safe default (no content disclosure); the optional
+panel adds enumeration-based recovery. Backfill of panel owner-index rows, if
+desired, is a separate metadata-only migration.
+
+Rollback: flip `HOSTED_CONTINUITY_ENABLED` off (path degrades to safe single-turn
+stateless) and revert the coordinated manifest pin. Because managed Conversations
+is SoR, the capability is stateless, and any owner index is metadata only, no
+chat-content migration is needed either direction; rotating
+`HOSTED_CONVERSATION_CAPABILITY_KEY_ID` invalidates outstanding capabilities and
+owner-index rows can be dropped.
+
+## Negative security tests (must pass before enable)
+
+- **NST-1 Cross-user read (BOLA/IDOR):** user B requests continuity/history on
+  user A's conversation ID → **404**, indistinguishable from a missing ID; no
+  managed-Conversations read is issued on A's items. (Reuses the INV-002 two-user
+  harness.)
+- **NST-2 No container read path:** infra/RBAC assertion that the hosted-agent
+  identity has **no** Conversations data-plane read/list/append role; a wire test
+  asserts the container receives only caller-supplied input and issues no
+  Conversations read.
+- **NST-3 No caller-ID-driven service read:** any code path where a caller-supplied
+  conversation ID reaches a service-identity Conversations read without a prior
+  owner hit is a failing test (static + integration).
+- **NST-4 Fail-closed on read/append failure:** injected read failure and injected
+  append failure each return an error and do **not** start a fresh thread or
+  stream a success-shaped completion.
+- **NST-5 Delegated mode stays inert:** with `HOSTED_CONVERSATION_OWNER_BINDING=delegated`
+  but `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED=false`, continuity does not
+  perform a native delegated read (safe capability/stateless), never a service
+  read.
+- **NST-6 No content leakage to Cosmos/telemetry:** after turns, assert no message
+  body or document content in Cosmos (owner index metadata only) or in
+  `audit-event-v1`.
+- **NST-7 Capability forgery/theft/replay:** a capability with a bad signature,
+  expired TTL, retired `key_id`, or `oid` not matching the live token → **404**
+  (uniform with missing); a stolen capability presented without the matching
+  authenticated `oid` token is rejected; rotating `..._KEY_ID` invalidates all
+  outstanding capabilities.
+- **NST-8 No-panel/zero-Cosmos continuity:** with the panel undeployed and no
+  Cosmos, a multi-turn conversation stays continuous within TTL using the
+  capability alone; no owner index or Cosmos client is instantiated.
+
+## Operational behaviors
+
+- **Concurrency:** one in-flight turn per conversation initially; concurrent turns
+  are serialized or rejected deterministically.
+- **Idempotency:** client turn IDs deduplicate retried appends; a retry never
+  double-appends.
+- **Bounded history:** replay is bounded by `HOSTED_HISTORY_MAX_ITEMS` /
+  `HOSTED_HISTORY_MAX_TOKENS` with `HOSTED_HISTORY_TRUNCATION`; policy is explicit
+  and observable.
+- **Failure semantics:** read failure and append failure both fail closed;
+  gateway 404 on a stale session cannot occur (no top-level `conversation`).
+- **Telemetry:** `audit-event-v1` records owner-bind result, read, append,
+  turn-generated, and legacy-404-detected — **metadata only**, correlation IDs
+  only, no conversation body or document content.
+
+## Compliance verification (fitness functions)
+
+- **FF-1 Continuity across replacement:** turn on version A, replace with a new
+  immutable digest (version B), then a turn on the same logical conversation
+  returns prior context with **no gateway 404**; repeat after rolling back to A.
+  Automated integration test in the isolated topology.
+- **FF-2 No version-bound session dependency:** contract/wire test asserts the BFF
+  sends the full stateless input and **never** the top-level `conversation`
+  parameter or `previous_response_id` for continuity.
+- **FF-3 History-blind stateless container:** RBAC assertion that the hosted-agent
+  identity holds no Conversations data-plane role; wire test asserts the container
+  issues no read/append and only generates from supplied input.
+- **FF-4 Owner gate before read:** a `(caller, conversation_id)` with no valid
+  owner binding (no capability match / signature / `oid` equality) returns
+  **404**; a caller ID never reaches a managed-Conversations read without a prior
+  owner-binding validation.
+- **FF-5 Managed Conversations is SoR / no Cosmos chat:** after a turn, items are
+  readable via the Conversations data API; hosted/no-panel constructs history
+  solely from it; assert no Cosmos chat client is instantiated and any owner index
+  holds metadata only.
+- **FF-6 Fail-closed read/append:** read or append failure returns an error and
+  does **not** start a fresh thread or stream a success-shaped completion.
+- **FF-7 Concurrency & idempotency:** concurrent turns on one conversation yield
+  deterministic ordering; a retried turn with the same client turn ID does not
+  double-append.
+- **FF-8 Retrieval identity preserved & separate:** reuse ADR-0001 INV-002
+  two-user negative retrieval test; per-user/group trimming via Toolbox
+  passthrough unchanged and independent of history ownership.
+- **FF-9 Canonical wire conformance:** requests/responses validate against the
+  Responses schema/SDK types (stateless input-items mode).
+
+## Documentation impact
+
+Update the hosted-agent operator page on the `docs` branch: describe BFF-mediated
+owner-bound continuity, the container's stateless/history-blind role, the
+`capability` (store-free default) vs `delegated` selector and its OQ-OWN gate, the
+capability lifecycle (mint/verify/rotate/TTL), the bounded-history policy and its
+App Configuration keys, the fail-closed 404/error semantics, and
+an explicit preview note that platform server-side `conversation` /
+`previous_response_id` threading is not durable across version replacement.
+Explicitly document that container-side history read/replay is prohibited.
+
+## Review trigger
+
+Reassess when any of the following occurs:
+
+- **OQ-OWN resolves:** live evidence proves (or denies) native per-user enforcement
+  for delegated managed-Conversations reads on the precise token/call path — only
+  then may `delegated` be enabled and the validation gate set.
+- Foundry changes `/responses` gateway session/pre-routing so a top-level
+  `conversation` survives immutable-version/compute replacement, or provides an
+  official rebind/continuation lifecycle.
+- Foundry changes managed-Conversations identity/RBAC, header propagation, ordering,
+  optimistic concurrency, or `store` semantics affecting read/append design.
+- Hosted agents leave preview.
+- Any NST or FF regresses in validation or production, or a security review reports
+  a cross-user or service-identity read path.
+
+## Open questions
+
+- **OQ-OWN (blocking `delegated` default):** does managed Conversations accept a
+  **delegated user token** and enforce per-user/owner authorization for the exact
+  BFF token/call path? If yes → `delegated` may supersede `capability` for reads
+  and the owner index is not needed for reads. If no → the store-free
+  `capability` binding stays and container-side/service-ID reads remain
+  prohibited. Live two-user experiment in progress; design is safe regardless
+  (`capability` default, zero Cosmos in no-panel).
+- **OQ-1 (ordered read + concurrency):** confirm the managed-Conversations data
+  API (used by the BFF, not the container) supports ordered read and an
+  optimistic-concurrency / turn-sequence primitive sufficient for FF-7. If not,
+  the single-active-turn constraint is the contract.
+- **OQ-2 (double-store):** confirm the container's stateless generation with
+  `store=false` on the response does not itself persist items, so the BFF is the
+  sole append path and no double-store occurs.
+- **OQ-3 (bounded-history policy):** finalize `HOSTED_HISTORY_MAX_ITEMS` /
+  `HOSTED_HISTORY_MAX_TOKENS` defaults and truncation-vs-summarization ownership.
+- **OQ-4 (owner stamp durability):** confirm the create path durably records the
+  owner principal (and that it survives version replacement) so ownership is
+  attributable without content inspection — shared with ADR-0004 OQ-611-OWNERSTAMP.
+- **OQ-CAP (capability sufficiency):** confirm the signed capability envelope
+  (`{oid, conversation_resource_id, issued_at, expiry, key_id}`) plus live-token
+  `oid` equality is sufficient owner binding for reads/appends with no store, and
+  finalize TTL/rotation defaults — shared with ADR-0004 OQ-611-CAP.
+- **OQ-REVOKE (revocation granularity):** in no-panel there is no per-capability
+  revocation (only TTL expiry + key rotation as bulk revocation); confirm this is
+  acceptable or require the panel/owner-index for fine-grained revocation —
+  shared with ADR-0004 OQ-611-REVOKE.
+- **OQ-7 (cancel/background lifecycle):** define cancel/partial-turn behavior;
+  recommend synchronous streaming with completed-turn-only append for the first
+  release, so a cancelled turn appends nothing.

--- a/docs/adr/ADR-0003-hosted-conversation-continuity.md
+++ b/docs/adr/ADR-0003-hosted-conversation-continuity.md
@@ -4,9 +4,9 @@
 **Date:** 2026-08-07<br>
 **Owners:** GPT-RAG maintainer (Paulo), architecture analysis, with gpt-rag-ui and gpt-rag-orchestrator component owners (revised after independent security review)
 
-> **Revision note (2026-08-07, superseded in part by ADR-0004).** Two points in
-> this ADR are tightened by ADR-0004 after security review, and this ADR is
-> updated to match:
+> **Revision note (2026-08-07, superseded in part by ADR-0004).** Three points
+> in this ADR are tightened after security review and after live OQ-OWN
+> evidence, and this ADR is updated to match:
 >
 > 1. **Persistence/replay location.** ADR-0004's approved invariant is that the
 >    hosted **container holds zero managed-Conversations data-plane RBAC (neither
@@ -20,14 +20,41 @@
 >    replays, and persists."
 > 2. **How the logical ID is carried.** The stable logical conversation
 >    identifier is **not** carried as a raw resource ID in request metadata that
->    a service could act on. It is carried as a **server-issued, signed,
->    opaque, owner-bound capability** minted by the BFF from the validated user
->    `oid` (`{oid, conversation_resource_id, issued_at, expiry, key_id}`), so no
->    caller-selected ID drives a read and a direct caller cannot forge ownership.
->    The capability requires **no store**, so continuity holds in
->    **hosted/no-panel with zero Cosmos**. See ADR-0004 for the capability
->    design, key rotation, replay/theft handling, and the panel-only owner index
->    used solely for cross-conversation enumeration.
+>    a service could act on. It is carried as a **BFF-issued, signed, opaque
+>    locator handle** referencing `conversation_resource_id`, so no
+>    caller-selected ID drives a read and a direct caller cannot forge
+>    ownership. In `capability` mode (the fallback/pre-gate mechanism) that
+>    handle additionally embeds an `oid` claim
+>    (`{oid, conversation_resource_id, issued_at, expiry, key_id}`) that the BFF
+>    re-checks against the live token before any read; in `delegated` mode (the
+>    chosen/default mechanism — see point 3) the handle omits the `oid` claim
+>    and the BFF-side re-check, because the Foundry platform itself enforces
+>    per-user authorization on the read. Either way the handle requires **no
+>    persistent store**, so continuity holds in **hosted/no-panel with zero
+>    Cosmos**. See ADR-0004 for the capability design, key rotation,
+>    replay/theft handling, and the panel-only owner index used solely for
+>    cross-conversation enumeration.
+> 3. **OQ-OWN resolved for the hosted-continuity call path (2026-08-07).** A
+>    live, end-to-end, disposable-environment experiment
+>    ([`gpt-rag#591` evidence comment](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245),
+>    [cleanup proof](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212334345))
+>    proved that Foundry hosted agents on container protocol **`responses`
+>    2.0.0** enforce **per-user isolation of the platform-managed response
+>    chain and `get_history`** from a trusted middle-tier identity asserting
+>    `x-ms-user-identity`, gated by a **custom `UserIdentityImpersonation`
+>    data action at agent scope** (present in no built-in role) plus a
+>    **narrow `Foundry Agent Consumer`** role for the interact action. This
+>    **supersedes `capability` as the default** owner-binding mechanism: the
+>    **native delegated-header mechanism becomes the chosen/default** binding
+>    once an **environment evidence gate** confirms the deployed protocol
+>    version and RBAC shape; `capability` becomes the **optional, safe
+>    fallback/alternative** (used automatically pre-gate or if the gate is
+>    ever unmet), not the primary requirement. This changes only *which
+>    mechanism authorizes a read*; it does **not** change the BFF-mediated,
+>    stateless, cross-version replay mechanism below (Option C) — the
+>    top-level `conversation` parameter and `previous_response_id` remain
+>    version-bound and are still never used for continuity. See the
+>    "Delegated header mechanism" subsection under the Decision.
 
 
 ## Context
@@ -125,25 +152,35 @@ owner-bound, fail-closed contract and its OQ-OWN read-mechanism selector.
 
 - `Azure/gpt-rag-ui` — thin **BFF** (`orchestrator_client.py`, `hosted_agent`
   path). **Owner of continuity**: authenticates the end user, binds conversation
-  ownership, reads managed-Conversation history, builds the complete bounded
-  ordered stateless Responses input, calls the hosted agent, and appends the new
-  turns to managed Conversations. Holds the only end-user token in the hosted
-  path.
+  ownership (via the `delegated` asserted header once the environment evidence
+  gate is met, or `capability` as fallback), reads managed-Conversation
+  history, builds the complete bounded ordered stateless Responses input, calls
+  the hosted agent, and appends the new turns to managed Conversations. Holds
+  the only end-user token in the hosted path; owns the BFF endpoint-call
+  identity that carries `Foundry Agent Consumer` + (in `delegated` mode) the
+  custom `UserIdentityImpersonation` action, both at agent scope.
 - `Azure/gpt-rag-orchestrator` — hosted-agent Responses v2 adapter. Reduced to
   **stateless generation**: consume the caller-supplied input items, run the
   turn, return output. **Removes** container-side managed-Conversations
   read/replay/append. Preserves the Toolbox/OBO retrieval path and the
-  `POST /retrieve` fail-closed boundary unchanged.
+  `POST /retrieve` fail-closed boundary unchanged. Never holds Conversations
+  RBAC, a capability signing key, or the `UserIdentityImpersonation` action —
+  those belong solely to the BFF's endpoint-call identity.
 - `Azure/GPT-RAG` (this repo) — App Configuration contract (label `gpt-rag`),
   ADR record, and the `contracts/` continuity/owner-binding schema. Holds all
   **GPT-RAG-specific** history policy.
 - `Azure/bicep-ptn-aiml-landing-zone` (**AILZ**) — generic landing-zone infra
   (consumed via the `infra/` submodule). Stays generic: it must **not** encode
   GPT-RAG history policy. Its only obligation here is to ensure the hosted-agent
-  identity carries **no** managed-Conversations data-plane role at all — no
-  create, read, append, or delete, and no append-only or write-only variant
-  either. Zero role, full stop; nothing is assumed or carved out. GPT-RAG-specific
-  policy stays in GPT-RAG.
+  **container** identity carries **no** managed-Conversations data-plane role at
+  all — no create, read, append, or delete, and no append-only or write-only
+  variant either. Zero role, full stop; nothing is assumed or carved out. AILZ
+  also provisions the custom `UserIdentityImpersonation` role definition as a
+  generic, reusable Azure role artifact (no GPT-RAG-specific meaning encoded in
+  the role itself) and assigns it, together with `Foundry Agent Consumer`, only
+  to the **BFF's** endpoint-call identity, scoped narrowly at agent scope —
+  never to the container. GPT-RAG-specific policy (which mode is active, when
+  the gate flips) stays in GPT-RAG's App Configuration.
 
 ### Prioritized characteristics (measures)
 
@@ -213,16 +250,19 @@ history-blind**. Each turn:
 1. The BFF **authenticates the end user** (it holds the Entra token) and
    **binds conversation ownership** for the logical conversation **before any
    read**. Ownership is enforced by the mechanism selected under OQ-OWN:
-   **`capability`** (default, safe today, **store-free** — a server-issued,
-   signed, opaque, owner-bound capability whose embedded `oid` the BFF re-checks
-   against the live token before any read; works in **hosted/no-panel with zero
-   Cosmos**) or **`delegated`** (native per-user reads, **inert** until live
-   OQ-OWN evidence proves per-user enforcement for the precise token/call path).
-   A raw caller-selected ID is never accepted. Non-owner, forged/expired
-   capability, and missing all return an **indistinguishable 404**. (The
-   panel-only **owner index** in Cosmos is used solely for cross-conversation
-   *enumeration* when the panel is deployed; it is **not** the continuity
-   binding.)
+   **`delegated`** (**chosen/default** once the environment evidence gate
+   confirms protocol + RBAC — native, per-user platform enforcement via a
+   BFF-asserted `x-ms-user-identity` header derived server-side from the
+   validated `oid`; see "Delegated header mechanism" below) or **`capability`**
+   (**optional, safe fallback/alternative** — used automatically before the
+   gate is met, or if it is ever unmet — **store-free**: a server-issued,
+   signed, opaque, owner-bound capability whose embedded `oid` the BFF
+   re-checks against the live token before any read; works in **hosted/no-panel
+   with zero Cosmos**). A raw caller-selected ID is never accepted under either
+   mechanism. Non-owner, forged/expired capability, bad/missing header, and
+   missing all return an **indistinguishable 404**. (The panel-only **owner
+   index** in Cosmos is used solely for cross-conversation *enumeration* when
+   the panel is deployed; it is **not** the continuity binding.)
 2. On an owner hit, the BFF **reads** the ordered managed-Conversation items and
    builds the **complete, bounded, ordered, stateless Responses input** (bounded
    by an explicit history policy). A read failure **fails closed** (error to the
@@ -246,18 +286,42 @@ history-blind**. Each turn:
 - Costs and risks: the BFF owns threading mechanics (owner-binding, read, bounded
   replay, append), concurrency/idempotency, and a bounded-history policy. Full
   input per turn costs tokens/latency and needs explicit truncation or
-  summarization. In `capability` mode the BFF signs/verifies a store-free
-  capability (key in Key Vault, rotation via key version, short TTL with rolling
-  re-mint; no fine-grained per-capability revocation in no-panel). The panel-only
-  owner index, when present, is metadata-only and must stay consistent with the
-  SoR (worst case: a 404 or a stale list row, never content disclosure).
+  summarization. In `delegated` mode the BFF must derive `x-ms-user-identity`
+  **server-side only** from the validated `oid` and never accept it from the
+  client; the asserted identity is middle-tier-asserted, not cryptographically
+  proven by the platform, so the BFF remains the trust boundary. **Both modes
+  require the same signing-key infrastructure** (key in Key Vault, rotation via
+  key version, short TTL with rolling re-mint; no fine-grained per-handle
+  revocation in no-panel): in `capability` mode the BFF signs/verifies the full
+  owner-bound capability (locator + `oid` claim, `oid` re-checked against the
+  live token); in `delegated` mode the BFF signs/verifies the same locator
+  shape **without** the `oid` claim/re-check, relying on the Foundry platform's
+  own per-request identity enforcement for authorization instead. The
+  panel-only owner index, when present, is metadata-only and must stay
+  consistent with the SoR (worst case: a 404 or a stale list row, never content
+  disclosure).
 - Security and identity: **three concerns kept separate** — (a) **history
-  ownership** enforced by the BFF before any read; (b) **delegated OBO/Toolbox
-  retrieval authorization** (document-level trimming) carried to Search via the
-  existing passthrough, unchanged and independent of history ownership; (c) the
-  **identity authenticating the Foundry `/responses` endpoint call**. Carried
-  user context (b) is never conflated with the endpoint-call identity (c), and
-  neither is treated as a history-ownership claim (a).
+  ownership** enforced by the BFF before any read (via `delegated` header or
+  `capability`); (b) **delegated OBO/Toolbox retrieval authorization**
+  (document-level trimming) carried to Search via the existing passthrough,
+  unchanged and independent of history ownership; (c) the **identity
+  authenticating the Foundry `/responses` endpoint call** — the BFF's own
+  narrowly-scoped service identity (`Foundry Agent Consumer` +, in `delegated`
+  mode, the custom `UserIdentityImpersonation` action, both at agent scope).
+  Carried user context (b) is never conflated with the endpoint-call identity
+  (c); the endpoint-call identity (c) is never itself treated as a
+  history-ownership claim (a) — ownership is the *asserted* `x-ms-user-identity`
+  value, which the BFF derives solely from (1) the validated `oid`, never from
+  the client.
+- **Residual risk (platform session-join, live-tested):** the platform allows
+  a request asserting a *different* `x-ms-user-identity` to **enter** (join) a
+  session the BFF's identity created for another user, even though it still
+  **fences** that session's response chain and `get_history` per asserted
+  identity. Session **membership** is therefore not a security boundary. The
+  container is unaffected (it is stateless and holds no data), but this ADR's
+  invariant is stated explicitly: **never store unpartitioned container/session
+  -keyed data** — any future container- or downstream-side state must be
+  partitioned per user, never keyed by session/agent-thread ID alone.
 - Operational consequences: continuity is independent of the serving version;
   rollback-safe; matches the immutable-version model; **no new always-on compute
   and no store in hosted/no-panel** (continuity uses the store-free capability;
@@ -269,6 +333,90 @@ history-blind**. Each turn:
 - Reversibility: single App Configuration switch; when continuity is off, the
   path degrades to safe **single-turn stateless** behavior, never to an
   unauthorized read.
+
+#### Delegated header mechanism (native, chosen/default post-gate)
+
+Live evidence
+([`gpt-rag#591` evidence comment](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245),
+[cleanup proof](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212334345))
+resolves OQ-OWN for the hosted-continuity call path. The mechanism:
+
+- **Protocol requirement:** the hosted agent must run container protocol
+  **`responses` 2.0.0**. Per-user response-chain/`get_history` fencing was
+  proven only on this protocol version; no other version is assumed to carry
+  the same guarantee.
+- **Header:** the BFF asserts `x-ms-user-identity` on its call to the Foundry
+  `/responses`/Conversations endpoints, derived **server-side only** from the
+  end user's Entra token `oid` **after** the BFF validates that token. The BFF
+  **never** accepts this header, or the `oid` it is derived from, as a
+  client-supplied value; a client-supplied `x-ms-user-identity`-shaped header
+  is stripped/ignored before the BFF's own value is set.
+- **Conversation locator (unchanged shape across mechanisms):** the header
+  authorizes the *read*; it does not tell the BFF *which* managed Conversation
+  to read. The client-held reference to `conversation_resource_id` is still a
+  **BFF-issued opaque locator handle** in both modes — never the raw resource
+  ID, never self-authorizing, never client-constructed. In `capability` mode
+  this handle **is** the signed capability (locator + `oid`-bound authorization
+  combined, per the Decision above). In `delegated` mode the BFF mints a
+  **structurally identical signed, opaque locator** (same signing-key
+  infrastructure and `{conversation_resource_id, issued_at, expiry, key_id}`
+  shape as the capability) but **omits the `oid` claim and the BFF-side `oid`
+  equality re-check** — the signature exists only to make the locator
+  tamper-evident and non-guessable (a client cannot construct or mutate one),
+  not to authorize the read. Authorization of *who* may resolve that locator is
+  performed once, per request, by the Foundry platform itself: it evaluates
+  the presented `conversation_resource_id` together with the live-derived
+  `x-ms-user-identity` header and returns the **platform's own 404** if they
+  don't match the identity that owns the target conversation, rather than a
+  BFF-side signature/`oid` mismatch. The handle is stored client-side
+  identically in both modes (see ADR-0004's `OQ-611-CAP` for the
+  persistence-surface question), and switching between modes at the
+  environment evidence gate does not change how or where the client holds it
+  — only whether the BFF also re-checks `oid` before trusting it.
+- **RBAC:** the BFF's own service identity (or a dedicated middle-tier
+  identity it controls) authenticates the endpoint call and must hold **only**
+  `Foundry Agent Consumer` (interact data action) plus the custom
+  **`UserIdentityImpersonation`** data action, both scoped **narrowly at agent
+  scope** — no broader project/account-scope Foundry role. No built-in role
+  includes `UserIdentityImpersonation`; it is a custom role definition
+  provisioned by infra/AILZ. `Foundry Agent Consumer` alone (without the
+  impersonation action) can still invoke the endpoint but is confirmed
+  **narrow**: it cannot read, enumerate, or delete another identity's sessions
+  or responses.
+- **Enforcement observed:** a request asserting one `x-ms-user-identity`
+  cannot continue another identity's response chain via `previous_response_id`
+  (404), cannot read another identity's stored response (404), and — even from
+  **inside** a session another identity's request created and this identity
+  was allowed to **enter** — still cannot continue that session's response
+  chain (404). See the residual-risk bullet above for the session-join
+  implication.
+- **Environment evidence gate:** `delegated` is the **chosen/default** owner-
+  binding mechanism, but it only actually engages once **environment evidence**
+  confirms, for the specific deployment: (1) the target hosted agent runs
+  protocol `responses` 2.0.0, and (2) the BFF's endpoint-call identity holds
+  exactly the narrow RBAC shape above (no broader Foundry role). Until both are
+  confirmed, the BFF automatically falls back to `capability` — it never fails
+  open to an unbound/unauthenticated read. This is an environment/deploy-time
+  confirmation, not a requirement to repeat the full live two-identity
+  experiment per deployment.
+- **Unaffected invariants:** the container remains **stateless with zero
+  Conversations RBAC** — the impersonation/consumer RBAC belongs to the BFF's
+  endpoint-call identity, never the container/hosted-agent identity, which has
+  no visibility into the header. Downstream OBO/Toolbox retrieval authorization
+  (document-level trimming, INV-002) is **unchanged and independent** of this
+  mechanism. **Cross-version stateless replay is unchanged**: `delegated`
+  changes only how the per-turn **read is authorized**; it does **not**
+  reintroduce reliance on the top-level `conversation` param or
+  `previous_response_id` for continuity across version/compute replacement,
+  because that routing **remains version-bound** (unaffected by this
+  evidence) — the BFF still assembles a fresh, complete, bounded, stateless
+  input every turn per steps 2–3 above.
+- **Scope of this evidence:** this resolves the owner-binding mechanism for
+  the hosted-continuity call path only. It does not resolve issue #591's
+  separate, still-open document-level-authorization question (retrieval/Toolbox
+  trimming), and it does not, by itself, resolve ADR-0004's independent panel
+  enumeration/read gate (`PANEL_HISTORY_OWNER_BINDING_VALIDATED`), which
+  requires its own live evidence for its own exact call path.
 
 ### Option D: BFF/gateway detects version change and mints a new platform conversation, linking/replaying managed history
 
@@ -322,21 +470,33 @@ managed-Conversations data-plane RBAC and only generates output from the input i
 is given. **Container-side replay and any caller-ID-driven service read are
 prohibited (Option B withdrawn).**
 
-The **owner-binding mechanism is a selector** consistent with ADR-0004,
-defaulting to the safe, **store-free** state so continuity holds in
-hosted/no-panel:
+The **owner-binding mechanism is a selector** consistent with ADR-0004. Live
+OQ-OWN evidence (issue #591) resolves the hosted-continuity call path, so the
+selector now defaults to the **native, chosen** mechanism once an environment
+evidence gate confirms protocol + RBAC, with the store-free mechanism retained
+as the safe fallback:
 
-- `capability` (**default**): a server-issued, signed, opaque, owner-bound
-  capability minted by the BFF from the validated user `oid`
-  (`{oid, conversation_resource_id, issued_at, expiry, key_id}`). The BFF
-  re-checks the capability `oid` against the live token before any read. Requires
-  **no store** (signing key in Key Vault, provisioned like `AUDIT-HMAC-KEY`), so
-  it works in **hosted/no-panel with zero Cosmos**. Safe today; no dependency on
-  an unproven platform capability.
-- `delegated` (**target, gated**): native per-user managed-Conversations reads as
-  the user. **Inert** until the live **OQ-OWN** two-user experiment proves actual
-  per-user enforcement for the precise token/call path; only then may it be
-  enabled.
+- `delegated` (**chosen/default, post-gate**): native per-user enforcement via
+  a BFF-asserted `x-ms-user-identity` header, derived server-side from the
+  validated `oid`, on a hosted agent running container protocol `responses`
+  2.0.0, with the BFF's endpoint-call identity holding narrowly-scoped RBAC
+  (`Foundry Agent Consumer` + the custom `UserIdentityImpersonation` action, at
+  agent scope). Live evidence
+  ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245))
+  proves per-user response-chain/`get_history` enforcement for this exact call
+  path. Engages automatically once the environment evidence gate (protocol +
+  RBAC confirmed) is `true` for the deployment; see "Delegated header
+  mechanism" above for the full mechanism, residual-trust caveats, and scope
+  limits.
+- `capability` (**optional, safe fallback/alternative**): a server-issued,
+  signed, opaque, owner-bound capability minted by the BFF from the validated
+  user `oid` (`{oid, conversation_resource_id, issued_at, expiry, key_id}`).
+  The BFF re-checks the capability `oid` against the live token before any
+  read. Requires **no store** (signing key in Key Vault, provisioned like
+  `AUDIT-HMAC-KEY`), so it works in **hosted/no-panel with zero Cosmos**. Used
+  automatically before the environment evidence gate is met, or if it is ever
+  unmet; remains fully specified and available as a rollback/defense-in-depth
+  option even after `delegated` is chosen.
 
 A raw caller-selected conversation ID is **never** accepted as a read key. The
 panel-only **owner index** (Cosmos) exists solely for cross-conversation
@@ -349,13 +509,28 @@ content. No Cosmos chat content exists in hosted/no-panel.
 Three distinct identities/authorizations must not be conflated:
 
 1. **History ownership** — enforced by the BFF against the authenticated end user
-   before any read; non-owner and missing both return **404**.
+   before any read; non-owner and missing both return **404**. Under
+   `delegated`, the ownership *signal* is the `x-ms-user-identity` value, which
+   the BFF derives **solely** from this validated identity, never from the
+   client.
 2. **Delegated OBO/Toolbox retrieval authorization** — the user context carried
    to Foundry IQ/Search for native document-level trimming (ADR-0001 target
    path). Unchanged by this ADR and independent of history ownership.
-3. **Foundry `/responses` endpoint-call identity** — whatever credential
-   authenticates the BFF→gateway call. Never treated as, or derived from, the
-   carried user context (2) or a history-ownership claim (1).
+3. **Foundry `/responses` endpoint-call identity** — the credential that
+   authenticates the BFF→gateway call. In `delegated` mode this is the BFF's
+   own narrowly-scoped service identity (`Foundry Agent Consumer` + the custom
+   `UserIdentityImpersonation` action, at agent scope). It is never treated as,
+   or derived from, the carried user context (2), and is never itself a
+   history-ownership claim (1) — it only carries the asserted identity that (1)
+   supplies.
+
+**Never store unpartitioned container/session-keyed data.** Live evidence
+shows the platform fences the response chain/`get_history` per asserted
+identity but does **not** fence session **membership** itself (a differently
+asserted identity can enter a session another identity's request created). The
+container is stateless today and holds no data, so this is a forward-looking
+invariant: any future container- or downstream-side state must be partitioned
+per user, never keyed by session/agent-thread ID alone.
 
 ### App Configuration contract (label `gpt-rag`, owned by Azure/GPT-RAG)
 
@@ -365,17 +540,27 @@ These align with ADR-0004's panel keys and the `POST /retrieve` idiom.
 - `HOSTED_CONTINUITY_ENABLED` (default `false`) — when `false`, the hosted path
   is **single-turn stateless** (no server history, safe). When `true`, the BFF
   performs owner-bound read + bounded replay + append.
-- `HOSTED_CONVERSATION_OWNER_BINDING` (default `capability`; alt `delegated`) —
-  selects the owner-binding mechanism; `delegated` is inert until the validation
-  gate is set. Same key as ADR-0004.
+- `HOSTED_CONVERSATION_OWNER_BINDING` (default `delegated`; alt `capability`) —
+  selects the owner-binding mechanism. `delegated` only actually engages once
+  the environment evidence gate is `true` for the deployment; until then, the
+  BFF automatically falls back to `capability`. Same key as ADR-0004.
 - `HOSTED_CONVERSATION_CAPABILITY_KEY` / `HOSTED_CONVERSATION_CAPABILITY_KEY_ID` /
   `HOSTED_CONVERSATION_CAPABILITY_TTL_SECONDS` — Key Vault-referenced signing key
   (provisioned like `AUDIT-HMAC-KEY`), active key version for rotation, and
-  capability lifetime with rolling re-mint. Present in **all** modes; no store.
-- `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED` (default `false`) — the **OQ-OWN
-  evidence gate**, mirroring `HOSTED_RETRIEVAL_INV_002_VALIDATED`. Continuity in
-  `delegated` mode stays disabled (safe capability/stateless) unless this is
-  `true`.
+  capability lifetime with rolling re-mint. Present in **all** modes (fallback
+  and defense-in-depth); no store.
+- `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED` (default `false`) — the
+  **environment evidence gate**: confirms, for this deployment, that (1) the
+  target hosted agent runs container protocol `responses` 2.0.0, and (2) the
+  BFF's endpoint-call identity holds exactly `Foundry Agent Consumer` + the
+  custom `UserIdentityImpersonation` action at agent scope (no broader Foundry
+  role). This mirrors `HOSTED_RETRIEVAL_INV_002_VALIDATED`'s pattern but checks
+  protocol/RBAC shape rather than repeating the live two-identity experiment
+  per deployment (that experiment is recorded once, in `gpt-rag#591`).
+  Continuity stays on the safe `capability` path unless this is `true`.
+- `HOSTED_CONVERSATION_PROTOCOL_VERSION` (expected `responses/2.0.0`) —
+  records/asserts the hosted agent's container protocol version; part of the
+  environment evidence gate check in (1) above.
 - `HOSTED_CONVERSATIONS_TOKEN_AUDIENCE` — managed-Conversations query-token
   audience for `delegated` mode (analogous to `HOSTED_RETRIEVAL_TOKEN_AUDIENCE`);
   required only when `delegated`.
@@ -387,7 +572,9 @@ These align with ADR-0004's panel keys and the `POST /retrieve` idiom.
 If a typed field is warranted (the continuity/capability envelope), it is added
 under `contracts/` and byte-pinned like `audit-event-v1`. **AILZ carries no
 GPT-RAG history policy**; it only guarantees the container identity holds no
-Conversations read/write role and no capability signing key.
+Conversations read/write role and no capability signing key, and that the
+custom `UserIdentityImpersonation` role definition (when provisioned) is
+assignable only at agent scope, never to the container/hosted-agent identity.
 
 ### Honest scope statement (protocol vs. continuity)
 
@@ -420,9 +607,13 @@ continuity across the platform's own immutable-version replacement. Therefore:
   the container only generates; no Cosmos chat content in hosted/no-panel.
 - History ownership, delegated retrieval authorization, and endpoint-call
   identity remain cleanly separated; INV-002 / `POST /retrieve` untouched.
-- Safe under OQ-OWN uncertainty: **store-free `capability`** ships now (works in
-  hosted/no-panel with zero Cosmos); `delegated` is a config flip after live
-  proof. Reversible behind one App Configuration switch.
+- **OQ-OWN resolved for this call path**: live evidence (`gpt-rag#591`) proves
+  native per-user enforcement via the delegated header on protocol `responses`
+  2.0.0. `delegated` ships as the **chosen/default** mechanism once the
+  environment evidence gate confirms protocol + RBAC; **store-free
+  `capability`** remains fully specified and available as the safe
+  pre-gate/rollback fallback. Reversible behind one App Configuration switch
+  either way.
 
 ### Negative or accepted
 
@@ -431,17 +622,27 @@ continuity across the platform's own immutable-version replacement. Therefore:
   component ADR-0001 wants thin.
 - Per-turn token/latency cost of sending full bounded input; requires the
   explicit truncation/summarization bound.
-- In `capability` mode the BFF signs/verifies a store-free capability (Key
-  Vault-backed key, rotation via key version, short TTL + rolling re-mint); no
-  fine-grained per-capability revocation in no-panel (bounded by TTL + rotation).
-  The panel-only owner index, when present, is metadata-only and must stay
-  consistent with the SoR (at worst a 404 or stale list row, never content
-  disclosure).
+- In `delegated` mode, the asserted `x-ms-user-identity` is middle-tier-asserted,
+  not cryptographically proven by the platform — the BFF must derive it
+  server-side only, never from the client, and remains the trust boundary. The
+  platform's session-**membership** fencing is weaker than its response-chain
+  fencing (live-tested); this ADR's invariant against storing unpartitioned
+  container/session-keyed data addresses that gap.
+- In `capability` mode (fallback) the BFF signs/verifies a store-free capability
+  (Key Vault-backed key, rotation via key version, short TTL + rolling re-mint);
+  no fine-grained per-capability revocation in no-panel (bounded by TTL +
+  rotation). The panel-only owner index, when present, is metadata-only and
+  must stay consistent with the SoR (at worst a 404 or stale list row, never
+  content disclosure).
 - Gives up the platform's server-side auto-threading convenience while the
-  preview limitation stands.
+  preview limitation stands; cross-version stateless replay is required
+  regardless of owner-binding mechanism, because `previous_response_id`/session
+  routing remains version-bound.
 - Reconciled with ADR-0004: managed-Conversation create/read/append/delete and
   ownership belong to the **BFF**, not the container; the container is stateless
-  with zero Conversations RBAC and no signing key.
+  with zero Conversations RBAC and no signing key — unaffected by the
+  delegated-header mechanism, whose RBAC belongs solely to the BFF's
+  endpoint-call identity.
 
 ## Adoption and migration
 
@@ -453,49 +654,61 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    `AUDIT-HMAC-KEY`), `HOSTED_CONVERSATION_CAPABILITY_KEY_ID`,
    `HOSTED_CONVERSATION_CAPABILITY_TTL_SECONDS`,
    `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`,
+   `HOSTED_CONVERSATION_PROTOCOL_VERSION`,
    `HOSTED_CONVERSATIONS_TOKEN_AUDIENCE`, `HOSTED_HISTORY_MAX_ITEMS`,
    `HOSTED_HISTORY_MAX_TOKENS`, `HOSTED_HISTORY_TRUNCATION`, all defaulting to the
-   safe state (continuity off, `capability`, validation gate `false`). Add the
-   `contracts/` continuity/capability envelope schema + `.sha256` if a typed field
-   is warranted. Publish this ADR. No runtime behavior change yet.
+   safe pre-gate state (continuity off, `delegated` selector present but
+   inactive until its validation gate is `true`, falling back to `capability`
+   in the interim). Add the `contracts/` continuity/capability envelope schema
+   + `.sha256` if a typed field is warranted. Publish this ADR. No runtime
+   behavior change yet.
 2. **gpt-rag-orchestrator** — reduce the hosted-agent Responses v2 adapter to
    **stateless generation**: consume the caller-supplied bounded ordered input
    items and return output. **Remove** any container-side managed-Conversations
    read/replay/append and any dependency on the top-level `conversation` /
    `previous_response_id` for continuity. Emit `audit-event-v1` for
    turn-generated and legacy-404-detected (metadata only). No Conversations
-   read/write role and no capability signing key on the container identity.
+   read/write role, no capability signing key, and no `UserIdentityImpersonation`
+   RBAC on the container identity — that RBAC belongs only to the BFF's
+   endpoint-call identity.
 3. **gpt-rag-ui** — in the `hosted_agent` BFF path: authenticate the end user;
-   bind conversation ownership (`capability` default — mint on create, verify
-   signature + expiry + `oid` equality) before any read; read ordered items from
+   bind conversation ownership before any read via the selected mechanism
+   (`delegated` — assert `x-ms-user-identity` derived server-side from the
+   validated `oid`, never from the client; or `capability` fallback — mint on
+   create, verify signature + expiry + `oid` equality); read ordered items from
    managed Conversations; build the complete bounded ordered stateless Responses
    input; call the hosted agent with a fresh `/responses` request (no top-level
    `conversation`, no `previous_response_id`); append the new user/assistant turns
    to managed Conversations with an idempotent client turn ID; enforce one
-   in-flight turn per conversation; re-mint a fresh capability on success; fail
-   closed on read or append failure (no fresh-thread masquerade). Non-owner,
-   forged/expired capability, and missing → 404.
+   in-flight turn per conversation; re-mint a fresh capability on success when in
+   `capability` mode; fail closed on read or append failure (no fresh-thread
+   masquerade). Non-owner, forged/expired capability, bad/missing header, and
+   missing → 404.
 4. **AILZ (`bicep-ptn-aiml-landing-zone`)** — no GPT-RAG history policy. Confirm
-   (infra/RBAC review) the hosted-agent identity carries **no**
-   managed-Conversations data-plane read/write role and **no** capability signing
-   key; Conversations RBAC and the signing key belong to the **BFF identity**
-   only.
+   (infra/RBAC review) the hosted-agent/container identity carries **no**
+   managed-Conversations data-plane read/write role, **no** capability signing
+   key, and **no** `UserIdentityImpersonation` action; provision the custom
+   `UserIdentityImpersonation` role definition and assign it, together with
+   `Foundry Agent Consumer`, only to the **BFF's endpoint-call identity**, scoped
+   narrowly at **agent scope**.
 5. Revalidate in both topology classes (Basic and network-isolated with private
    endpoints/private ACR), run the negative security suite (below) **including
-   no-panel/zero-Cosmos continuity**, then update `manifest.json` pins for
-   gpt-rag-orchestrator and gpt-rag-ui together.
+   no-panel/zero-Cosmos continuity and the delegated-header tests**, then update
+   `manifest.json` pins for gpt-rag-orchestrator and gpt-rag-ui together.
 
 Migration boundaries: no backfill required. Existing managed-Conversation items
 are read by the BFF via owner-bound lookup; only the read/append **owner** and
-the routing mechanism change. Classic mode is unaffected. In `capability` mode a
-conversation without a live capability (e.g., browser/session loss in no-panel)
-starts fresh — an accepted, safe default (no content disclosure); the optional
-panel adds enumeration-based recovery. Backfill of panel owner-index rows, if
+the routing mechanism change. Classic mode is unaffected. Before the
+environment evidence gate is met, or in `capability` mode, a conversation
+without a live capability (e.g., browser/session loss in no-panel) starts
+fresh — an accepted, safe default (no content disclosure); the optional panel
+adds enumeration-based recovery. Backfill of panel owner-index rows, if
 desired, is a separate metadata-only migration.
 
 Rollback: flip `HOSTED_CONTINUITY_ENABLED` off (path degrades to safe single-turn
-stateless) and revert the coordinated manifest pin. Because managed Conversations
-is SoR, the capability is stateless, and any owner index is metadata only, no
+stateless), or flip `HOSTED_CONVERSATION_OWNER_BINDING` back to `capability`,
+and revert the coordinated manifest pin. Because managed Conversations is SoR,
+the capability is stateless, and any owner index is metadata only, no
 chat-content migration is needed either direction; rotating
 `HOSTED_CONVERSATION_CAPABILITY_KEY_ID` invalidates outstanding capabilities and
 owner-index rows can be dropped.
@@ -516,10 +729,10 @@ owner-index rows can be dropped.
 - **NST-4 Fail-closed on read/append failure:** injected read failure and injected
   append failure each return an error and do **not** start a fresh thread or
   stream a success-shaped completion.
-- **NST-5 Delegated mode stays inert:** with `HOSTED_CONVERSATION_OWNER_BINDING=delegated`
-  but `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED=false`, continuity does not
-  perform a native delegated read (safe capability/stateless), never a service
-  read.
+- **NST-5 Fallback when gate unmet:** with `HOSTED_CONVERSATION_OWNER_BINDING=delegated`
+  but `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED=false`, continuity
+  automatically uses the safe `capability` mechanism (never a native delegated
+  read, never fails open, never a bare service read).
 - **NST-6 No content leakage to Cosmos/telemetry:** after turns, assert no message
   body or document content in Cosmos (owner index metadata only) or in
   `audit-event-v1`.
@@ -530,7 +743,26 @@ owner-index rows can be dropped.
   outstanding capabilities.
 - **NST-8 No-panel/zero-Cosmos continuity:** with the panel undeployed and no
   Cosmos, a multi-turn conversation stays continuous within TTL using the
-  capability alone; no owner index or Cosmos client is instantiated.
+  active owner-binding mechanism alone; no owner index or Cosmos client is
+  instantiated.
+- **NST-9 Header spoofing rejected:** a client-supplied `x-ms-user-identity`
+  value is stripped/ignored by the BFF; only the server-derived value (from the
+  validated `oid`) is ever forwarded — a wire/contract test asserts the BFF
+  never forwards a client-controlled header value verbatim.
+- **NST-10 Cross-user response-chain/read 404 in `delegated` mode:** user B's
+  `previous_response_id` continuation or stored-response read against user A's
+  response/session → **404**, indistinguishable from missing (reuses the
+  `gpt-rag#591` two-identity harness for this exact call path).
+- **NST-11 Session-join does not leak response chain/history:** an asserted
+  identity that is allowed to enter/join a session created by a different
+  asserted identity's request still receives **404** on that session's
+  response chain and `get_history` — session **membership** is not a
+  substitute for response-chain ownership.
+- **NST-12 RBAC narrowness:** `Foundry Agent Consumer` alone (without the
+  custom `UserIdentityImpersonation` action) is insufficient for the BFF's
+  endpoint-call identity to assert `x-ms-user-identity` — an infra/RBAC
+  assertion confirms no built-in Foundry role includes the impersonation
+  action and that it is assigned only at agent scope.
 
 ## Operational behaviors
 
@@ -555,14 +787,16 @@ owner-index rows can be dropped.
   Automated integration test in the isolated topology.
 - **FF-2 No version-bound session dependency:** contract/wire test asserts the BFF
   sends the full stateless input and **never** the top-level `conversation`
-  parameter or `previous_response_id` for continuity.
+  parameter or `previous_response_id` for continuity — unaffected by owner-binding
+  mechanism, preserving cross-version stateless replay in both `delegated` and
+  `capability` modes.
 - **FF-3 History-blind stateless container:** RBAC assertion that the hosted-agent
   identity holds no Conversations data-plane role; wire test asserts the container
   issues no read/append and only generates from supplied input.
 - **FF-4 Owner gate before read:** a `(caller, conversation_id)` with no valid
-  owner binding (no capability match / signature / `oid` equality) returns
-  **404**; a caller ID never reaches a managed-Conversations read without a prior
-  owner-binding validation.
+  owner binding (no capability match / signature / `oid` equality / valid
+  asserted header) returns **404**; a caller ID never reaches a
+  managed-Conversations read without a prior owner-binding validation.
 - **FF-5 Managed Conversations is SoR / no Cosmos chat:** after a turn, items are
   readable via the Conversations data API; hosted/no-panel constructs history
   solely from it; assert no Cosmos chat client is instantiated and any owner index
@@ -577,43 +811,92 @@ owner-index rows can be dropped.
   passthrough unchanged and independent of history ownership.
 - **FF-9 Canonical wire conformance:** requests/responses validate against the
   Responses schema/SDK types (stateless input-items mode).
+- **FF-10 Environment evidence gate is protocol+RBAC, not per-deploy pentest:**
+  `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED` flips to `true` only via an
+  automatable check of (a) `HOSTED_CONVERSATION_PROTOCOL_VERSION` equals
+  `responses/2.0.0` and (b) the BFF's endpoint-call identity's role
+  assignments equal exactly `Foundry Agent Consumer` +
+  `UserIdentityImpersonation` at agent scope — never a manual/undocumented
+  toggle.
+- **FF-11 Header derivation only:** static/contract test asserts every code
+  path that sets `x-ms-user-identity` sources it from the BFF's own validated
+  `oid`, never from a request header, query parameter, or body field supplied
+  by the client.
+- **FF-12 No session-keyed unpartitioned state (forward-looking):** static/code
+  review gate — any new container-side or downstream cache/store introduced
+  after this ADR must key exclusively by validated `oid` (or an
+  `oid`-partitioned derivative), never by session/agent-thread ID alone; a
+  lint/review checklist item blocks merging a session-ID-only cache key,
+  consistent with the observed platform behavior that session **membership**
+  is not fenced even though the response chain/history is.
 
 ## Documentation impact
 
 Update the hosted-agent operator page on the `docs` branch: describe BFF-mediated
 owner-bound continuity, the container's stateless/history-blind role, the
-`capability` (store-free default) vs `delegated` selector and its OQ-OWN gate, the
-capability lifecycle (mint/verify/rotate/TTL), the bounded-history policy and its
-App Configuration keys, the fail-closed 404/error semantics, and
-an explicit preview note that platform server-side `conversation` /
-`previous_response_id` threading is not durable across version replacement.
-Explicitly document that container-side history read/replay is prohibited.
+`delegated` (native header, chosen/default post-gate) vs `capability`
+(store-free fallback) selector and its environment evidence gate, the
+delegated-header derivation rule (server-side only, never from client) and its
+RBAC requirement (`Foundry Agent Consumer` + custom `UserIdentityImpersonation`
+at agent scope), the capability lifecycle (mint/verify/rotate/TTL), the
+bounded-history policy and its App Configuration keys, the fail-closed
+404/error semantics, and an explicit preview note that platform server-side
+`conversation` / `previous_response_id` threading is not durable across version
+replacement. Explicitly document that container-side history read/replay is
+prohibited, and that session **membership** is not fenced by the platform even
+though the response chain/history is — so no unpartitioned container/session
+state may ever be stored.
 
 ## Review trigger
 
 Reassess when any of the following occurs:
 
-- **OQ-OWN resolves:** live evidence proves (or denies) native per-user enforcement
-  for delegated managed-Conversations reads on the precise token/call path — only
-  then may `delegated` be enabled and the validation gate set.
+- **OQ-OWN resolved for this call path:** live evidence
+  ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245),
+  cleanup:
+  [comment](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212334345))
+  proves native per-user response-chain/`get_history` enforcement for the
+  exact BFF/hosted-agent call path, on protocol `responses` 2.0.0, with the
+  narrow `Foundry Agent Consumer` + custom `UserIdentityImpersonation` RBAC at
+  agent scope. `delegated` is now the chosen/default mechanism once the
+  environment evidence gate (protocol + RBAC confirmation) is met; `capability`
+  remains the fallback. **Not automatically inherited by ADR-0004's panel-path
+  gate** (`PANEL_HISTORY_OWNER_BINDING_VALIDATED`) — that gate requires its own
+  independent confirmation for the panel's call shape, per the discipline that
+  each call path needs its own live evidence.
 - Foundry changes `/responses` gateway session/pre-routing so a top-level
   `conversation` survives immutable-version/compute replacement, or provides an
   official rebind/continuation lifecycle.
 - Foundry changes managed-Conversations identity/RBAC, header propagation, ordering,
   optimistic concurrency, or `store` semantics affecting read/append design.
+- Foundry changes the platform's session-membership fencing behavior (currently
+  weaker than response-chain fencing per live evidence) — reassess the
+  unpartitioned-storage prohibition if membership becomes fenced too.
 - Hosted agents leave preview.
 - Any NST or FF regresses in validation or production, or a security review reports
   a cross-user or service-identity read path.
 
 ## Open questions
 
-- **OQ-OWN (blocking `delegated` default):** does managed Conversations accept a
-  **delegated user token** and enforce per-user/owner authorization for the exact
-  BFF token/call path? If yes → `delegated` may supersede `capability` for reads
-  and the owner index is not needed for reads. If no → the store-free
-  `capability` binding stays and container-side/service-ID reads remain
-  prohibited. Live two-user experiment in progress; design is safe regardless
-  (`capability` default, zero Cosmos in no-panel).
+- **OQ-OWN (RESOLVED for hosted-continuity call path):** does managed
+  Conversations accept a delegated/asserted user identity and enforce
+  per-user/owner authorization for the exact BFF↔hosted-agent call path?
+  **Yes** — live two-identity experiment
+  ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245))
+  confirms cross-user 404 on `previous_response_id` continuation and stored-response
+  read, on protocol `responses` 2.0.0, with narrow `Foundry Agent Consumer` +
+  custom `UserIdentityImpersonation` RBAC at agent scope. `delegated`
+  supersedes `capability` as the default once the environment evidence gate
+  (protocol + RBAC) is met for the deployment; `capability` remains the
+  fully-specified fallback (zero Cosmos in no-panel either way). **Residual/still
+  open:** (a) the asserted header is middle-tier-trusted, not
+  cryptographically proven by the platform — treat as a residual-trust
+  invariant, not a closed risk; (b) session **membership** is not fenced by the
+  platform (a differently asserted identity can enter a session), motivating
+  the new "never store unpartitioned container/session-keyed data" invariant;
+  (c) this does **not** resolve issue #591's separate document-level-authorization
+  question, and does **not** automatically resolve ADR-0004's independently-tracked
+  panel enumeration/read gate.
 - **OQ-1 (ordered read + concurrency):** confirm the managed-Conversations data
   API (used by the BFF, not the container) supports ordered read and an
   optimistic-concurrency / turn-sequence primitive sufficient for FF-7. If not,
@@ -629,11 +912,14 @@ Reassess when any of the following occurs:
 - **OQ-CAP (capability sufficiency):** confirm the signed capability envelope
   (`{oid, conversation_resource_id, issued_at, expiry, key_id}`) plus live-token
   `oid` equality is sufficient owner binding for reads/appends with no store, and
-  finalize TTL/rotation defaults — shared with ADR-0004 OQ-611-CAP.
+  finalize TTL/rotation defaults — shared with ADR-0004 OQ-611-CAP. Remains
+  relevant as the fallback mechanism even after OQ-OWN resolution.
 - **OQ-REVOKE (revocation granularity):** in no-panel there is no per-capability
   revocation (only TTL expiry + key rotation as bulk revocation); confirm this is
   acceptable or require the panel/owner-index for fine-grained revocation —
-  shared with ADR-0004 OQ-611-REVOKE.
+  shared with ADR-0004 OQ-611-REVOKE. Also applies to `delegated` mode: confirm
+  whether the platform offers any session/response revocation primitive beyond
+  the environment evidence gate flip.
 - **OQ-7 (cancel/background lifecycle):** define cancel/partial-turn behavior;
   recommend synchronous streaming with completed-turn-only append for the first
   release, so a cancelled turn appends nothing.

--- a/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
+++ b/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
@@ -1,0 +1,743 @@
+# ADR-0004: Owner-bound managed-Conversations panel contract to finish the hosted-agent feature (issue #611)
+
+**Status:** Proposed<br>
+**Date:** 2026-08-07<br>
+**Owners:** GPT-RAG maintainer (Paulo), architecture analysis, with gpt-rag-ui,
+gpt-rag-orchestrator, and gpt-rag-ingestion component owners
+
+## Context
+
+ADR-0001 packaged GPT-RAG orchestration as a Foundry hosted agent, made the
+orchestrator Container Apps optional, and froze two facts that bind this ADR:
+
+- Hosted modes use **Foundry managed Conversations** as the chat-history system
+  of record. **No Cosmos** carries chat content in hosted/no-panel. Feedback and
+  administrative curation metadata live in Cosmos and exist **only when the
+  administrative panel is deployed** (`DEPLOY_ADMINISTRATIVE_PANEL=true`).
+- Hosted versions are immutable; update = publish + switch, rollback = revert.
+
+ADR-0003 made multi-turn continuity **application-managed against managed
+Conversations**, keyed by a stable logical conversation ID carried in Responses
+**request metadata** (never the top-level `conversation` routing parameter,
+which 404s across version replacement).
+
+**Reconciliation with the approved zero-RBAC invariant (this revision).** A
+subsequent security review tightened the container invariant beyond ADR-0003's
+original wording. The approved invariant is now: **the hosted container must
+hold NO managed-Conversations data-plane RBAC at all — neither read nor
+write.** This is stronger than "history-blind reads." The reason is decisive:
+per ADR-0001 the Foundry gateway strips the `Authorization` header, so **the
+user token never reaches the container**. A container therefore has **no
+authenticated source of the owner principal**; any owner value it wrote would be
+derived from caller-supplied request metadata and is **forgeable by a direct
+Foundry caller**. Granting the container even append/write RBAC would let a
+direct caller (or a compromised version) write items and stamp arbitrary
+ownership. Consequently, ADR-0003's design of "the hosted agent retrieves and
+persists items to managed Conversations" is **superseded on the persistence
+location only**: the container becomes **purely stateless** — it receives a
+**complete, ordered set of input items** each turn and returns output, exactly
+the "canonical stateless Responses input" ADR-0003 confirmed remains viable —
+and **all** managed-Conversation create/read/append/delete plus the owner index
+move to the **authenticated UI BFF**, which is the only component holding the
+user identity. ADR-0003's other freezes (managed Conversations as SoR, logical
+ID in metadata, no top-level `conversation` param, bounded replay) are
+unchanged; only *who* touches the Conversations data plane changes.
+
+Issue #611 requires the **optional panel** to finish the feature, not just ship
+no-panel preview. The panel must support **history, feedback, curation, and
+overview**. This ADR decides the ownership, identity model, and versioned API
+contract for those four surfaces without violating ADR-0001/0003 freezes and
+while honoring the stricter zero-RBAC container invariant above.
+
+### Inventory (executable sources of truth, read-only)
+
+Release pins (`manifest.json`): umbrella `v3.7.0`; gpt-rag-ui `v2.3.13`,
+gpt-rag-orchestrator `v3.8.0`, gpt-rag-ingestion `v2.5.0`.
+
+Runtime and contract facts observed in this repository and the pinned
+components:
+
+- **gpt-rag-ingestion** (`dataingest` ACA, always deployed for indexing) hosts a
+  FastAPI app that already mounts `api.admin` (operator dashboard router), a
+  Vite-built admin frontend (`/dashboard`, `/assets`), and `api.retrieval`
+  (`POST /retrieve`, the fail-closed Toolbox boundary). It authenticates
+  internal callers by `X-API-KEY` (`validate_api_key_header`) and validates a
+  **delegated user bearer** only for `POST /ingest-documents` and `POST
+  /retrieve` (`validate_delegated_user_bearer`, which rejects app-only tokens
+  and requires `idtyp=user` + `scp`). Its identity holds Search/Storage/Cosmos
+  data roles for ingestion, **not** managed-Conversations read authority.
+- **`POST /retrieve`** (`retrieval_v2.py`) is the reference fail-closed pattern:
+  server-owned index and identity, caller-supplied IDs are schema violations
+  (`extra="forbid"`), disabled-by-default returning **503** unless
+  `HOSTED_RETRIEVAL_ENABLED` **and** `HOSTED_RETRIEVAL_INV_002_VALIDATED` are
+  both true, bounded outputs, Search failures → 502, and the user bearer is
+  forwarded unchanged to Search via `x-ms-query-source-authorization` for native
+  trimming. Tests in `test_retrieval_v2.py` assert 403 on app-only tokens and
+  503 when the evidence gate is unset.
+- **gpt-rag-ui** (`frontend` ACA, deployed in every mode that serves chat) is
+  the Chainlit thin BFF that holds the **user Entra token**, performs OBO, and
+  owns the logical conversation ID (ADR-0001/0003). It is the only component in
+  the hosted path that has the end-user identity in hand.
+- **Cosmos** (`main.parameters.json`) has a `conversations` container
+  partitioned by `/principal_id` with composite indexes on
+  `isDeleted`/`_ts`/`name` — the classic-mode chat store. Hosted modes must not
+  repopulate it with protected chat content.
+- **Current 501 behavior:** in hosted mode the panel/history call path returns
+  **HTTP 501 Not Implemented** because no authorized cross-repo
+  managed-Conversations contract exists yet. 501 is the correct fail-closed
+  placeholder: it neither invents a service-identity read nor leaks data.
+
+### The security problem this ADR must not get wrong
+
+The panel needs to show a user their own conversations from managed
+Conversations. Four constraints are non-negotiable:
+
+1. The hosted container holds **zero managed-Conversations data-plane RBAC** —
+   neither read nor write. It is stateless: it receives complete ordered input
+   items and returns output, and never touches the Conversations data plane.
+2. **Owner identity must come from an authenticated source**, never from
+   caller-supplied request metadata. Only a component that validates the user
+   token (the UI BFF) may assert an owner principal. A **direct Foundry caller
+   must be unable to forge ownership** — which it cannot, because it can only
+   reach the stateless container, and the container writes nothing to
+   Conversations and holds no ownership authority.
+3. A **caller-selected conversation ID must never drive a service-identity
+   read**. That is a classic confused-deputy / IDOR: caller supplies another
+   user's ID, a service credential reads it, and per-user isolation is lost.
+   Every read is preceded by an authenticated owner check.
+4. The panel must **fail closed** and must **not duplicate protected
+   conversation content into Cosmos**. Cosmos carries only feedback and
+   curation **metadata** where strictly necessary.
+
+The evolving decision, under live **OQ-OWN** testing, is the **owner-binding
+mechanism used by the authenticated UI BFF**. Two concerns must be separated,
+because conflating them created a contradiction (a Cosmos-backed owner index
+cannot be the default in hosted/no-panel, where **no Cosmos is deployed**):
+
+- **Per-conversation owner binding (continuity + single-conversation history) —
+  required in ALL hosted modes including no-panel.** Baseline is a
+  **server-issued, signed, opaque, owner-bound conversation capability** minted
+  by the BFF from the validated user token; it requires **no persistent store**
+  and therefore holds in no-panel with zero Cosmos. The target, when **OQ-OWN**
+  proves it, is **delegated OBO** reads where Foundry enforces per-user access
+  natively.
+- **Cross-conversation enumeration (the panel "list my conversations") — a
+  panel-only feature.** It legitimately requires a metadata store and therefore
+  exists **only** when `DEPLOY_ADMINISTRATIVE_PANEL=true`, backed by the
+  BFF-authored **owner index** in panel Cosmos (or delegated enumeration under
+  OBO). In hosted/no-panel there is simply **no enumeration endpoint** — the user
+  continues the conversation they hold a capability for; there is no list to
+  recover. This is expected and acceptable.
+
+In both concerns the authority is the BFF, never the container. This ADR decides
+everything invariant across the OQ-OWN outcome and makes only the BFF mechanism
+selectable, defaulting to the store-free capability until OQ-OWN passes.
+
+### Resolving the no-panel / no-Cosmos continuity contradiction
+
+The prior revision wrongly made the Cosmos owner index the default owner-binding
+for continuity. But continuity is needed in hosted/no-panel, where no Cosmos is
+provisioned. The smallest enforceable fix that adds **no chat content, no new
+always-on compute, and no store in no-panel** is a **signed owner-bound
+conversation capability**:
+
+- **Shape.** An opaque token = `base64url(payload) . base64url(HMAC/JWS over
+  payload)` where payload = `{ oid, conversation_resource_id, issued_at, expiry,
+  key_id }`. It carries **no chat content** — only a pointer, the owner, and
+  lifetime/key metadata.
+- **Minting.** Only the BFF mints, and only from a **validated user token**: at
+  conversation creation it derives `oid` from the verified token, allocates the
+  managed Conversation, and signs the capability. The container never mints (no
+  token, no signing key).
+- **Verification (every turn / history read).** The BFF (1) verifies the
+  signature with the active key, (2) checks `expiry`, and (3) asserts the
+  capability's `oid` **equals the current authenticated user's `oid`**. Only then
+  does it read prior items by `conversation_resource_id` and assemble stateless
+  input. Any failure → uniform **404**. A raw caller-selected conversation ID is
+  never accepted; the only accepted reference is a signed capability whose owner
+  is re-checked against the live token.
+- **Signing key.** A secret in **Key Vault** referenced from App Configuration,
+  reusing the existing `AUDIT-HMAC-KEY` provisioning precedent (created from
+  cryptographically random bits when absent, only its reference stored in App
+  Config). Key Vault exists in all modes; the BFF (`frontend` ACA) already holds
+  `KeyVaultSecretsUser`. **No Cosmos, no storage account, no new compute.**
+- **Key rotation / revocation.** `key_id` names the active version. Rotation
+  advances `key_id` and retains the previous verification key for a bounded
+  overlap window; capabilities minted under a retired key fail verification after
+  overlap (bulk revocation). Because there is no per-capability store in
+  no-panel, **fine-grained single-capability revocation is not available in
+  no-panel**; it is bounded instead by a **short TTL with rolling re-mint** (each
+  successful turn returns a fresh capability), keeping the live theft window
+  small. Per-conversation revocation/delete IS available in panel mode via the
+  owner index/SoR delete.
+- **Restart / browser persistence.** The capability is **self-contained**, so a
+  BFF restart loses no server state (nothing is stored server-side). The client
+  persists it in the Chainlit user session / secure `HttpOnly` cookie. If the
+  browser/session loses it in no-panel, the pointer is gone and the user starts a
+  new conversation (no enumeration exists to recover it) — acceptable for
+  no-panel; recovery is exactly what the optional panel adds.
+- **List / history behavior.** No-panel: history of the **held** conversation
+  works via its capability; there is **no** cross-conversation list. Panel:
+  enumeration is added via the owner index; each listed conversation is rendered
+  through the same capability/owner-gate before any content read.
+- **Panel `{id}` is a lookup key, never a self-authorizing reference.** The
+  `{id}` a panel client passes on `/panel/conversations/{id}/...` endpoints is
+  the raw `conversation_resource_id` returned by enumeration (metadata only —
+  see the panel endpoint table). It is **never** trusted on its own. Before any
+  read/write, the BFF performs an **owner check** for that `{id}`: an
+  owner-index row lookup asserting `principal_id == live oid` (Option A) or an
+  equivalent delegated per-user authorization (Option B). Only after that
+  check succeeds does the BFF treat `{id}` as `conversation_resource_id` and
+  proceed — internally, this may reuse or mint a capability to perform the
+  actual read, but the **client is never required to hold or present a
+  capability for panel browsing**; the owner check on `{id}` is the
+  authorization, consistent with "no caller-selected raw ID drives a
+  service-identity read" because the read is never driven by `{id}` alone —
+  it is driven by `{id}` **conditioned on** a passing owner check.
+- **Replay / theft.** The capability is **not sufficient by itself** — a read
+  also requires a valid Entra user token whose `oid` matches the capability's
+  `oid`. A stolen capability presented by a different user fails the `oid`
+  equality check (→404). Theft is only useful if the victim's Entra session is
+  also compromised, which is out of this boundary's scope. Short TTL + rolling
+  re-mint further bound replay.
+- **404 equivalence.** Bad signature, expired, wrong `oid`, retired key, or
+  unknown conversation all return an identical **404** — no existence oracle.
+- **Direct-caller spoofing.** Direct Foundry callers reach only the stateless,
+  zero-RBAC container; they cannot mint (no signing key) or forge a capability,
+  and the container reads/writes/owns nothing. Ownership only ever originates
+  from a BFF mint over a validated token.
+- **Sufficiency for cross-version continuity.** Yes. The capability carries
+  `conversation_resource_id`, which points at the managed Conversation (SoR) that
+  **survives version/compute replacement** (ADR-0003 evidence). The capability is
+  not a version-bound gateway session (unlike the top-level `conversation`
+  param), so it does not 404 across version swaps. Each turn is a fresh stateless
+  request; continuity = capability (pointer+authz) + managed Conversations (SoR).
+  The capability holds no content and is not the SoR.
+
+An existing generic private store (e.g., the provisioned `conversation-cache`
+Blob container) was considered for owner→conversation metadata in no-panel and
+**rejected for the continuity path**: it reintroduces a persistent store, a
+write path, and consistency/cleanup obligations that the capability avoids
+entirely. A store remains justified **only** for the panel enumeration feature,
+where cross-conversation listing genuinely needs one — and there it is Cosmos,
+gated by the panel flag.
+
+### Affected repositories
+
+- `Azure/GPT-RAG` (this repo) — App Configuration contract (label `gpt-rag`),
+  the versioned `contracts/conversations-panel-v1` schema, the panel deploy flag
+  wiring, this ADR. Infra must assign managed-Conversations data-plane RBAC to
+  the **UI BFF identity only** (Option A) or none (Option B/OBO), and **never**
+  to the hosted agent / container identity.
+- `Azure/gpt-rag-ui` — **exclusive owner** of all managed-Conversation
+  create/read/append/delete and the owner index, and of user-facing
+  list/read/feedback/deletion. It is the only component holding the user token,
+  so it is the only authenticated source of the owner principal (the validated
+  `oid`). Per turn it: validates the token, owner-gates, reads prior ordered
+  items, sends a **complete stateless input set** to the container, receives
+  output, and appends the new user/assistant items.
+- `Azure/gpt-rag-ingestion` — **operator-facing** panel backend for **overview
+  metrics over metadata** and **corpus/document curation it already has content
+  access to**. It has **no conversation-content access** and exposes **no
+  curation derived from conversation content**. Replaces the 501 only for these
+  metadata/corpus surfaces; keeps its evidence-gated, fail-closed posture.
+- `Azure/gpt-rag-orchestrator` — the hosted agent/container is **stateless**:
+  it receives complete ordered input items and returns output. It holds **zero
+  managed-Conversations RBAC**, creates/reads/appends nothing, and stamps no
+  ownership. It cannot be an owner authority because it never sees the user
+  token.
+
+### Prioritized characteristics (measures)
+
+1. **Authorization correctness / fail-closedness** — no cross-user read, no
+   service-identity read driven by a caller ID, disabled surfaces return 503,
+   non-owner returns 404 (no existence disclosure). (Two-user negative tests.)
+2. **Content confinement** — zero protected chat content written to Cosmos or
+   telemetry; overview metrics carry counts only. (Store-inspection tests.)
+3. **Container zero-RBAC** — the hosted agent/container identity holds **no**
+   Conversations data-plane role, read or write. (RBAC assertion / infra review.)
+4. **Owner-authenticity / anti-spoof** — ownership is asserted only from a
+   validated user token by the BFF; a direct Foundry caller cannot forge
+   ownership. (Negative test: direct call cannot create/own a conversation.)
+5. **Reversibility** — every surface is behind one flag; default preserves
+   today's 501/absent-panel behavior. (Config-flip test.)
+6. **Operability under the immutable-version + network-isolated model** — no new
+   always-on compute; works with private endpoints. (Topology matrix.)
+
+## Alternatives considered
+
+### Option A: BFF-minted signed owner-bound capability for continuity (all modes), plus a panel-only owner index for enumeration (chosen baseline)
+
+The **UI BFF** is the sole component that touches the Conversations data plane.
+On the first turn the **authenticated BFF** (holding the validated user token,
+`oid`) creates the managed Conversation, writes the new items, and mints a
+**signed owner-bound capability** = signed `{oid, conversation_resource_id,
+issued_at, expiry, key_id}`. The owner principal is the **validated `oid`**,
+never caller metadata. The capability holds **no chat content** and needs **no
+store** — so it works in hosted/no-panel with **zero Cosmos**. The stateless
+container receives the complete ordered input set the BFF assembles and returns
+output; it writes nothing.
+
+- Per-conversation reads (all modes): the BFF verifies the capability signature,
+  checks expiry/`key_id`, and asserts the capability `oid` **equals the live
+  authenticated `oid`**; only then reads items by `conversation_resource_id`.
+  Any failure → **404**. A raw caller-selected ID is never accepted.
+- Enumeration (**panel only**, `DEPLOY_ADMINISTRATIVE_PANEL=true`): the BFF also
+  records a **minimal owner-index** row — `principal_id → {conversation_id,
+  title, timestamps}` — in the panel Cosmos container so the panel can list the
+  user's conversations. `GET /panel/conversations` returns only rows where
+  `principal_id == oid`; each item still passes the capability/owner gate before
+  any content read. **Metadata only; no message content.** In no-panel this store
+  and endpoint do not exist; continuity is unaffected.
+- Anti-spoof: a direct Foundry caller reaches only the stateless container, which
+  has zero Conversations RBAC and mints/owns nothing. Ownership originates only
+  from a BFF mint over a validated token; a capability cannot be forged without
+  the Key Vault signing key.
+- Operator surfaces (gpt-rag-ingestion): overview reads **counts over metadata**
+  only; corpus curation operates on documents ingestion already indexes — never
+  on conversation content.
+- Benefits: works today in **every** mode with no store for continuity; no
+  dependency on unproven delegated auth; **container holds zero Conversations
+  RBAC**; owner authority is the authenticated BFF; matches the `POST /retrieve`
+  fail-closed idiom and the `AUDIT-HMAC-KEY` Key Vault precedent.
+- Costs and risks: the **BFF service identity** holds Conversations read/write
+  RBAC, so the confused-deputy risk is concentrated there and mitigated by the
+  capability `oid`-equality gate. No-panel lacks fine-grained per-capability
+  revocation (bounded by short TTL + rolling re-mint and by key rotation); the
+  panel adds per-conversation revocation via the owner index/SoR delete. The BFF
+  must keep the (panel-only) index consistent with the SoR; a stale row can only
+  cause a 404 or a spurious list entry, never content disclosure.
+- Security and identity: the gate is a **server-side check** binding a signed,
+  token-derived capability to the live token `oid` — not a caller claim and not
+  forgeable by the container. Cosmos (panel only) holds only `principal_id` +
+  identifiers/titles.
+- Operational consequences: no new ACA; signing key in Key Vault (all modes);
+  owner index in panel-only Cosmos; works network-isolated over private
+  endpoints. Infra grants Conversations RBAC to the **BFF identity only**.
+- Component compatibility: coordinated change across all four repos; App
+  Configuration selector + capability-key keys; one `contracts/` schema.
+- Reversibility: continuity mechanism is a single selector; panel enumeration is
+  behind the panel flag; when a surface is off it returns 503 and writes nothing.
+
+### Option B: Native delegated (OBO) reads/writes against managed Conversations from the BFF (preferred target, gated on OQ-OWN)
+
+The BFF exchanges the user token (OBO) for a token that reads **and writes**
+managed Conversations **as the user**, so Foundry/Conversations enforces per-user
+authorization natively — the same philosophy as `POST /retrieve` forwarding the
+user bearer to Search. No GPT-RAG-authored owner index is needed, and the **BFF
+holds no standing Conversations RBAC**.
+
+- Benefits: authorization enforced by the platform at the data plane; no
+  GPT-RAG-owned ownership state; cleanest confused-deputy elimination; the BFF
+  needs no ambient Conversations role; smallest long-term surface.
+- Costs and risks: **depends on OQ-OWN** — whether the managed Conversations data
+  API accepts a delegated user token and enforces per-user/owner access. If it
+  only accepts a service credential, Option B collapses into a service-read and
+  is **unsafe by itself**; it must not ship without native per-user enforcement
+  proven.
+- Security and identity: strongest when supported; the container still holds no
+  role — the **user's** delegated token authorizes reads/writes, minted by the
+  BFF which already holds the user token.
+- Operational consequences: no index to keep consistent; requires a Conversations
+  query-token audience config, analogous to `HOSTED_RETRIEVAL_TOKEN_AUDIENCE`.
+- Component compatibility: same repo set; the mechanism differs only inside the
+  BFF behind the selector.
+- Reversibility: single flag; can fall back to Option A.
+
+### Option C: A service identity (container or panel) reads/writes by caller-supplied conversation ID or caller-supplied owner (rejected)
+
+Let any service identity create/read managed Conversations using caller-supplied
+IDs or caller-supplied ownership — including the container stamping owner from
+request metadata.
+
+- Benefits: trivial to implement.
+- Costs and risks: **rejected on security grounds.** Two failures: (1) cross-user
+  IDs would drive service-identity reads (confused-deputy/IDOR); (2) ownership
+  stamped from caller metadata is **forgeable by a direct Foundry caller**, since
+  the container never sees the user token. It also requires granting the
+  container Conversations RBAC, violating the zero-RBAC invariant.
+- Reversibility: n/a — unsafe at any setting.
+
+### Option D: Panel backend on a revived orchestrator ACA (rejected for this feature)
+
+Bring the orchestrator Container Apps back as the panel backend (original
+ADR-0001 wording).
+
+- Benefits: a dedicated home; matches the earliest sketch.
+- Costs and risks: reintroduces the compute ADR-0001 removed; in no-panel mode
+  it is absent, so it cannot host owner-bound reads without also being deployed;
+  it does not hold the user token (the UI does), so owner-binding would still
+  route through the UI. More resource, no security benefit.
+- Reversibility: heavier; a whole app toggles.
+
+### Do not change (Option E)
+
+- Benefits: none beyond deferral; keeps the safe 501.
+- Costs and risks: the hosted-agent feature **cannot finish** — no history,
+  feedback, curation, or overview in hosted mode. Fails issue #611.
+
+## Decision
+
+Finish the hosted panel with an **owner-bound, fail-closed, content-confining**
+contract in which the **container holds zero managed-Conversations RBAC** and
+the **authenticated UI BFF exclusively owns** managed-Conversation
+create/read/append/delete and the owner index, split by audience across
+already-deployed compute, with the BFF read mechanism selectable and defaulted
+to the safe state:
+
+1. **Stateless container, BFF-exclusive Conversations.** The hosted
+   agent/container is stateless: it receives a **complete ordered input set**
+   from the BFF each turn and returns output. It holds **zero
+   managed-Conversations data-plane RBAC** and never creates, reads, appends, or
+   deletes conversation items or ownership. The **gpt-rag-ui BFF** — the only
+   component holding the user token — performs, per turn: token validation →
+   owner gate → read prior ordered items → assemble complete stateless input →
+   call container → append new user/assistant items. It is the sole authenticated
+   source of the owner principal (validated `oid`). This supersedes ADR-0003's
+   in-container persistence on the *location* of the write only.
+
+2. **No new ACA.** User-facing history/feedback/deletion land in the
+   **gpt-rag-ui** BFF (it holds the user token → owner-binding). Operator-facing
+   **overview metrics (metadata counts)** and **corpus/document curation**
+   (content ingestion already indexes) land in the **gpt-rag-ingestion** admin
+   app, replacing the 501 for those surfaces. Ingestion exposes **no curation
+   derived from conversation content** — it has no conversation-content access.
+   The panel **frontend** extends the existing ingestion Vite admin dashboard for
+   the **operator** overview/corpus-curation views and reuses the Chainlit UI for
+   the **user** history/feedback views. Smallest safe footprint: endpoints attach
+   to compute that already runs.
+
+3. **Owner-binding is invariant; the BFF mechanism is a selector; continuity is
+   store-free.** Ship **Option A** baseline: per-conversation owner binding
+   (continuity + single-conversation history in **all** modes) via a **BFF-minted
+   signed owner-bound capability** that needs **no store**, plus a **panel-only**
+   owner index (Cosmos) for cross-conversation enumeration. Adopt **Option B
+   (native delegated OBO)** the moment **OQ-OWN** proves managed Conversations
+   enforces per-user authorization for delegated tokens. Both keep the
+   **container at zero Conversations RBAC** and both fail closed. **Option C is
+   prohibited.** No-panel has no enumeration endpoint and no Cosmos; continuity
+   still works via the capability.
+
+4. **Fail-closed by default.** Every panel surface is disabled unless the panel
+   is deployed **and** its evidence gate is set, mirroring `POST /retrieve`.
+   Until owner-binding is validated, hosted history keeps returning the safe
+   status (503 when the surface exists but is gated off; 501 remains acceptable
+   only where no endpoint is wired yet). No service-identity-by-caller-ID read
+   and no caller-asserted ownership is shipped in any state.
+
+5. **Content confinement.** Managed Conversations remains the sole store of chat
+   content. Cosmos (panel-only) carries feedback and curation **metadata** and
+   the owner index — identifiers, titles, timestamps, principal IDs, decisions —
+   **never** message bodies or retrieved document content. Overview metrics are
+   aggregate counts with a minimum-cardinality threshold and never join content.
+
+### Versioned API contract: `conversations-panel-v1`
+
+Owned by `Azure/GPT-RAG` in `contracts/`, byte-pinned like `audit-event-v1`,
+consumed by gpt-rag-ui (user surfaces) and gpt-rag-ingestion (operator
+surfaces). Common rules: request bodies are strict (`extra=forbid`); identity
+and index/store selection are **server-owned**; correlation via `req_[0-9a-f]{32}`
+propagated into `audit-event-v1`; pagination via **opaque, signed, expiring
+cursors** (never raw offsets or caller IDs); all list/read responses are
+bounded.
+
+User-facing (gpt-rag-ui BFF, requires delegated user token, owner-gated):
+
+| Method / path | Purpose | Authorization | Not-authorized result |
+| --- | --- | --- | --- |
+| `GET /panel/conversations?cursor=` | **Panel-only** — list the caller's conversations (id, title, created/updated); no content | Owner-index rows where `principal_id == oid` (A) or delegated list (B). **Absent in no-panel** | Empty page; never another user's rows |
+| `GET /panel/conversations/{id}/messages?cursor=` | Ordered history for one owned conversation (all modes) | **Owner check on `{id}`**: owner-index row `principal_id == live oid` (A) or delegated per-user authorization (B); only on success does the BFF read by `conversation_resource_id == {id}` (may reuse/mint a capability internally) | **404** (no existence disclosure) |
+| `POST /panel/conversations/{id}/feedback` | Create feedback **metadata** (rating, reason code, message ref) → Cosmos | Owner gate | **404** |
+| `GET /panel/conversations/{id}/feedback` | Read caller's own feedback | Owner gate | **404** |
+| `DELETE /panel/conversations/{id}` | Owner-initiated retention/deletion: delete managed Conversation items + panel metadata/index row | Owner gate | **404** |
+
+Operator-facing (gpt-rag-ingestion admin, requires operator app role / group,
+**not** end-user tokens, **no conversation-content access**):
+
+| Method / path | Purpose | Authorization | Leakage control |
+| --- | --- | --- | --- |
+| `GET /panel/corpus-curation/queue?cursor=` | **Document/knowledge-base** curation items (documents ingestion already indexes and can access) | Operator role | Corpus artifacts only; **no conversation content** |
+| `POST /panel/corpus-curation/{item_id}/decision` | Record a corpus curation decision (metadata) | Operator role | Decision + document refs only |
+| `GET /panel/overview/metrics` | Aggregate **counts over panel metadata** (conversation/feedback counts, corpus states) | Operator role | Counts only; suppress buckets below min-cardinality; **no content join** |
+
+Conversation-content curation is **not** an operator surface. If a user wishes to
+curate their own conversation (e.g., flag/redact a message), that is an
+**owner-scoped** action on a user-facing endpoint under the owner gate, never an
+ingestion-operator capability. Any future operator content-review capability
+would require a separate, explicitly-authorized, audited design and is out of
+scope here (denied by default) — see OQ-611-OPSCOPE.
+
+Error semantics (uniform): **401** missing/invalid bearer; **403** wrong token
+type/audience (app-only token on a user surface, or missing operator role);
+**404** not-owner or missing (never 403 for ownership, to avoid existence
+disclosure); **422** schema/bounds violation; **502** managed-Conversations or
+downstream failure; **503** surface deployed but evidence gate unset. Retention:
+deletion is a hard delete of managed-Conversation items plus panel metadata;
+`delete_after`-style policy intent is recorded but GPT-RAG performs no automatic
+scheduled deletion (consistent with v3.7.0 governance guidance).
+
+### App Configuration contract (label `gpt-rag`, owned by Azure/GPT-RAG)
+
+Continuity keys (apply in **all** hosted modes, including no-panel; no store).
+Authoritatively defined in ADR-0003; restated here for context — ADR-0003 is
+the source of truth if wording ever diverges:
+
+- `HOSTED_CONVERSATION_OWNER_BINDING` (default `capability`; alt `delegated`) —
+  selects per-conversation owner binding: BFF-minted signed capability (A) vs.
+  delegated OBO (B). `delegated` is inert until
+  **`HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`** (ADR-0003) is `true` for
+  the hosted continuity call path — this is a **different, independent** gate
+  from the panel-only `PANEL_HISTORY_OWNER_BINDING_VALIDATED` below; neither
+  substitutes for the other.
+- `HOSTED_CONVERSATION_CAPABILITY_KEY` — **Key Vault reference** to the HMAC/JWS
+  signing key, provisioned like `AUDIT-HMAC-KEY` (created from random bits when
+  absent; only the reference is stored in App Config). Present in all modes; no
+  Cosmos, no storage account.
+- `HOSTED_CONVERSATION_CAPABILITY_KEY_ID` (default `v1`) — active signing key
+  version; advance to rotate (previous key retained for a bounded overlap).
+- `HOSTED_CONVERSATION_CAPABILITY_TTL_SECONDS` (default e.g. `3600`) — capability
+  lifetime; the BFF re-mints a fresh capability on each successful turn (rolling)
+  to bound replay/theft in the absence of per-capability revocation.
+
+Panel keys (apply **only** when the administrative panel is deployed):
+
+- `DEPLOY_ADMINISTRATIVE_PANEL` (existing, default `false`) — provisions panel
+  Cosmos metadata containers (feedback, curation, owner index) and enables panel
+  routers, **including cross-conversation enumeration**. Absent → no Cosmos, no
+  enumeration.
+- `PANEL_HISTORY_ENABLED` (default `false`) — panel user history/feedback gate.
+- `PANEL_HISTORY_OWNER_BINDING_VALIDATED` (default `false`) — the **OQ-OWN
+  evidence gate for the panel enumeration/read call path only**, mirroring
+  `HOSTED_RETRIEVAL_INV_002_VALIDATED`. `PANEL_CONVERSATION_ENUMERATION_MODE=
+  delegated` and any delegated per-conversation panel read require it true.
+  This gate is **independent of** `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`
+  (ADR-0003) — it governs only the panel's own list/read path and never
+  unlocks `delegated` for the core hosted-continuity binding, and vice versa.
+- `PANEL_CONVERSATION_ENUMERATION_MODE` (default `owner_index`; alt `delegated`)
+  — panel-only listing backend: BFF-authored owner index in panel Cosmos (A) vs.
+  delegated user enumeration (B).
+- `PANEL_CONVERSATIONS_TOKEN_AUDIENCE` — Conversations query-token audience for
+  Option B (analogous to `HOSTED_RETRIEVAL_TOKEN_AUDIENCE`); required only in
+  `delegated` binding/enumeration.
+- `PANEL_OVERVIEW_MIN_CARDINALITY` (default e.g. `5`) — metric bucket
+  suppression threshold.
+
+## Threat model
+
+| Threat | Vector | Mitigation in this ADR |
+| --- | --- | --- |
+| **Cross-user conversation IDs (IDOR)** | Caller passes another user's `conversation_id` | Only a signed capability is accepted; the BFF re-checks the capability `oid` equals the live token `oid` before any read; miss → 404. A raw caller ID never drives a read (A) or the read is delegated as the user (B) |
+| **Capability theft / replay** | Attacker presents a stolen capability | A capability alone is **insufficient**: reads also require a valid Entra token whose `oid` matches the capability `oid`, so a different user fails the equality check (→404). Short TTL + rolling re-mint bound the window; key rotation performs bulk revocation |
+| **Capability forgery** | Attacker mints/edits a capability | Signed with a Key Vault key held only by the BFF; edits break the signature (→404); the container has no signing key and cannot mint |
+| **Direct agent/Foundry callers** | Direct caller reaches the container and tries to read/enumerate/own conversations | Container holds **zero Conversations RBAC** and never touches the data plane; it only consumes BFF-supplied stateless input, and cannot mint capabilities. It reads, writes, and owns nothing |
+| **Ownership forgery** | Caller-supplied owner in request metadata to claim a conversation | Ownership originates only from a BFF mint (capability) over a validated token `oid`; the container writes no ownership, so caller metadata can never establish ownership |
+| **Service-identity confused deputy** | A service credential reads by caller ID | Prohibited (Option C rejected). Only the **BFF identity** holds Conversations RBAC (Option A) or none (Option B/OBO); every BFF read is gated by the capability `oid`-equality check |
+| **Support/admin over-reach** | Operator role reads protected user chat content | Operator surfaces expose metadata/counts and **corpus** artifacts only; ingestion has no conversation-content access; raw conversation content is not provided and would require a separate, elevated, audited path (out of scope, denied by default) |
+| **Document-citation leakage** | Re-rendered history shows citations to documents the user has since lost access to | History stores **citation references**, not document content; render re-checks access (native trimming) before resolving a citation; snapshot-vs-live divergence recorded as OQ-611-CITE |
+| **Telemetry leakage** | Content or IDs in logs/metrics | `audit-event-v1` metadata-only; correlation IDs only; overview metrics thresholded; capability signatures/keys never logged; no conversation body or document content in any log/metric |
+| **Existence disclosure** | 403-vs-404 oracle reveals a conversation exists | Uniform **404** for bad/expired/wrong-`oid`/retired-key capability and for missing |
+| **Pagination tampering** | Caller forges cursor to page another user's data | Opaque, signed, expiring cursors bound to the authenticated principal |
+
+## Consequences
+
+### Positive
+
+- The hosted-agent feature can **finish**: history, feedback, curation, and
+  overview exist in hosted mode with a versioned, fail-closed contract.
+- No new always-on compute; endpoints attach to already-deployed UI and
+  ingestion apps; works in the network-isolated topology.
+- Container holds **zero Conversations RBAC**, managed-Conversations-as-SoR, and
+  no-Cosmos-chat freezes (ADR-0001/0003) are preserved and strengthened.
+- Safe under OQ-OWN uncertainty: the safe mechanism ships now; the preferred
+  native mechanism is a config flip once proven.
+
+### Negative or accepted
+
+- Baseline Option A adds a GPT-RAG-owned owner index that must stay consistent
+  with the SoR (bounded blast radius: at worst a 404 or a stale list row, never
+  content disclosure), and concentrates Conversations RBAC on the **BFF identity**.
+- The BFF now owns per-turn read-prior-items + assemble-stateless-input + append
+  (moved out of the container per the stricter invariant). This adds BFF logic
+  and the bounded-replay policy (ADR-0003) now lives entirely in the BFF.
+- Audience split means two backends implement one contract; the shared
+  `contracts/` schema and conformance tests keep them aligned.
+- Citation snapshot-vs-live access divergence is an accepted, documented risk
+  pending OQ-611-CITE.
+- **ADR-0003 has been revised** (see its revision note): its in-container
+  persist/replay design is superseded on location — the BFF, not the
+  container, reads/appends managed Conversations. Its other freezes are
+  retained.
+
+## Adoption and migration
+
+Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
+
+1. **Azure/GPT-RAG** — add `contracts/conversations-panel-v1` (schema +
+   `.sha256`); the App Configuration keys above (defaults preserve current
+   behavior); the **capability signing key** provisioned in Key Vault like
+   `AUDIT-HMAC-KEY` (created from random bits when absent, only its reference in
+   App Config) — present in **all** hosted modes; panel Cosmos metadata containers
+   gated by `DEPLOY_ADMINISTRATIVE_PANEL`; and infra RBAC assigning Conversations
+   data-plane roles to the **BFF identity only** and **removing any such role from
+   the hosted agent/container identity**. Publish this ADR. No runtime behavior
+   change yet.
+2. **gpt-rag-orchestrator** — make the hosted agent/container **stateless**:
+   remove any managed-Conversations read/append/persist from the container and
+   confirm it consumes only the BFF-supplied complete ordered input. Remove any
+   Conversations RBAC from the container identity. No owner stamping and no
+   capability minting in the container (it has no authenticated identity or key).
+   Emit `audit-event-v1` for the turn only.
+3. **gpt-rag-ui** — the BFF becomes the **exclusive** Conversations owner and the
+   **sole capability minter/verifier**. Continuity (all modes,
+   `HOSTED_CONVERSATION_OWNER_BINDING=capability`): on create, allocate the
+   managed Conversation and mint a signed owner-bound capability from the
+   validated `oid`; per turn, verify capability (signature + expiry + `oid`
+   equality) → read prior items by `conversation_resource_id` → assemble complete
+   stateless input → call container → append items → re-mint a fresh capability.
+   Panel (when deployed): also write/read the owner index for enumeration behind
+   `PANEL_HISTORY_ENABLED` + (`delegated` requires
+   `PANEL_HISTORY_OWNER_BINDING_VALIDATED`); implement history/feedback/deletion.
+   Never accept a raw caller-selected ID.
+4. **gpt-rag-ingestion** — implement operator **overview (metadata counts)** and
+   **corpus/document curation** routers behind `DEPLOY_ADMINISTRATIVE_PANEL`,
+   replacing the 501 for those surfaces; **no conversation-content access or
+   conversation-content curation**; fail-closed 503 when gated off; operator-role
+   check plus existing bearer patterns.
+5. Revalidate in Basic and network-isolated topologies; run the two-user negative
+   suite, the direct-caller anti-spoof test, and a **capability
+   theft/expiry/rotation** test; validate **no-panel continuity with zero Cosmos**;
+   then update `manifest.json` pins for all changed components together.
+
+Migration boundaries: no backfill. Existing classic Cosmos-backed history is
+untouched and remains the classic path. Hosted/no-panel provisions **no Cosmos**
+and uses store-free capability continuity; hosted/panel adds the Cosmos owner
+index for enumeration only.
+
+Rollback: flip `HOSTED_CONVERSATION_OWNER_BINDING`/`PANEL_HISTORY_ENABLED`/
+`DEPLOY_ADMINISTRATIVE_PANEL` as needed and revert the coordinated manifest pin.
+Because managed Conversations is SoR, the capability is stateless, and Cosmos
+holds only metadata, no chat-content migration is needed either direction;
+owner-index rows are metadata and can be dropped; rotating
+`HOSTED_CONVERSATION_CAPABILITY_KEY_ID` invalidates outstanding capabilities.
+
+## Compliance verification (fitness functions)
+
+- **FF-1 Owner gate (deterministic):** `GET /messages`, feedback, and delete for
+  a capability whose `oid` ≠ live token `oid`, or an absent/forged capability,
+  return **404**; a raw caller-selected ID is never accepted. Unit + contract.
+- **FF-1b Capability lifecycle (deterministic):** a tampered signature, expired
+  capability, or capability minted under a retired `key_id` (past overlap) all
+  return **404**; a valid capability with matching `oid` succeeds; a successful
+  turn returns a fresh (rolling) capability. Unit tests over the signer/verifier.
+- **FF-1c No-panel continuity with zero store (live):** in hosted/no-panel
+  (`DEPLOY_ADMINISTRATIVE_PANEL=false`, no Cosmos), a multi-turn conversation
+  retains prior context via the capability across turns **and** across an
+  immutable-version/compute replacement, with **no Cosmos provisioned** and no
+  gateway 404 (ties to ADR-0003 FF-1).
+- **FF-2 Two-user negative (live):** user A creates a conversation; user B's list
+  (panel) omits it; B presenting A's capability with B's token, or A's raw ID,
+  fails `GET /messages`, feedback POST/GET, and DELETE with 404; operator overview
+  shows counts without content. Reuse INV-002.
+- **FF-3 Content confinement:** after any operation, assert **no** message body or
+  document content exists in Cosmos, the capability, or telemetry; overview
+  responses contain only counts and suppress sub-threshold buckets.
+- **FF-4 Container zero-RBAC (strengthened):** infra/RBAC assertion that the
+  hosted agent/container identity holds **no** Conversations data-plane role
+  (read *or* write) and has **no** capability signing key; a container-originated
+  read/append/create attempt fails at the platform. Conversations RBAC exists
+  **only** on the BFF identity (Option A) or nowhere (Option B/OBO).
+- **FF-4b Anti-spoof / direct caller (live):** a direct Foundry call to the
+  container cannot create, own, read, or append a conversation, and cannot mint a
+  capability; caller-supplied owner metadata never establishes ownership; the only
+  conversations that exist are those the authenticated BFF created from a
+  validated token.
+- **FF-5 Fail-closed gating:** panel user history endpoints return **503** unless
+  `PANEL_HISTORY_ENABLED` (and, for `delegated`, `PANEL_HISTORY_OWNER_BINDING_VALIDATED`);
+  operator endpoints return **503** unless `DEPLOY_ADMINISTRATIVE_PANEL`;
+  `HOSTED_CONVERSATION_OWNER_BINDING=delegated` is inert until its validated gate.
+- **FF-6 Token-type enforcement:** user surfaces reject app-only tokens (403,
+  reusing the `idtyp`/`scp` checks); operator surfaces reject end-user tokens
+  lacking the operator role (403).
+- **FF-7 Contract conformance:** requests/responses validate against
+  `conversations-panel-v1`; capabilities and cursors are opaque, signed,
+  principal-bound, and expiring; the byte-pinned `.sha256` matches in both
+  consumers.
+- **FF-8 Error-semantics matrix:** 401/403/404/422/502/503 mapping verified per
+  the table, including uniform 404 for bad/expired/wrong-`oid` capability vs
+  missing.
+- **FF-9 No conversation-content curation on operator surface:** ingestion
+  operator endpoints expose no conversation body; corpus-curation touches only
+  documents ingestion already indexes.
+
+## Documentation impact
+
+Update the hosted-agent operator page on the `docs` branch: panel modes and
+flags, the `conversations-panel-v1` contract, the **stateless-container /
+BFF-exclusive-Conversations** model and the owner-binding model with its OQ-OWN
+gate, the audience split (user history/feedback in the UI, operator overview and
+**corpus** curation in the ingestion admin app — no conversation-content
+curation), the zero-Conversations-RBAC container guarantee, content-confinement
+guarantees, retention/deletion semantics, and the citation snapshot caveat. Note
+that ADR-0003 is superseded on persistence location and must be updated.
+
+## Review trigger
+
+Reassess when any of the following occurs:
+
+- **OQ-OWN resolves (two independent, per-call-path gates — neither substitutes
+  for the other):**
+  - Hosted continuity call path: managed Conversations data API confirms
+    per-user authorization for delegated tokens on the **BFF's per-turn
+    read/append path** — switch `HOSTED_CONVERSATION_OWNER_BINDING` to
+    `delegated` only after setting **`HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`**
+    (ADR-0003) true for that exact call path.
+  - Panel history/enumeration call path: the same API property confirmed
+    separately for the **panel's list/read path** — switch
+    `PANEL_CONVERSATION_ENUMERATION_MODE` (and, for per-conversation panel
+    reads, the delegated-read branch) to `delegated` only after setting
+    **`PANEL_HISTORY_OWNER_BINDING_VALIDATED`** (this ADR) true for that exact
+    call path. This gate never unlocks `HOSTED_CONVERSATION_OWNER_BINDING`,
+    and the ADR-0003 gate never unlocks panel delegated enumeration/reads —
+    each path requires its own live evidence per the "exact call path"
+    requirement.
+- Foundry changes managed-Conversations identity/RBAC, ordering, or deletion
+  semantics.
+- Any FF regresses in validation or production, or a security review reports a
+  cross-user or service-identity read path, or a capability theft/forgery path.
+- Hosted agents leave preview or change header/identity propagation.
+
+## Open questions
+
+- **OQ-OWN (governs the binding mechanism, not continuity availability):** Does
+  the managed Conversations data API accept a **delegated user token** and enforce
+  per-user (owner-bound) authorization? If yes → `delegated` (Option B) may
+  supersede the capability **for reads** and the owner index is dropped for reads.
+  If no → the **capability** (Option A) remains the store-free continuity binding
+  and Option C stays prohibited. Note: continuity is **not** blocked on OQ-OWN —
+  the capability works today with zero store; OQ-OWN only decides whether the
+  platform can enforce reads natively instead.
+- **OQ-611-CAP (capability primitives):** Confirm the signing algorithm and key
+  handling (HMAC vs JWS), Key Vault provisioning parity with `AUDIT-HMAC-KEY`,
+  the TTL/rolling-re-mint values, and the rotation overlap window. Confirm the
+  client persistence surface (Chainlit session vs `HttpOnly` cookie) meets the
+  restart/browser requirements without exposing the capability to scripts.
+- **OQ-611-OWNERSTAMP:** Confirm the **BFF** can durably record ownership — via a
+  signed capability (Option A, no store) or via managed-Conversation ownership
+  established by the user's delegated identity (Option B) — and that it survives
+  version replacement (ADR-0003). The **container never records ownership**.
+- **OQ-611-BFF-RBAC:** For Option A, confirm the minimal Conversations data-plane
+  role the **BFF identity** needs (read + append + delete for owner-gated
+  operations) scoped without granting the container any role. For Option B,
+  confirm the BFF can operate with **no standing Conversations RBAC** using OBO.
+- **OQ-611-REVOKE:** Confirm the acceptability of no fine-grained per-capability
+  revocation in no-panel (bounded by short TTL + rolling re-mint + key rotation),
+  or define a minimal revocation signal that does not reintroduce an always-on
+  store in no-panel.
+- **OQ-611-CITE:** Decide citation re-render policy — re-check live access before
+  resolving a stored citation reference vs. accept a documented snapshot risk.
+- **OQ-611-OPSCOPE:** Confirm operator identity model for ingestion panel
+  surfaces (app role vs. Entra group) and whether any elevated, audited
+  content-access path is ever in scope (default: no).
+- **OQ-611-DELRETENTION:** Confirm deletion propagation SLA/consistency between
+  managed-Conversation item delete and owner-index/feedback metadata delete
+  (panel mode).

--- a/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
+++ b/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
@@ -17,9 +17,17 @@ orchestrator Container Apps optional, and froze two facts that bind this ADR:
 - Hosted versions are immutable; update = publish + switch, rollback = revert.
 
 ADR-0003 made multi-turn continuity **application-managed against managed
-Conversations**, keyed by a stable logical conversation ID carried in Responses
-**request metadata** (never the top-level `conversation` routing parameter,
-which 404s across version replacement).
+Conversations**. The client-held reference to the managed Conversation is a
+**BFF-issued opaque locator handle** — never the raw resource ID, never
+self-authorizing, and never carried as caller-controllable request metadata
+that a service could act on. In `capability` mode (fallback/pre-gate default)
+this handle is a signed, owner-bound capability combining the locator with an
+`oid`-bound authorization check; in `delegated` mode (chosen/default once
+ADR-0003's own environment evidence gate is met) the handle is a locator only,
+and authorization is enforced per-request by the Foundry platform itself via a
+BFF-asserted `x-ms-user-identity` header derived server-side from the
+validated `oid`. Neither mode uses the top-level `conversation` routing
+parameter, which 404s across version replacement.
 
 **Reconciliation with the approved zero-RBAC invariant (this revision).** A
 subsequent security review tightened the container invariant beyond ADR-0003's
@@ -39,8 +47,9 @@ location only**: the container becomes **purely stateless** — it receives a
 the "canonical stateless Responses input" ADR-0003 confirmed remains viable —
 and **all** managed-Conversation create/read/append/delete plus the owner index
 move to the **authenticated UI BFF**, which is the only component holding the
-user identity. ADR-0003's other freezes (managed Conversations as SoR, logical
-ID in metadata, no top-level `conversation` param, bounded replay) are
+user identity. ADR-0003's other freezes (managed Conversations as SoR,
+opaque-locator-not-raw-ID, no top-level `conversation` param, bounded replay,
+and the two-mechanism owner-binding selector gated by live evidence) are
 unchanged; only *who* touches the Conversations data plane changes.
 
 Issue #611 requires the **optional panel** to finish the feature, not just ship
@@ -109,29 +118,41 @@ Conversations. Four constraints are non-negotiable:
    conversation content into Cosmos**. Cosmos carries only feedback and
    curation **metadata** where strictly necessary.
 
-The evolving decision, under live **OQ-OWN** testing, is the **owner-binding
-mechanism used by the authenticated UI BFF**. Two concerns must be separated,
-because conflating them created a contradiction (a Cosmos-backed owner index
-cannot be the default in hosted/no-panel, where **no Cosmos is deployed**):
+The evolving decision, previously under live **OQ-OWN** testing and now
+**resolved for ADR-0003's hosted-continuity call path**
+([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245)),
+is the **owner-binding mechanism used by the authenticated UI BFF**. Two
+concerns must be separated, because conflating them created a contradiction (a
+Cosmos-backed owner index cannot be the default in hosted/no-panel, where **no
+Cosmos is deployed**):
 
 - **Per-conversation owner binding (continuity + single-conversation history) —
-  required in ALL hosted modes including no-panel.** Baseline is a
-  **server-issued, signed, opaque, owner-bound conversation capability** minted
-  by the BFF from the validated user token; it requires **no persistent store**
-  and therefore holds in no-panel with zero Cosmos. The target, when **OQ-OWN**
-  proves it, is **delegated OBO** reads where Foundry enforces per-user access
-  natively.
+  required in ALL hosted modes including no-panel.** Fallback/pre-gate default
+  is a **server-issued, signed, opaque, owner-bound conversation capability**
+  minted by the BFF from the validated user token; it requires **no persistent
+  store** and therefore holds in no-panel with zero Cosmos. The chosen target
+  is the **native delegated header** mechanism (`x-ms-user-identity`, asserted
+  server-side by the BFF from the validated `oid`, on protocol `responses`
+  2.0.0, with narrow `Foundry Agent Consumer` + custom
+  `UserIdentityImpersonation` RBAC at agent scope), where Foundry enforces
+  per-user access to the response chain/history natively. ADR-0003 has already
+  validated this mechanism for the BFF↔hosted-agent continuity call path; this
+  ADR's panel history/read call path requires its **own** independent
+  confirmation (`PANEL_HISTORY_OWNER_BINDING_VALIDATED`) before switching —
+  the ADR-0003 evidence is strong precedent, not a substitute.
 - **Cross-conversation enumeration (the panel "list my conversations") — a
   panel-only feature.** It legitimately requires a metadata store and therefore
   exists **only** when `DEPLOY_ADMINISTRATIVE_PANEL=true`, backed by the
-  BFF-authored **owner index** in panel Cosmos (or delegated enumeration under
-  OBO). In hosted/no-panel there is simply **no enumeration endpoint** — the user
-  continues the conversation they hold a capability for; there is no list to
-  recover. This is expected and acceptable.
+  BFF-authored **owner index** in panel Cosmos (or delegated enumeration once
+  the panel's own gate is met). In hosted/no-panel there is simply **no
+  enumeration endpoint** — the user continues the conversation they hold a
+  capability for (or that the delegated mechanism authorizes); there is no
+  list to recover. This is expected and acceptable.
 
 In both concerns the authority is the BFF, never the container. This ADR decides
-everything invariant across the OQ-OWN outcome and makes only the BFF mechanism
-selectable, defaulting to the store-free capability until OQ-OWN passes.
+everything invariant across the owner-binding mechanism and makes only the BFF
+mechanism selectable, defaulting to the store-free capability until this ADR's
+own environment evidence gate is met.
 
 ### Resolving the no-panel / no-Cosmos continuity contradiction
 
@@ -153,9 +174,12 @@ conversation capability**:
   signature with the active key, (2) checks `expiry`, and (3) asserts the
   capability's `oid` **equals the current authenticated user's `oid`**. Only then
   does it read prior items by `conversation_resource_id` and assemble stateless
-  input. Any failure → uniform **404**. A raw caller-selected conversation ID is
-  never accepted; the only accepted reference is a signed capability whose owner
-  is re-checked against the live token.
+  input. Any failure → uniform **404**. The managed-Conversations **read itself**
+  is always driven by a verified capability, never a bare ID: in no-panel the
+  client holds nothing else, so this is the only path; in panel, a client-passed
+  `{id}` may additionally gate entry to this step (see "Panel `{id}` is a lookup
+  key" below), but the read step's own reference is still the capability, whose
+  owner is re-checked against the live token every time.
 - **Signing key.** A secret in **Key Vault** referenced from App Configuration,
   reusing the existing `AUDIT-HMAC-KEY` provisioning precedent (created from
   cryptographically random bits when absent, only its reference stored in App
@@ -226,9 +250,11 @@ gated by the panel flag.
 
 - `Azure/GPT-RAG` (this repo) — App Configuration contract (label `gpt-rag`),
   the versioned `contracts/conversations-panel-v1` schema, the panel deploy flag
-  wiring, this ADR. Infra must assign managed-Conversations data-plane RBAC to
-  the **UI BFF identity only** (Option A) or none (Option B/OBO), and **never**
-  to the hosted agent / container identity.
+  wiring, this ADR. Infra must assign managed-Conversations data-plane RBAC (or,
+  for delegated mode, `Foundry Agent Consumer` + custom `UserIdentityImpersonation`
+  at agent scope) to the **UI BFF's endpoint-call identity only** (capability
+  mode: Option A; delegated mode: Option B) and **never** to the hosted agent /
+  container identity.
 - `Azure/gpt-rag-ui` — **exclusive owner** of all managed-Conversation
   create/read/append/delete and the owner index, and of user-facing
   list/read/feedback/deletion. It is the only component holding the user token,
@@ -266,7 +292,7 @@ gated by the panel flag.
 
 ## Alternatives considered
 
-### Option A: BFF-minted signed owner-bound capability for continuity (all modes), plus a panel-only owner index for enumeration (chosen baseline)
+### Option A: BFF-minted signed owner-bound capability for continuity (all modes), plus a panel-only owner index for enumeration (fallback/pre-gate default)
 
 The **UI BFF** is the sole component that touches the Conversations data plane.
 On the first turn the **authenticated BFF** (holding the validated user token,
@@ -281,7 +307,11 @@ output; it writes nothing.
 - Per-conversation reads (all modes): the BFF verifies the capability signature,
   checks expiry/`key_id`, and asserts the capability `oid` **equals the live
   authenticated `oid`**; only then reads items by `conversation_resource_id`.
-  Any failure → **404**. A raw caller-selected ID is never accepted.
+  Any failure → **404**. A raw caller-selected ID is never *self-authorizing*:
+  in no-panel the client holds only the capability, never a bare ID; in panel,
+  a client-passed `{id}` is accepted solely as a lookup key that must first
+  clear the capability/owner-index gate before the BFF treats it as
+  `conversation_resource_id` (see "Panel `{id}` is a lookup key" below).
 - Enumeration (**panel only**, `DEPLOY_ADMINISTRATIVE_PANEL=true`): the BFF also
   records a **minimal owner-index** row — `principal_id → {conversation_id,
   title, timestamps}` — in the panel Cosmos container so the panel can list the
@@ -296,10 +326,11 @@ output; it writes nothing.
 - Operator surfaces (gpt-rag-ingestion): overview reads **counts over metadata**
   only; corpus curation operates on documents ingestion already indexes — never
   on conversation content.
-- Benefits: works today in **every** mode with no store for continuity; no
-  dependency on unproven delegated auth; **container holds zero Conversations
-  RBAC**; owner authority is the authenticated BFF; matches the `POST /retrieve`
-  fail-closed idiom and the `AUDIT-HMAC-KEY` Key Vault precedent.
+- Benefits: works today in **every** mode with no store for continuity; remains
+  fully specified and available as the **safe fallback/alternative** even after
+  Option B's mechanism is chosen for a given call path; **container holds zero
+  Conversations RBAC**; owner authority is the authenticated BFF; matches the
+  `POST /retrieve` fail-closed idiom and the `AUDIT-HMAC-KEY` Key Vault precedent.
 - Costs and risks: the **BFF service identity** holds Conversations read/write
   RBAC, so the confused-deputy risk is concentrated there and mitigated by the
   capability `oid`-equality gate. No-panel lacks fine-grained per-capability
@@ -319,30 +350,57 @@ output; it writes nothing.
 - Reversibility: continuity mechanism is a single selector; panel enumeration is
   behind the panel flag; when a surface is off it returns 503 and writes nothing.
 
-### Option B: Native delegated (OBO) reads/writes against managed Conversations from the BFF (preferred target, gated on OQ-OWN)
+### Option B: Native delegated-header reads against managed Conversations from the BFF (native, chosen/default once its own environment evidence gate is met)
 
-The BFF exchanges the user token (OBO) for a token that reads **and writes**
-managed Conversations **as the user**, so Foundry/Conversations enforces per-user
-authorization natively — the same philosophy as `POST /retrieve` forwarding the
-user bearer to Search. No GPT-RAG-authored owner index is needed, and the **BFF
-holds no standing Conversations RBAC**.
+The BFF asserts a trusted, server-derived `x-ms-user-identity` header (from the
+validated `oid`, never from the client) on hosted agents running container
+protocol `responses` 2.0.0, so Foundry/Conversations enforces per-user
+authorization on the response chain and `get_history` natively — the same
+philosophy as `POST /retrieve` forwarding the user bearer to Search. No
+GPT-RAG-authored owner index is needed for the mechanism itself (the panel's
+own enumeration index, described below, is a separate concern), and the BFF's
+endpoint-call identity holds only the narrow `Foundry Agent Consumer` role plus
+the custom `UserIdentityImpersonation` data action, both scoped to the agent.
 
 - Benefits: authorization enforced by the platform at the data plane; no
-  GPT-RAG-owned ownership state; cleanest confused-deputy elimination; the BFF
-  needs no ambient Conversations role; smallest long-term surface.
-- Costs and risks: **depends on OQ-OWN** — whether the managed Conversations data
-  API accepts a delegated user token and enforces per-user/owner access. If it
-  only accepts a service credential, Option B collapses into a service-read and
-  is **unsafe by itself**; it must not ship without native per-user enforcement
-  proven.
+  GPT-RAG-owned ownership state for the read/write path itself; cleanest
+  confused-deputy elimination; the BFF needs no ambient standing Conversations
+  RBAC (only the narrow agent-scoped roles above); smallest long-term surface.
+- **OQ-OWN resolved for ADR-0003's hosted-continuity call path**: live evidence
+  ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245),
+  cleanup:
+  [comment](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212334345))
+  proves managed Conversations enforces per-user isolation of the response
+  chain/`get_history` for the BFF↔hosted-agent call path in ADR-0003, on
+  protocol `responses` 2.0.0 with the narrow RBAC above. This is **strong,
+  directly relevant precedent** for the panel's read/history call shape, which
+  is expected to traverse the same call path. It does **not** by itself flip
+  this ADR's own gate (`PANEL_HISTORY_OWNER_BINDING_VALIDATED`, distinct from
+  ADR-0003's `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`): the panel's
+  implementation must independently confirm the same protocol version and RBAC
+  shape apply to its own history/read calls before this option engages for the
+  panel path — per the discipline that each independent call path requires its
+  own live evidence, not an inherited assumption. Until then, the panel
+  continues to rely on Option A (fallback) for its own history/read gate, even
+  though ADR-0003 has already moved to `delegated` for its call path.
 - Security and identity: strongest when supported; the container still holds no
-  role — the **user's** delegated token authorizes reads/writes, minted by the
-  BFF which already holds the user token.
-- Operational consequences: no index to keep consistent; requires a Conversations
-  query-token audience config, analogous to `HOSTED_RETRIEVAL_TOKEN_AUDIENCE`.
+  role — the BFF's own narrowly-scoped, agent-assigned identity asserts the
+  validated identity, minted server-side by the BFF which already holds the
+  user's validated `oid`. The asserted identity is middle-tier-asserted, not
+  cryptographically proven by the platform, so the BFF remains the trust
+  boundary; the header is never accepted from the client.
+- Operational consequences: no index to keep consistent for the read/write
+  mechanism itself; requires `HOSTED_CONVERSATION_PROTOCOL_VERSION` and the
+  narrow RBAC assignment, analogous to `HOSTED_RETRIEVAL_TOKEN_AUDIENCE`'s
+  role in INV-002. Live evidence also shows the platform does **not** fence
+  session **membership** (a differently asserted identity can enter a session
+  another identity's request created), even though it does fence the response
+  chain/history — so no unpartitioned container/session-keyed data may ever be
+  stored, in either the panel or no-panel case.
 - Component compatibility: same repo set; the mechanism differs only inside the
-  BFF behind the selector.
-- Reversibility: single flag; can fall back to Option A.
+  BFF behind the selector; shares the same App Configuration keys as ADR-0003.
+- Reversibility: single flag per its own gate; falls back to Option A
+  automatically pre-gate or if the gate is ever unmet.
 
 ### Option C: A service identity (container or panel) reads/writes by caller-supplied conversation ID or caller-supplied owner (rejected)
 
@@ -408,22 +466,45 @@ to the safe state:
    to compute that already runs.
 
 3. **Owner-binding is invariant; the BFF mechanism is a selector; continuity is
-   store-free.** Ship **Option A** baseline: per-conversation owner binding
-   (continuity + single-conversation history in **all** modes) via a **BFF-minted
-   signed owner-bound capability** that needs **no store**, plus a **panel-only**
+   safe pre-gate.** Ship **Option A** (capability, store-free) as the
+   **fallback/pre-gate default**: per-conversation owner binding (continuity +
+   single-conversation history in **all** modes) via a **BFF-minted signed
+   owner-bound capability** that needs **no store**, plus a **panel-only**
    owner index (Cosmos) for cross-conversation enumeration. Adopt **Option B
-   (native delegated OBO)** the moment **OQ-OWN** proves managed Conversations
-   enforces per-user authorization for delegated tokens. Both keep the
-   **container at zero Conversations RBAC** and both fail closed. **Option C is
-   prohibited.** No-panel has no enumeration endpoint and no Cosmos; continuity
-   still works via the capability.
+   (native delegated header)** for the panel's history/read call path once
+   this ADR's **own** environment evidence gate
+   (`PANEL_HISTORY_OWNER_BINDING_VALIDATED`) confirms the same protocol
+   version and RBAC shape that ADR-0003 already validated for the
+   BFF↔hosted-agent continuity path apply to the panel's calls too. **ADR-0003's
+   OQ-OWN resolution**
+   ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245))
+   is strong, directly relevant precedent — it is **not** a substitute for this
+   ADR's own gate, because each independent call path requires its own live
+   evidence. Both mechanisms keep the **container at zero Conversations
+   RBAC** and both fail closed. **Option C is prohibited.** No-panel has no
+   enumeration endpoint and no Cosmos; continuity still works via the active
+   owner-binding mechanism (capability pre-gate, or delegated once its own
+   gate is met).
 
-4. **Fail-closed by default.** Every panel surface is disabled unless the panel
-   is deployed **and** its evidence gate is set, mirroring `POST /retrieve`.
-   Until owner-binding is validated, hosted history keeps returning the safe
-   status (503 when the surface exists but is gated off; 501 remains acceptable
-   only where no endpoint is wired yet). No service-identity-by-caller-ID read
-   and no caller-asserted ownership is shipped in any state.
+4. **Fail-closed by default.** Every user-facing history/feedback panel surface
+   is disabled unless the panel is deployed (`DEPLOY_ADMINISTRATIVE_PANEL` +
+   `PANEL_HISTORY_ENABLED`), mirroring `POST /retrieve`; operator surfaces
+   (corpus curation, overview metrics) have their own independent
+   deploy/role-authorization requirement and are never gated by owner-binding
+   evidence. The deploy gate is independent of the owner-binding mechanism:
+   **`capability` mode requires no additional gate** and is the safe
+   pre-gate/fallback default the moment the panel is deployed. Only the
+   **switch to `delegated`** additionally requires
+   `PANEL_HISTORY_OWNER_BINDING_VALIDATED`; until that gate is set, the panel
+   continues serving history/feedback/deletion via `capability` — an unmet
+   gate never itself produces an error response, it only selects which
+   mechanism enforces ownership. A genuine **503** is reserved for the
+   history/feedback surface (or, for operator endpoints, the panel/admin app)
+   being undeployed; a genuine **502** is reserved for the underlying
+   managed-Conversations/downstream dependency itself failing (501 remains
+   acceptable only where no endpoint is wired yet). No
+   service-identity-by-caller-ID read and no caller-asserted ownership is
+   shipped in any state.
 
 5. **Content confinement.** Managed Conversations remains the sole store of chat
    content. Cosmos (panel-only) carries feedback and curation **metadata** and
@@ -471,7 +552,14 @@ Error semantics (uniform): **401** missing/invalid bearer; **403** wrong token
 type/audience (app-only token on a user surface, or missing operator role);
 **404** not-owner or missing (never 403 for ownership, to avoid existence
 disclosure); **422** schema/bounds violation; **502** managed-Conversations or
-downstream failure; **503** surface deployed but evidence gate unset. Retention:
+other downstream dependency **actually failing** (network/service error) —
+never used for gate state; **503** the user history/feedback surface itself is
+undeployed (`DEPLOY_ADMINISTRATIVE_PANEL` or `PANEL_HISTORY_ENABLED` is
+`false`) or, for operator surfaces, the panel/ingestion-admin app is
+undeployed — never used for an unmet owner-binding evidence gate. An unmet
+`PANEL_HISTORY_OWNER_BINDING_VALIDATED` gate produces **no error at all**: the
+BFF falls back to `capability`/`owner_index` transparently, so gate state
+alone never surfaces as either a 502 or a 503. Retention:
 deletion is a hard delete of managed-Conversation items plus panel metadata;
 `delete_after`-style policy intent is recorded but GPT-RAG performs no automatic
 scheduled deletion (consistent with v3.7.0 governance guidance).
@@ -482,17 +570,32 @@ Continuity keys (apply in **all** hosted modes, including no-panel; no store).
 Authoritatively defined in ADR-0003; restated here for context — ADR-0003 is
 the source of truth if wording ever diverges:
 
-- `HOSTED_CONVERSATION_OWNER_BINDING` (default `capability`; alt `delegated`) —
-  selects per-conversation owner binding: BFF-minted signed capability (A) vs.
-  delegated OBO (B). `delegated` is inert until
-  **`HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`** (ADR-0003) is `true` for
-  the hosted continuity call path — this is a **different, independent** gate
-  from the panel-only `PANEL_HISTORY_OWNER_BINDING_VALIDATED` below; neither
-  substitutes for the other.
+- `HOSTED_CONVERSATION_OWNER_BINDING` (default `delegated`; alt `capability`) —
+  selects per-conversation owner binding: native delegated header (B, chosen/
+  default) vs. BFF-minted signed capability (A, fallback). `delegated` is
+  active only once **`HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`** (ADR-0003)
+  — the hosted-continuity environment evidence gate confirming protocol
+  `responses` 2.0.0 and the narrow RBAC shape — is `true`; otherwise the
+  selector falls back to `capability` automatically. This is a **different,
+  independent** gate from the panel-only
+  `PANEL_HISTORY_OWNER_BINDING_VALIDATED` below; neither substitutes for the
+  other, even though ADR-0003's resolution
+  ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245))
+  is strong precedent for the panel's own gate.
+- `HOSTED_CONVERSATION_PROTOCOL_VERSION` (ADR-0003; expected `responses/2.0.0`
+  when `HOSTED_CONVERSATION_OWNER_BINDING=delegated`) — restated here for
+  context; ADR-0003 is authoritative.
 - `HOSTED_CONVERSATION_CAPABILITY_KEY` — **Key Vault reference** to the HMAC/JWS
   signing key, provisioned like `AUDIT-HMAC-KEY` (created from random bits when
   absent; only the reference is stored in App Config). Present in all modes; no
-  Cosmos, no storage account.
+  Cosmos, no storage account. Required in **both** modes: `capability` mode
+  signs/verifies the full owner-bound capability (locator +
+  `oid` claim/check); `delegated` mode signs/verifies the same locator shape
+  **minus** the `oid` claim/check (integrity/non-guessability only — the
+  Foundry platform's own per-request identity check via `x-ms-user-identity`
+  is what authorizes the read). The key is never unneeded once `delegated`
+  is active; only the `oid`-check step is skipped.
+
 - `HOSTED_CONVERSATION_CAPABILITY_KEY_ID` (default `v1`) — active signing key
   version; advance to rotate (previous key retained for a bounded overlap).
 - `HOSTED_CONVERSATION_CAPABILITY_TTL_SECONDS` (default e.g. `3600`) — capability
@@ -526,17 +629,19 @@ Panel keys (apply **only** when the administrative panel is deployed):
 
 | Threat | Vector | Mitigation in this ADR |
 | --- | --- | --- |
-| **Cross-user conversation IDs (IDOR)** | Caller passes another user's `conversation_id` | Only a signed capability is accepted; the BFF re-checks the capability `oid` equals the live token `oid` before any read; miss → 404. A raw caller ID never drives a read (A) or the read is delegated as the user (B) |
+| **Cross-user conversation IDs (IDOR)** | Caller passes another user's `conversation_id` (no-panel: no such surface exists; panel: as the `{id}` path segment) | No-panel: the client never holds a bare ID, only its own signed capability, so there is nothing to guess-and-pass. Panel: `{id}` is accepted only as a **lookup key** — the BFF performs an owner-index check (`principal_id == live oid`, Option A) or equivalent delegated per-user authorization (Option B) *before* treating it as `conversation_resource_id`; a foreign ID fails that check. Either way, the ID is never *self-authorizing* and never drives a read on its own; miss → 404 |
 | **Capability theft / replay** | Attacker presents a stolen capability | A capability alone is **insufficient**: reads also require a valid Entra token whose `oid` matches the capability `oid`, so a different user fails the equality check (→404). Short TTL + rolling re-mint bound the window; key rotation performs bulk revocation |
 | **Capability forgery** | Attacker mints/edits a capability | Signed with a Key Vault key held only by the BFF; edits break the signature (→404); the container has no signing key and cannot mint |
 | **Direct agent/Foundry callers** | Direct caller reaches the container and tries to read/enumerate/own conversations | Container holds **zero Conversations RBAC** and never touches the data plane; it only consumes BFF-supplied stateless input, and cannot mint capabilities. It reads, writes, and owns nothing |
 | **Ownership forgery** | Caller-supplied owner in request metadata to claim a conversation | Ownership originates only from a BFF mint (capability) over a validated token `oid`; the container writes no ownership, so caller metadata can never establish ownership |
-| **Service-identity confused deputy** | A service credential reads by caller ID | Prohibited (Option C rejected). Only the **BFF identity** holds Conversations RBAC (Option A) or none (Option B/OBO); every BFF read is gated by the capability `oid`-equality check |
+| **Service-identity confused deputy** | A service credential reads by caller ID | Prohibited (Option C rejected). Conversations RBAC exists **only** on the BFF's endpoint-call identity — never the container — whether via Option A's read/write role or Option B's narrow `Foundry Agent Consumer` + `UserIdentityImpersonation`; every BFF read is gated by the capability `oid`-equality check (A) or the server-derived identity header (B) |
 | **Support/admin over-reach** | Operator role reads protected user chat content | Operator surfaces expose metadata/counts and **corpus** artifacts only; ingestion has no conversation-content access; raw conversation content is not provided and would require a separate, elevated, audited path (out of scope, denied by default) |
 | **Document-citation leakage** | Re-rendered history shows citations to documents the user has since lost access to | History stores **citation references**, not document content; render re-checks access (native trimming) before resolving a citation; snapshot-vs-live divergence recorded as OQ-611-CITE |
 | **Telemetry leakage** | Content or IDs in logs/metrics | `audit-event-v1` metadata-only; correlation IDs only; overview metrics thresholded; capability signatures/keys never logged; no conversation body or document content in any log/metric |
 | **Existence disclosure** | 403-vs-404 oracle reveals a conversation exists | Uniform **404** for bad/expired/wrong-`oid`/retired-key capability and for missing |
 | **Pagination tampering** | Caller forges cursor to page another user's data | Opaque, signed, expiring cursors bound to the authenticated principal |
+| **Session-membership not fenced (delegated mode)** | Platform lets a differently-asserted identity "enter" a session/conversation another identity's request created, even though it fences the response chain/history | ADR-0003's invariant carries over: **never store unpartitioned container/session-keyed data** in either mode; panel Cosmos stores only owner-index/metadata keyed by `principal_id`, never session-keyed content; per-read owner/oid check (both mechanisms) still gates every content read regardless of session membership |
+| **Header spoofing / trust-boundary drift (delegated mode)** | Attacker or misconfigured client attempts to supply `x-ms-user-identity` directly | The header is asserted **server-side only** by the BFF from its own validated `oid`; it is never accepted from client input; the BFF remains the sole trust boundary, mirroring ADR-0003 |
 
 ## Consequences
 
@@ -548,17 +653,31 @@ Panel keys (apply **only** when the administrative panel is deployed):
   ingestion apps; works in the network-isolated topology.
 - Container holds **zero Conversations RBAC**, managed-Conversations-as-SoR, and
   no-Cosmos-chat freezes (ADR-0001/0003) are preserved and strengthened.
-- Safe under OQ-OWN uncertainty: the safe mechanism ships now; the preferred
-  native mechanism is a config flip once proven.
+- **OQ-OWN resolved for ADR-0003's call path**
+  ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245)):
+  live evidence is strong precedent that the same delegated-header mechanism
+  will validate for the panel's history/read call path too, once independently
+  confirmed via this ADR's own gate. Safe under continued uncertainty for the
+  panel's own gate: the fallback mechanism ships now and works regardless; the
+  chosen native mechanism is a config flip once this ADR's own evidence gate
+  passes.
 
 ### Negative or accepted
 
-- Baseline Option A adds a GPT-RAG-owned owner index that must stay consistent
+- Fallback Option A adds a GPT-RAG-owned owner index that must stay consistent
   with the SoR (bounded blast radius: at worst a 404 or a stale list row, never
-  content disclosure), and concentrates Conversations RBAC on the **BFF identity**.
+  content disclosure), and concentrates Conversations RBAC on the **BFF
+  identity** while capability mode is active (pre-gate, or as fallback).
 - The BFF now owns per-turn read-prior-items + assemble-stateless-input + append
   (moved out of the container per the stricter invariant). This adds BFF logic
   and the bounded-replay policy (ADR-0003) now lives entirely in the BFF.
+- **Delegated mode (once this ADR's own gate is met)**: the asserted identity is
+  middle-tier-asserted, not cryptographically proven by the platform, so the BFF
+  remains the trust boundary; the header is never accepted from the client.
+  Platform session-membership is not fenced (a differently asserted identity can
+  "enter" a session another identity's request created) even though the
+  response chain/history is fenced — this is why unpartitioned
+  container/session-keyed data must never be stored, in either mode.
 - Audience split means two backends implement one contract; the shared
   `contracts/` schema and conformance tests keep them aligned.
 - Citation snapshot-vs-live access divergence is an accepted, documented risk
@@ -566,7 +685,9 @@ Panel keys (apply **only** when the administrative panel is deployed):
 - **ADR-0003 has been revised** (see its revision note): its in-container
   persist/replay design is superseded on location — the BFF, not the
   container, reads/appends managed Conversations. Its other freezes are
-  retained.
+  retained, including the delegated-header RBAC (`Foundry Agent Consumer` +
+  custom `UserIdentityImpersonation`) belonging solely to the BFF's
+  endpoint-call identity, never the container.
 
 ## Adoption and migration
 
@@ -588,33 +709,45 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    capability minting in the container (it has no authenticated identity or key).
    Emit `audit-event-v1` for the turn only.
 3. **gpt-rag-ui** — the BFF becomes the **exclusive** Conversations owner and the
-   **sole capability minter/verifier**. Continuity (all modes,
-   `HOSTED_CONVERSATION_OWNER_BINDING=capability`): on create, allocate the
-   managed Conversation and mint a signed owner-bound capability from the
-   validated `oid`; per turn, verify capability (signature + expiry + `oid`
-   equality) → read prior items by `conversation_resource_id` → assemble complete
-   stateless input → call container → append items → re-mint a fresh capability.
-   Panel (when deployed): also write/read the owner index for enumeration behind
-   `PANEL_HISTORY_ENABLED` + (`delegated` requires
+   **sole capability minter/verifier and header asserter**. Continuity (all
+   modes): once `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED` (ADR-0003) is
+   met, assert `x-ms-user-identity` server-side from the validated `oid` on
+   protocol `responses` 2.0.0 (`delegated`, chosen/default); otherwise (or as
+   fallback) mint/verify the signed owner-bound capability from the validated
+   `oid` (`capability`): on create, allocate the managed Conversation and mint
+   a signed owner-bound capability; per turn, verify capability (signature +
+   expiry + `oid` equality) → read prior items by `conversation_resource_id` →
+   assemble complete stateless input → call container → append items →
+   re-mint a fresh capability. Panel (when deployed): also write/read the
+   owner index for enumeration behind `PANEL_HISTORY_ENABLED` + (`delegated`
+   requires
    `PANEL_HISTORY_OWNER_BINDING_VALIDATED`); implement history/feedback/deletion.
-   Never accept a raw caller-selected ID.
+   Never accept a raw caller-selected ID as self-authorizing (panel `{id}` is a
+   lookup key gated by an owner check, never trusted on its own). No
+   `UserIdentityImpersonation` RBAC or signing key on the container.
 4. **gpt-rag-ingestion** — implement operator **overview (metadata counts)** and
    **corpus/document curation** routers behind `DEPLOY_ADMINISTRATIVE_PANEL`,
    replacing the 501 for those surfaces; **no conversation-content access or
    conversation-content curation**; fail-closed 503 when gated off; operator-role
    check plus existing bearer patterns.
 5. Revalidate in Basic and network-isolated topologies; run the two-user negative
-   suite, the direct-caller anti-spoof test, and a **capability
-   theft/expiry/rotation** test; validate **no-panel continuity with zero Cosmos**;
-   then update `manifest.json` pins for all changed components together.
+   suite, the direct-caller anti-spoof test, the **capability
+   theft/expiry/rotation** test, and (once each ADR's own gate is met)
+   **delegated-header tests** (header spoofing rejected, cross-user 404,
+   session-join-does-not-leak-history); validate **no-panel continuity with
+   zero Cosmos**; then update `manifest.json` pins for all changed components
+   together.
 
 Migration boundaries: no backfill. Existing classic Cosmos-backed history is
 untouched and remains the classic path. Hosted/no-panel provisions **no Cosmos**
-and uses store-free capability continuity; hosted/panel adds the Cosmos owner
-index for enumeration only.
+and uses the active owner-binding mechanism (capability pre-gate/fallback, or
+delegated once its own gate is met) for continuity; hosted/panel adds the
+Cosmos owner index for enumeration only, used only pre-gate/as fallback for
+the panel's own enumeration/read gate.
 
-Rollback: flip `HOSTED_CONVERSATION_OWNER_BINDING`/`PANEL_HISTORY_ENABLED`/
-`DEPLOY_ADMINISTRATIVE_PANEL` as needed and revert the coordinated manifest pin.
+Rollback: flip `HOSTED_CONVERSATION_OWNER_BINDING` back to `capability`,
+`PANEL_HISTORY_ENABLED`/`DEPLOY_ADMINISTRATIVE_PANEL` as needed, and revert the
+coordinated manifest pin.
 Because managed Conversations is SoR, the capability is stateless, and Cosmos
 holds only metadata, no chat-content migration is needed either direction;
 owner-index rows are metadata and can be dropped; rotating
@@ -622,9 +755,11 @@ owner-index rows are metadata and can be dropped; rotating
 
 ## Compliance verification (fitness functions)
 
-- **FF-1 Owner gate (deterministic):** `GET /messages`, feedback, and delete for
-  a capability whose `oid` ≠ live token `oid`, or an absent/forged capability,
-  return **404**; a raw caller-selected ID is never accepted. Unit + contract.
+- **FF-1 Owner gate (deterministic):** panel `GET .../messages`, feedback, and
+  delete for an `{id}` whose owner-index check fails (capability `oid` ≠ live
+  token `oid`, or an absent/forged capability, or no matching owner-index row)
+  return **404**; the `{id}` is accepted only as a lookup key and is never
+  self-authorizing on its own. Unit + contract.
 - **FF-1b Capability lifecycle (deterministic):** a tampered signature, expired
   capability, or capability minted under a retired `key_id` (past overlap) all
   return **404**; a valid capability with matching `oid` succeeds; a successful
@@ -643,18 +778,27 @@ owner-index rows are metadata and can be dropped; rotating
   responses contain only counts and suppress sub-threshold buckets.
 - **FF-4 Container zero-RBAC (strengthened):** infra/RBAC assertion that the
   hosted agent/container identity holds **no** Conversations data-plane role
-  (read *or* write) and has **no** capability signing key; a container-originated
-  read/append/create attempt fails at the platform. Conversations RBAC exists
-  **only** on the BFF identity (Option A) or nowhere (Option B/OBO).
+  (read *or* write), **no** `UserIdentityImpersonation` action, and has **no**
+  capability signing key; a container-originated read/append/create attempt
+  fails at the platform. Conversations RBAC exists **only** on the BFF's
+  endpoint-call identity (capability mode: read/write role; delegated mode:
+  `Foundry Agent Consumer` + `UserIdentityImpersonation`, both agent-scoped) —
+  never on the container.
 - **FF-4b Anti-spoof / direct caller (live):** a direct Foundry call to the
   container cannot create, own, read, or append a conversation, and cannot mint a
-  capability; caller-supplied owner metadata never establishes ownership; the only
-  conversations that exist are those the authenticated BFF created from a
-  validated token.
-- **FF-5 Fail-closed gating:** panel user history endpoints return **503** unless
-  `PANEL_HISTORY_ENABLED` (and, for `delegated`, `PANEL_HISTORY_OWNER_BINDING_VALIDATED`);
-  operator endpoints return **503** unless `DEPLOY_ADMINISTRATIVE_PANEL`;
-  `HOSTED_CONVERSATION_OWNER_BINDING=delegated` is inert until its validated gate.
+  capability or assert an identity header; caller-supplied owner metadata never
+  establishes ownership; the only conversations that exist are those the
+  authenticated BFF created from a validated token.
+- **FF-5 Fail-closed gating:** panel user history endpoints return **503**
+  unless `PANEL_HISTORY_ENABLED` (independent of owner-binding mechanism);
+  operator endpoints return **503** unless `DEPLOY_ADMINISTRATIVE_PANEL`. An
+  unmet owner-binding gate never itself produces a 503: with
+  `PANEL_HISTORY_OWNER_BINDING_VALIDATED` unset, the panel continues serving
+  via `capability`; likewise `HOSTED_CONVERSATION_OWNER_BINDING=delegated`
+  falls back to `capability` automatically until
+  `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED` (ADR-0003) is `true`, and
+  `PANEL_CONVERSATION_ENUMERATION_MODE=delegated` falls back to `owner_index`
+  until `PANEL_HISTORY_OWNER_BINDING_VALIDATED` is `true`.
 - **FF-6 Token-type enforcement:** user surfaces reject app-only tokens (403,
   reusing the `idtyp`/`scp` checks); operator surfaces reject end-user tokens
   lacking the operator role (403).
@@ -664,71 +808,112 @@ owner-index rows are metadata and can be dropped; rotating
   consumers.
 - **FF-8 Error-semantics matrix:** 401/403/404/422/502/503 mapping verified per
   the table, including uniform 404 for bad/expired/wrong-`oid` capability vs
-  missing.
+  missing, and (delegated mode) bad/missing identity header vs missing.
 - **FF-9 No conversation-content curation on operator surface:** ingestion
   operator endpoints expose no conversation body; corpus-curation touches only
   documents ingestion already indexes.
+- **FF-10 Evidence-gate scope (static/documentation):** `PANEL_HISTORY_OWNER_BINDING_VALIDATED`
+  is verified to be a distinct config key from ADR-0003's
+  `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`, and neither key's flip auto-sets
+  the other; each ADR's gate is a protocol+RBAC-shape confirmation for its own
+  call path, not a shared or inherited claim.
+- **FF-11 Header derivation only (static/contract):** panel and continuity code
+  paths never construct, forward, or accept an `x-ms-user-identity` value from
+  request/query/cookie input under any panel or no-panel configuration; the only
+  legitimate source is the BFF's own server-side derivation from the validated
+  `oid` (reuses ADR-0003 FF-11).
 
 ## Documentation impact
 
 Update the hosted-agent operator page on the `docs` branch: panel modes and
 flags, the `conversations-panel-v1` contract, the **stateless-container /
-BFF-exclusive-Conversations** model and the owner-binding model with its OQ-OWN
-gate, the audience split (user history/feedback in the UI, operator overview and
-**corpus** curation in the ingestion admin app — no conversation-content
-curation), the zero-Conversations-RBAC container guarantee, content-confinement
-guarantees, retention/deletion semantics, and the citation snapshot caveat. Note
-that ADR-0003 is superseded on persistence location and must be updated.
+BFF-exclusive-Conversations** model, and the owner-binding model — the native
+delegated header (`x-ms-user-identity`, chosen/default once each call path's
+own environment evidence gate is met) and the capability (fallback/pre-gate
+default), the two independent per-call-path gates
+(`HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED` for continuity,
+`PANEL_HISTORY_OWNER_BINDING_VALIDATED` for the panel), and the invariant that
+unpartitioned container/session-keyed data is never stored because platform
+session-membership is not fenced even though the response chain/history is.
+Also cover the audience split (user history/feedback in the UI, operator
+overview and **corpus** curation in the ingestion admin app — no
+conversation-content curation), the zero-Conversations-RBAC container
+guarantee (including no `UserIdentityImpersonation` on the container), content-
+confinement guarantees, retention/deletion semantics, and the citation
+snapshot caveat. Note that ADR-0003 is superseded on persistence location and
+must be updated.
 
 ## Review trigger
 
 Reassess when any of the following occurs:
 
-- **OQ-OWN resolves (two independent, per-call-path gates — neither substitutes
-  for the other):**
-  - Hosted continuity call path: managed Conversations data API confirms
-    per-user authorization for delegated tokens on the **BFF's per-turn
-    read/append path** — switch `HOSTED_CONVERSATION_OWNER_BINDING` to
-    `delegated` only after setting **`HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`**
-    (ADR-0003) true for that exact call path.
-  - Panel history/enumeration call path: the same API property confirmed
-    separately for the **panel's list/read path** — switch
-    `PANEL_CONVERSATION_ENUMERATION_MODE` (and, for per-conversation panel
-    reads, the delegated-read branch) to `delegated` only after setting
-    **`PANEL_HISTORY_OWNER_BINDING_VALIDATED`** (this ADR) true for that exact
-    call path. This gate never unlocks `HOSTED_CONVERSATION_OWNER_BINDING`,
-    and the ADR-0003 gate never unlocks panel delegated enumeration/reads —
-    each path requires its own live evidence per the "exact call path"
-    requirement.
+- **OQ-OWN (two independent, per-call-path gates — neither substitutes for the
+  other):**
+  - Hosted continuity call path: **resolved**
+    ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245),
+    cleanup:
+    [comment](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212334345)) —
+    live evidence confirms managed Conversations enforces per-user isolation
+    of the response chain/history on the **BFF's per-turn read/append path**
+    for protocol `responses` 2.0.0 with the narrow RBAC. ADR-0003 has switched
+    `HOSTED_CONVERSATION_OWNER_BINDING` to `delegated` for that path.
+  - Panel history/enumeration call path: **still pending** — the same API
+    property must be confirmed **separately** for the **panel's list/read
+    path** before switching `PANEL_CONVERSATION_ENUMERATION_MODE` (and, for
+    per-conversation panel reads, the delegated-read branch) to `delegated`,
+    by setting **`PANEL_HISTORY_OWNER_BINDING_VALIDATED`** (this ADR) true for
+    that exact call path. The ADR-0003 resolution is strong precedent (same
+    protocol/RBAC shape, same BFF component) but does **not** auto-set this
+    gate — each path requires its own live evidence per the "exact call path"
+    requirement established in this ADR.
 - Foundry changes managed-Conversations identity/RBAC, ordering, or deletion
   semantics.
+- Foundry changes platform session-membership fencing behavior (currently:
+  session membership is not fenced, but the response chain/history is).
 - Any FF regresses in validation or production, or a security review reports a
   cross-user or service-identity read path, or a capability theft/forgery path.
 - Hosted agents leave preview or change header/identity propagation.
 
 ## Open questions
 
-- **OQ-OWN (governs the binding mechanism, not continuity availability):** Does
-  the managed Conversations data API accept a **delegated user token** and enforce
-  per-user (owner-bound) authorization? If yes → `delegated` (Option B) may
-  supersede the capability **for reads** and the owner index is dropped for reads.
-  If no → the **capability** (Option A) remains the store-free continuity binding
-  and Option C stays prohibited. Note: continuity is **not** blocked on OQ-OWN —
-  the capability works today with zero store; OQ-OWN only decides whether the
-  platform can enforce reads natively instead.
+- **OQ-OWN (governs the binding mechanism, not continuity availability) —
+  RESOLVED for ADR-0003's hosted-continuity call path; STILL PENDING for this
+  ADR's panel history/enumeration call path.** Live evidence
+  ([`gpt-rag#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245))
+  confirms managed Conversations accepts a BFF-asserted, server-derived
+  `x-ms-user-identity` header and enforces per-user (owner-bound)
+  authorization on the response chain/history, on protocol `responses` 2.0.0
+  with narrow RBAC (`Foundry Agent Consumer` + custom
+  `UserIdentityImpersonation` at agent scope) — for the **hosted-continuity**
+  call path specifically. This is strong precedent, but this ADR's **own**
+  gate (`PANEL_HISTORY_OWNER_BINDING_VALIDATED`) requires the panel's list/read
+  call path to be independently confirmed before `delegated`/Option B engages
+  for the panel. Residual/still-open regardless of this ADR's own gate outcome:
+  (a) the asserted identity is middle-tier-trusted, not cryptographically
+  proven by the platform; (b) platform session-membership is not fenced
+  (motivating the never-store-unpartitioned-session-data invariant above);
+  (c) this does not resolve issue #591's separate document-level-authorization
+  question. Until this ADR's own gate passes, the **capability** (Option A)
+  remains the fallback/pre-gate default continuity and enumeration binding,
+  and Option C stays prohibited. Note: continuity is **not** blocked on this
+  ADR's own gate — the capability works today with zero store; the gate only
+  decides whether the panel's platform enforces reads natively instead.
 - **OQ-611-CAP (capability primitives):** Confirm the signing algorithm and key
   handling (HMAC vs JWS), Key Vault provisioning parity with `AUDIT-HMAC-KEY`,
   the TTL/rolling-re-mint values, and the rotation overlap window. Confirm the
   client persistence surface (Chainlit session vs `HttpOnly` cookie) meets the
   restart/browser requirements without exposing the capability to scripts.
 - **OQ-611-OWNERSTAMP:** Confirm the **BFF** can durably record ownership — via a
-  signed capability (Option A, no store) or via managed-Conversation ownership
-  established by the user's delegated identity (Option B) — and that it survives
-  version replacement (ADR-0003). The **container never records ownership**.
+  signed capability (Option A, no store) or via the delegated-header mechanism
+  (Option B, BFF-asserted `x-ms-user-identity` from the validated `oid`) — and
+  that it survives version replacement (ADR-0003). The **container never
+  records ownership**.
 - **OQ-611-BFF-RBAC:** For Option A, confirm the minimal Conversations data-plane
   role the **BFF identity** needs (read + append + delete for owner-gated
   operations) scoped without granting the container any role. For Option B,
-  confirm the BFF can operate with **no standing Conversations RBAC** using OBO.
+  confirm the BFF's endpoint-call identity operates with only the narrow
+  `Foundry Agent Consumer` + custom `UserIdentityImpersonation` roles at agent
+  scope — no standing Conversations read/write RBAC.
 - **OQ-611-REVOKE:** Confirm the acceptability of no fine-grained per-capability
   revocation in no-panel (bounded by short TTL + rolling re-mint + key rotation),
   or define a minimal revocation signal that does not reintroduce an always-on


### PR DESCRIPTION
## Summary

Publishes two Architecture Decision Records defining how hosted-agent conversation continuity is authorized and how the optional administrative panel exposes conversation history/feedback:

- `docs/adr/ADR-0003-hosted-conversation-continuity.md`
- `docs/adr/ADR-0004-hosted-panel-conversations-contract.md`

## Non-negotiable decisions encoded

- Authenticated UI BFF exclusively owns managed Conversation create/read/append/delete.
- Hosted container is stateless/history-blind: zero Conversations RBAC, no signing key.
- No caller-selected raw ID drives a service-identity read; a raw/panel `{id}` is a lookup key, never self-authorizing.
- Default owner binding for hosted/no-panel: **native delegated header mode** (`x-ms-user-identity`, trusted-BFF-derived from validated `oid`) once an environment evidence gate confirms container protocol `responses/2.0.0` + narrow `Foundry Agent Consumer` role + custom `UserIdentityImpersonation` action at agent scope for the exact call path. `capability` (BFF-minted signed opaque handle, short TTL/key version, zero Cosmos) remains the safe pre-gate/disabled fallback, not the primary requirement.
- Bad signature/expiry/key/oid/missing/mismatched-identity is indistinguishable 404; a direct caller cannot establish ownership.
- Delegated mode only became the chosen default after live OQ-OWN evidence for the exact call path (see below).
- Panel Cosmos owner index is metadata-only, used solely for cross-conversation enumeration — never chat content.
- Ingestion operator surface has no conversation-body curation — only metadata metrics and corpus/document curation.
- GPT-RAG-specific policy stays outside generic AILZ.

## Live OQ-OWN evidence

Both ADRs incorporate live experiment evidence from [`Azure/GPT-RAG#591`](https://github.com/Azure/GPT-RAG/issues/591#issuecomment-5212288245) (protocol/RBAC-shape proof for the exact call path) and its cleanup/teardown confirmation, gating the delegated-header mode's promotion from "future option" to "chosen default."

## Validation

- Inspected ADR-0001 and existing repo ADR conventions for format/tone/structure consistency.
- No automated markdown/ADR lint pipeline exists in this repo; validated via manual grep sweeps for internal-consistency issues (terminology, config-key names, error-code semantics) across both files.
- Ran an independent rubber-duck architecture/security review across **4 rounds**:
  - Round 1: 4 blocking + 1 non-blocking finding — all fixed (delegated-mode locator gap, stale "carried in request metadata" claim, panel fail-closed vs. safe-fallback contradiction, raw-ID "never accepted" vs. "lookup key" inconsistency, plus FF-12 added for the non-blocking session-state-partitioning gap).
  - Round 2: re-surfaced 2 issues needing deeper fixes (delegated locator needed to be an actual integrity-protected/signed handle, not signature-free; 503/502 error-code scoping still conflated deploy-gate-unset with dependency failure) — both fixed.
  - Round 3: 2 residual inconsistencies (a stray "capability key not required once delegated is active" line; a leftover "502 is the only outcome of an unmet gate" parenthetical) — both fixed.
  - Round 4 (final confirmation): reviewer confirmed **both resolved, no new contradictions**.
- Confirmed via `git status`/`git diff --stat` that only the two ADR files are touched — no manifest, infra, or deployment config changes.

Per user authorization: PR targets `develop`, no release/tag, admin-merge bypass authorized after review if required.