### PR TITLE
feat(panel): add hosted panel platform contract (issue #611, ADR-0004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@
 
 ### Added
 
+- **Hosted administrative panel platform contract (issue #611, ADR-0004).**
+  Published the versioned `contracts/conversations-panel-v1` JSON Schema
+  (+ `.sha256` pin) covering the user-facing history/messages/feedback/delete
+  surfaces and the operator-facing overview/corpus-curation surfaces, with
+  strict `extra=forbid` semantics, a uniform error matrix, opaque
+  signed/expiring cursors, and `audit-event-v1`-compatible correlation IDs.
+  Added `config.panel.settings` (App Configuration defaults for
+  `PANEL_HISTORY_ENABLED`, `PANEL_HISTORY_OWNER_BINDING_VALIDATED`,
+  `PANEL_CONVERSATION_ENUMERATION_MODE`, `PANEL_CONVERSATIONS_TOKEN_AUDIENCE`,
+  `PANEL_CONVERSATIONS_TENANT_ID`, `PANEL_OWNER_INDEX_DATABASE_CONTAINER`,
+  `PANEL_FEEDBACK_DATABASE_CONTAINER`, `PANEL_CURSOR_TTL_SECONDS`,
+  `PANEL_OVERVIEW_MIN_CARDINALITY` — all published unconditionally and safely
+  inert, matching the already-merged `gpt-rag-ui` panel configuration exactly)
+  and `config.deployment.composition.panel_database_containers`/
+  `resolve_database_containers`, which provision exactly two
+  metadata-only, `/principal_id`-partitioned Cosmos containers (owner index,
+  feedback) for hosted/panel — never the classic
+  `conversations`/`datasources`/`prompts`/`mcp` list, so switching topologies
+  can never mix protected chat content with panel metadata. Added
+  `config.panel.setup`, a new `postProvision` hook (wired into both
+  `scripts/postProvision.ps1` and `.sh`) that assigns **container-scoped**
+  (never account-scope) Cosmos SQL role assignments: Data Contributor for the
+  `gpt-rag-ui` BFF identity and Data Reader for `gpt-rag-ingestion` (operator
+  overview counts only) on the two panel containers — the hosted
+  agent/container identity is never resolved or granted any role. The panel's
+  pagination cursor reuses the UI's existing `CHAINLIT_AUTH_SECRET`
+  (already Key-Vault-backed); no new secret or Key Vault RBAC was introduced.
+  `DEPLOY_ADMINISTRATIVE_PANEL=true` (hosted-panel topology selection) still
+  fails closed pending the remaining gpt-rag-ingestion operator-surface work;
+  this change is the platform-layer prerequisite, with no other runtime
+  behavior change.
 - **Deterministic deployment topologies.** Classic, hosted/no-panel, and
   hosted/panel remain recognized topology values, but only classic and
   hosted/no-panel are currently deployable. `DEPLOY_ADMINISTRATIVE_PANEL`

--- a/config/deployment/composition.py
+++ b/config/deployment/composition.py
@@ -13,6 +13,13 @@ from pathlib import Path
 from typing import Mapping
 
 from config.continuity.settings import public_settings as continuity_public_settings
+from config.panel.settings import (
+    FEEDBACK_CONTAINER_CONFIG_KEY,
+    FEEDBACK_CONTAINER_NAME,
+    OWNER_INDEX_CONTAINER_CONFIG_KEY,
+    OWNER_INDEX_CONTAINER_NAME,
+    public_settings as panel_public_settings,
+)
 
 
 APP_CONFIG_LABEL = "gpt-rag"
@@ -417,6 +424,36 @@ def materialized_settings(
     }
 
 
+def resolve_database_containers(
+    mode: DeploymentMode,
+    existing_containers: list[dict[str, object]],
+    *,
+    preserving_classic_runtime: bool = False,
+) -> list[dict[str, object]]:
+    """Return the exact ``databaseContainersList`` value for ``mode``.
+
+    A small, directly-testable pure function (mirrors ``describe_mode``/
+    ``materialized_settings`` in this module, which also take ``mode`` as a
+    plain argument) so the panel/no-panel container-list contract can be unit
+    tested without needing ``resolve_mode`` to accept a hosted-panel
+    environment signal, which still fails closed pending the remaining
+    https://github.com/Azure/gpt-rag/issues/611 component work.
+
+    - Classic (or a migrating hosted deployment still preserving the classic
+      runtime): the static classic list is unchanged.
+    - Hosted/no-panel: no Cosmos containers at all (ADR-0001/0004).
+    - Hosted/panel: *only* the two panel metadata containers (owner index,
+      feedback) -- never the classic ``conversations``/``datasources``/
+      ``prompts``/``mcp`` list -- so panel Cosmos never mixes protected chat
+      content with metadata in the shared account/database.
+    """
+    if preserving_classic_runtime or mode is DeploymentMode.CLASSIC:
+        return existing_containers
+    if mode is DeploymentMode.HOSTED_PANEL:
+        return panel_database_containers()
+    return []
+
+
 def selected_components(mode: DeploymentMode) -> tuple[str, ...]:
     if mode is DeploymentMode.CLASSIC:
         return (
@@ -425,6 +462,42 @@ def selected_components(mode: DeploymentMode) -> tuple[str, ...]:
             "gpt-rag-ingestion",
         )
     return ("gpt-rag-ui", "gpt-rag-ingestion")
+
+
+def panel_database_containers() -> list[dict[str, object]]:
+    """Return the exact, reversible Cosmos containers for hosted/panel mode.
+
+    Used only when ``mode is DeploymentMode.HOSTED_PANEL`` -- see
+    ``compose_parameters``. Both containers are partitioned by
+    ``/principal_id`` (matching the classic ``conversations`` container
+    convention) and carry metadata only: the owner index (conversation
+    id/title/timestamps) and feedback (rating/category/comment/message
+    reference) -- never message content, citations, or document content
+    (ADR-0004). Deliberately distinct from the classic ``conversations``
+    chat-content container, and hosted/panel provisions *only* these two
+    containers -- not the classic mode's ``conversations``/``datasources``/
+    ``prompts``/``mcp`` list -- so switching topologies never mixes protected
+    chat content with panel metadata in one container. Each entry's
+    ``canonical_name`` is published verbatim to App Configuration (label
+    ``gpt-rag``) by the generic AILZ database-container-list mechanism,
+    matching the exact keys ``gpt-rag-ui``'s merged panel configuration
+    already consumes (``PANEL_OWNER_INDEX_DATABASE_CONTAINER``,
+    ``PANEL_FEEDBACK_DATABASE_CONTAINER``). Container-scoped Cosmos RBAC for
+    these containers is assigned separately by ``config.panel.setup`` (never
+    through the generic account-scope ``containerAppsList`` role loop).
+    """
+    return [
+        {
+            "name": OWNER_INDEX_CONTAINER_NAME,
+            "canonical_name": OWNER_INDEX_CONTAINER_CONFIG_KEY,
+            "partitionKey": "/principal_id",
+        },
+        {
+            "name": FEEDBACK_CONTAINER_NAME,
+            "canonical_name": FEEDBACK_CONTAINER_CONFIG_KEY,
+            "partitionKey": "/principal_id",
+        },
+    ]
 
 
 def _setting(name: str, value: str) -> dict[str, str]:
@@ -569,10 +642,13 @@ def compose_parameters(
             for app in apps
             if isinstance(app, dict) and app.get("service_name") != "orchestrator"
         ]
-    if (
-        mode is DeploymentMode.HOSTED_NO_PANEL
-        and not preserving_classic_runtime
-    ):
+    if hosted and not preserving_classic_runtime:
+        # Neither hosted topology grants Cosmos RBAC to dataingest through
+        # the generic account-scope role loop. Hosted/no-panel has no Cosmos
+        # at all; hosted/panel assigns dataingest a narrow, container-scoped
+        # Data Reader role (aggregate overview counts only) exclusively via
+        # config.panel.setup, never the account-wide Data Contributor role
+        # this static list otherwise grants in classic mode.
         for app in apps:
             if app.get("service_name") == "dataingest":
                 app["roles"] = [
@@ -582,11 +658,19 @@ def compose_parameters(
                 ]
     parameters["containerAppsList"] = {"value": apps}
 
-    if (
-        mode is DeploymentMode.HOSTED_NO_PANEL
-        and not preserving_classic_runtime
-    ):
-        parameters["databaseContainersList"] = {"value": []}
+    databases_parameter = parameters.get("databaseContainersList")
+    existing_containers = (
+        databases_parameter.get("value")
+        if isinstance(databases_parameter, dict)
+        else None
+    )
+    parameters["databaseContainersList"] = {
+        "value": resolve_database_containers(
+            mode,
+            existing_containers if isinstance(existing_containers, list) else [],
+            preserving_classic_runtime=preserving_classic_runtime,
+        )
+    }
 
     parameters["additionalAppConfigurationSettings"] = {
         "value": [
@@ -623,6 +707,10 @@ def compose_parameters(
             *[
                 _setting(name, value)
                 for name, value in continuity_public_settings(environment).items()
+            ],
+            *[
+                _setting(name, value)
+                for name, value in panel_public_settings(environment).items()
             ],
             # The routing selector is intentionally last so endpoint and
             # immutable-image prerequisites materialize before cutover.

--- a/config/panel/__init__.py
+++ b/config/panel/__init__.py
@@ -1,0 +1,1 @@
+"""Hosted administrative panel platform configuration (issue #611, ADR-0004)."""

--- a/config/panel/settings.py
+++ b/config/panel/settings.py
@@ -1,0 +1,77 @@
+"""Public hosted-panel settings shared by deployment publishers.
+
+Mirrors ``config.continuity.settings``: every key here is safe to publish
+unconditionally (App Configuration label ``gpt-rag``) because it is inert
+unless ``DEPLOY_ADMINISTRATIVE_PANEL`` and ``PANEL_HISTORY_ENABLED`` are both
+``true`` (see ADR-0004 and the merged ``gpt-rag-ui`` ``panel_config.py``,
+which this module's key names and defaults match exactly -- no duplicate or
+invented keys).
+
+``PANEL_HISTORY_OWNER_BINDING_VALIDATED`` is forced to ``false`` here the
+same way ``HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`` is forced to
+``false`` in ``config.continuity.settings``: it is this ADR's own
+environment-evidence gate for the panel's list/read call path, and no live
+verification procedure for that gate ships in this change (only the
+platform contract -- containers, RBAC, App Configuration keys, and the
+versioned schema). Flipping it to ``true`` is out of scope until a
+dedicated verification procedure exists; until then the panel safely stays
+on its ``owner_index`` pre-gate/fallback mechanism, which is fully
+functional and never itself returns an error for the unmet gate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+LABEL = "gpt-rag"
+
+# Canonical panel Cosmos container names. Both are partitioned by
+# ``/principal_id`` (matching the classic ``conversations`` container
+# convention) and carry metadata only -- never message content, citations,
+# or document content. Distinct from the classic chat-content container so
+# switching topologies never mixes content and metadata in one container.
+OWNER_INDEX_CONTAINER_NAME = "panel-conversation-owner-index"
+FEEDBACK_CONTAINER_NAME = "panel-feedback"
+
+# App Configuration keys that receive the container names above (published
+# by the generic AILZ database-container-list mechanism via each entry's
+# ``canonical_name``; see ``config.deployment.composition.panel_database_containers``).
+OWNER_INDEX_CONTAINER_CONFIG_KEY = "PANEL_OWNER_INDEX_DATABASE_CONTAINER"
+FEEDBACK_CONTAINER_CONFIG_KEY = "PANEL_FEEDBACK_DATABASE_CONTAINER"
+
+DEFAULT_CURSOR_TTL_SECONDS = "600"
+DEFAULT_OVERVIEW_MIN_CARDINALITY = "5"
+
+DEFAULT_SETTINGS: Mapping[str, str] = {
+    "PANEL_HISTORY_ENABLED": "false",
+    "PANEL_HISTORY_OWNER_BINDING_VALIDATED": "false",
+    "PANEL_CONVERSATION_ENUMERATION_MODE": "owner_index",
+    "PANEL_CONVERSATIONS_TOKEN_AUDIENCE": "",
+    "PANEL_CONVERSATIONS_TENANT_ID": "",
+    OWNER_INDEX_CONTAINER_CONFIG_KEY: OWNER_INDEX_CONTAINER_NAME,
+    FEEDBACK_CONTAINER_CONFIG_KEY: FEEDBACK_CONTAINER_NAME,
+    "PANEL_CURSOR_TTL_SECONDS": DEFAULT_CURSOR_TTL_SECONDS,
+    "PANEL_OVERVIEW_MIN_CARDINALITY": DEFAULT_OVERVIEW_MIN_CARDINALITY,
+}
+
+
+def public_settings(environment: Mapping[str, str]) -> dict[str, str]:
+    """Return the panel settings to publish, keeping the evidence-gated flag
+    fail closed regardless of what an operator may have set locally.
+
+    While ``DEPLOY_ADMINISTRATIVE_PANEL``/``PANEL_HISTORY_ENABLED`` are
+    ``false`` (today's default and only supported state -- hosted-panel
+    topology selection itself still fails closed pending
+    https://github.com/Azure/gpt-rag/issues/611's remaining component work),
+    every value here stays at its safe default and no Cosmos container or
+    RBAC assignment is provisioned (see
+    ``config.deployment.composition.panel_database_containers`` and
+    ``config.panel.setup``).
+    """
+    settings = {
+        key: str(environment.get(key, default))
+        for key, default in DEFAULT_SETTINGS.items()
+    }
+    settings["PANEL_HISTORY_OWNER_BINDING_VALIDATED"] = "false"
+    return settings

--- a/config/panel/setup.py
+++ b/config/panel/setup.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Assign container-scoped Cosmos RBAC for the optional administrative panel.
+
+Issue #611 / ADR-0004. This script is the *only* place that grants Cosmos
+data-plane access for the panel's owner-index and feedback metadata
+containers. It never uses the generic AILZ account-scope role-assignment
+loop (``containerAppsList[].roles`` + ``modules/security/cosmos-data-plane-
+role-assignment.bicep`` in the ``infra`` submodule): that loop only supports
+whole-account scope, which would also grant access to any other container in
+the shared account/database -- including, in a migrated environment, the
+classic ``conversations`` chat-content container. Panel Cosmos RBAC must
+never risk exposing chat content, so every assignment here is scoped to
+exactly one container path (``/dbs/{database}/colls/{container}``) using the
+same built-in Cosmos SQL role GUIDs AILZ already uses
+(``00000000-0000-0000-0000-000000000002`` Data Contributor,
+``00000000-0000-0000-0000-000000000001`` Data Reader). This keeps the
+AI Landing Zone submodule generic while all GPT-RAG-specific narrowing lives
+here, in a GPT-RAG config/hook, per AGENTS.md.
+
+Identity/role matrix (ADR-0004):
+
+- **gpt-rag-ui (frontend)** -- the only component holding the user token and
+  the exclusive owner of managed-Conversation create/read/append/delete and
+  the owner index -- gets **Cosmos DB Built-in Data Contributor**, scoped to
+  *only* the two panel containers.
+- **gpt-rag-ingestion (dataingest)** -- the operator overview surface reads
+  aggregate counts over panel metadata only -- gets **Cosmos DB Built-in
+  Data Reader**, scoped to the *same* two containers. It never gets write
+  access and never gets the classic ``conversations``/``datasources``/
+  ``prompts``/``mcp`` containers through this script.
+- **gpt-rag-orchestrator (hosted agent/container)** -- stateless, holds
+  **zero** managed-Conversations RBAC per ADR-0001/0003/0004 -- gets
+  *nothing* here. This script has no code path that resolves or assigns a
+  role to the orchestrator/hosted-agent identity.
+
+Idempotent: every assignment is looked up by (principalId, roleDefinitionId,
+scope) before creating, so re-running this script (every ``postProvision``)
+never fails on an assignment that already exists and never duplicates one.
+
+Reversible: deleting the two container-scoped assignments (or simply setting
+``DEPLOY_ADMINISTRATIVE_PANEL=false`` and re-running provisioning, which never
+calls this script) fully revokes panel Cosmos access without touching any
+other container, account, or identity.
+
+No-op unless ``DEPLOY_ADMINISTRATIVE_PANEL`` is ``true`` -- which, as of this
+change, cannot yet be reached through normal topology resolution (hosted-panel
+topology selection still fails closed pending the remaining
+https://github.com/Azure/gpt-rag/issues/611 component work in
+gpt-rag-ingestion). This script exists so the platform contract -- the exact,
+reviewed, narrow-scope RBAC shape -- is ready the moment that gate lifts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from util.azure_cli import resolve_az_command
+
+
+LABEL = "gpt-rag"
+
+COSMOS_DATA_CONTRIBUTOR_ROLE_GUID = "00000000-0000-0000-0000-000000000002"
+COSMOS_DATA_READER_ROLE_GUID = "00000000-0000-0000-0000-000000000001"
+
+FRONTEND_APP_SERVICE_NAME = "frontend"
+DATA_INGEST_APP_SERVICE_NAME = "dataingest"
+# The hosted agent/orchestrator identity is deliberately absent from this
+# module: it must never be resolved or assigned a Cosmos role here.
+
+
+class PanelRbacError(RuntimeError):
+    """Raised when panel Cosmos RBAC cannot be safely assigned or verified."""
+
+
+@dataclass(frozen=True)
+class PanelContainerGrant:
+    """One (principal, role, container) triple to reconcile."""
+
+    service_name: str
+    role_definition_guid: str
+    container_name: str
+
+
+def is_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
+def container_scope_path(
+    subscription_id: str,
+    resource_group: str,
+    account_name: str,
+    database_name: str,
+    container_name: str,
+) -> str:
+    """Return the exact container-scoped Cosmos SQL RBAC scope path.
+
+    Deliberately narrower than the account-root scope the generic AILZ
+    ``containerAppsList``-driven role loop uses, so a grant here can never
+    reach any other container in the shared account/database -- including a
+    classic ``conversations`` chat-content container that may still exist
+    from a prior topology.
+    """
+    for value, name in (
+        (subscription_id, "subscription_id"),
+        (resource_group, "resource_group"),
+        (account_name, "account_name"),
+        (database_name, "database_name"),
+        (container_name, "container_name"),
+    ):
+        if not (value or "").strip():
+            raise PanelRbacError(f"container_scope_path requires a non-empty {name}.")
+    return (
+        f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+        f"/providers/Microsoft.DocumentDB/databaseAccounts/{account_name}"
+        f"/dbs/{database_name}/colls/{container_name}"
+    )
+
+
+def role_definition_id(
+    subscription_id: str,
+    resource_group: str,
+    account_name: str,
+    role_definition_guid: str,
+) -> str:
+    return (
+        f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+        f"/providers/Microsoft.DocumentDB/databaseAccounts/{account_name}"
+        f"/sqlRoleDefinitions/{role_definition_guid}"
+    )
+
+
+def panel_container_grants() -> tuple[PanelContainerGrant, ...]:
+    """Return the exact, reviewed grants this script ever assigns.
+
+    Frontend (UI BFF) gets read/write (Data Contributor) on both panel
+    containers -- it is the exclusive owner of the owner index and feedback
+    metadata. Ingestion (operator overview) gets read-only (Data Reader) on
+    the same two containers -- aggregate counts only, never a write. The
+    hosted agent/orchestrator identity is never a grant target.
+    """
+    from config.panel.settings import FEEDBACK_CONTAINER_NAME, OWNER_INDEX_CONTAINER_NAME
+
+    containers = (OWNER_INDEX_CONTAINER_NAME, FEEDBACK_CONTAINER_NAME)
+    grants = []
+    for container_name in containers:
+        grants.append(
+            PanelContainerGrant(
+                service_name=FRONTEND_APP_SERVICE_NAME,
+                role_definition_guid=COSMOS_DATA_CONTRIBUTOR_ROLE_GUID,
+                container_name=container_name,
+            )
+        )
+    for container_name in containers:
+        grants.append(
+            PanelContainerGrant(
+                service_name=DATA_INGEST_APP_SERVICE_NAME,
+                role_definition_guid=COSMOS_DATA_READER_ROLE_GUID,
+                container_name=container_name,
+            )
+        )
+    return tuple(grants)
+
+
+def _run_az(arguments: list[str], *, required: bool = True) -> str:
+    completed = subprocess.run(
+        [resolve_az_command(), *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = completed.stdout.strip()
+    if completed.returncode != 0 or (required and not output):
+        detail = completed.stderr.strip() or output
+        raise PanelRbacError(f"Azure CLI command failed: az {' '.join(arguments)}: {detail}")
+    return output
+
+
+def resolve_container_app_principal_id(resource_group: str, app_name: str) -> str:
+    output = _run_az(
+        [
+            "containerapp",
+            "show",
+            "--resource-group",
+            resource_group,
+            "--name",
+            app_name,
+            "--query",
+            "identity.principalId",
+            "--output",
+            "tsv",
+        ]
+    )
+    principal_id = output.strip()
+    if not principal_id or principal_id.lower() == "none":
+        raise PanelRbacError(
+            f"Container app {app_name!r} has no principal ID; cannot assign "
+            "panel Cosmos RBAC without a resolvable managed identity."
+        )
+    return principal_id
+
+
+def existing_cosmos_sql_role_assignment(
+    account_name: str,
+    resource_group: str,
+    principal_id: str,
+    scope: str,
+) -> Mapping[str, object] | None:
+    output = _run_az(
+        [
+            "cosmosdb",
+            "sql",
+            "role",
+            "assignment",
+            "list",
+            "--account-name",
+            account_name,
+            "--resource-group",
+            resource_group,
+            "--output",
+            "json",
+        ],
+        required=False,
+    )
+    if not output:
+        return None
+    for assignment in json.loads(output):
+        if (
+            str(assignment.get("principalId") or "").lower() == principal_id.lower()
+            and str(assignment.get("scope") or "").rstrip("/").lower()
+            == scope.rstrip("/").lower()
+        ):
+            return assignment
+    return None
+
+
+def ensure_cosmos_sql_role_assignment(
+    account_name: str,
+    resource_group: str,
+    subscription_id: str,
+    principal_id: str,
+    role_definition_guid: str,
+    scope: str,
+) -> bool:
+    """Create the container-scoped role assignment if it is not already present.
+
+    Returns ``True`` when a new assignment was created, ``False`` when a
+    matching assignment (any role at this exact scope for this principal)
+    already existed and was left untouched -- idempotent by design.
+    """
+    existing = existing_cosmos_sql_role_assignment(
+        account_name, resource_group, principal_id, scope
+    )
+    if existing is not None:
+        return False
+    _run_az(
+        [
+            "cosmosdb",
+            "sql",
+            "role",
+            "assignment",
+            "create",
+            "--account-name",
+            account_name,
+            "--resource-group",
+            resource_group,
+            "--role-definition-id",
+            role_definition_id(
+                subscription_id, resource_group, account_name, role_definition_guid
+            ),
+            "--principal-id",
+            principal_id,
+            "--scope",
+            scope,
+        ],
+        required=False,
+    )
+    return True
+
+
+def resolve_subscription_id(environment: Mapping[str, str]) -> str:
+    """Return the subscription ID, falling back to ``az account show``.
+
+    Mirrors ``scripts/postProvision.ps1``'s ``Set-GptRagAppConfiguration``,
+    which resolves ``AZURE_SUBSCRIPTION_ID`` the same way when the azd
+    environment does not carry it explicitly.
+    """
+    subscription_id = (environment.get("AZURE_SUBSCRIPTION_ID") or "").strip()
+    if subscription_id:
+        return subscription_id
+    return _run_az(["account", "show", "--query", "id", "--output", "tsv"]).strip()
+
+
+def configure_panel_rbac(environment: Mapping[str, str]) -> int:
+    """Reconcile every panel Cosmos container-scoped grant.
+
+    No-op (returns 0) unless ``DEPLOY_ADMINISTRATIVE_PANEL`` is ``true``.
+    Returns the number of newly created assignments.
+    """
+    if not is_truthy(environment.get("DEPLOY_ADMINISTRATIVE_PANEL")):
+        logging.info(
+            "[panel.setup] DEPLOY_ADMINISTRATIVE_PANEL is not true; skipping "
+            "panel Cosmos RBAC (no container, no role assignment)."
+        )
+        return 0
+
+    # Validate every environment-supplied requirement before making any
+    # Azure CLI call (including the AZURE_SUBSCRIPTION_ID fallback below),
+    # so a misconfigured environment fails fast and deterministically.
+    resource_group = (environment.get("AZURE_RESOURCE_GROUP") or "").strip()
+    account_name = (environment.get("DATABASE_ACCOUNT_NAME") or "").strip()
+    resource_token = (environment.get("RESOURCE_TOKEN") or "").strip()
+    for value, name in (
+        (resource_group, "AZURE_RESOURCE_GROUP"),
+        (account_name, "DATABASE_ACCOUNT_NAME"),
+        (resource_token, "RESOURCE_TOKEN"),
+    ):
+        if not value:
+            raise PanelRbacError(
+                f"DEPLOY_ADMINISTRATIVE_PANEL is true but {name} is not set; "
+                "cannot assign panel Cosmos RBAC."
+            )
+    subscription_id = resolve_subscription_id(environment)
+    if not subscription_id:
+        raise PanelRbacError(
+            "DEPLOY_ADMINISTRATIVE_PANEL is true but AZURE_SUBSCRIPTION_ID "
+            "could not be determined; cannot assign panel Cosmos RBAC."
+        )
+    database_name = (environment.get("DATABASE_NAME") or "").strip() or account_name
+
+    app_names = {
+        FRONTEND_APP_SERVICE_NAME: f"ca-{resource_token}-frontend",
+        DATA_INGEST_APP_SERVICE_NAME: f"ca-{resource_token}-dataingest",
+    }
+    principal_ids = {
+        service_name: resolve_container_app_principal_id(resource_group, app_name)
+        for service_name, app_name in app_names.items()
+    }
+
+    created = 0
+    for grant in panel_container_grants():
+        scope = container_scope_path(
+            subscription_id,
+            resource_group,
+            account_name,
+            database_name,
+            grant.container_name,
+        )
+        if ensure_cosmos_sql_role_assignment(
+            account_name,
+            resource_group,
+            subscription_id,
+            principal_ids[grant.service_name],
+            grant.role_definition_guid,
+            scope,
+        ):
+            created += 1
+            logging.info(
+                "[panel.setup] granted %s role %s on container %s scope-only.",
+                grant.service_name,
+                grant.role_definition_guid,
+                grant.container_name,
+            )
+        else:
+            logging.info(
+                "[panel.setup] %s already has a role assignment at container "
+                "%s scope; left untouched.",
+                grant.service_name,
+                grant.container_name,
+            )
+    return created
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    created = configure_panel_rbac(os.environ)
+    logging.info("[panel.setup] finished; %d new role assignment(s) created.", created)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/config/panel/tests/__init__.py
+++ b/config/panel/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the hosted administrative panel platform configuration."""

--- a/config/panel/tests/test_contract.py
+++ b/config/panel/tests/test_contract.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class ConversationsPanelContractTests(unittest.TestCase):
+    def test_schema_checksum_matches_pinned_sha256(self) -> None:
+        schema_path = (
+            REPO_ROOT / "contracts" / "conversations-panel-v1.schema.json"
+        )
+        checksum_path = (
+            REPO_ROOT / "contracts" / "conversations-panel-v1.sha256"
+        )
+        checksum = checksum_path.read_text(encoding="utf-8").split()[0]
+
+        self.assertEqual(
+            hashlib.sha256(
+                schema_path.read_bytes().replace(b"\r\n", b"\n")
+            ).hexdigest(),
+            checksum,
+        )
+
+    def test_schema_is_valid_json_with_every_expected_shape(self) -> None:
+        schema_path = (
+            REPO_ROOT / "contracts" / "conversations-panel-v1.schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        defs = schema["$defs"]
+
+        expected_defs = {
+            "CorrelationId",
+            "Cursor",
+            "ConversationSummary",
+            "ConversationsListResponse",
+            "MessageItem",
+            "MessagesResponse",
+            "FeedbackCreateRequest",
+            "FeedbackRecord",
+            "FeedbackListResponse",
+            "DeleteConversationResponse",
+            "OperatorOverviewMetricsResponse",
+            "SuppressibleCount",
+            "CorpusCurationItem",
+            "CorpusCurationQueueResponse",
+            "CorpusCurationDecisionRequest",
+            "CorpusCurationDecisionResponse",
+            "ErrorResponse",
+        }
+        self.assertEqual(expected_defs, set(defs))
+
+    def test_every_object_shape_forbids_extra_properties(self) -> None:
+        schema_path = (
+            REPO_ROOT / "contracts" / "conversations-panel-v1.schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+        for name, definition in schema["$defs"].items():
+            if definition.get("type") == "object":
+                with self.subTest(shape=name):
+                    self.assertFalse(
+                        definition.get("additionalProperties", True),
+                        f"{name} must set additionalProperties: false",
+                    )
+
+    def test_correlation_id_matches_audit_event_v1_pattern(self) -> None:
+        schema_path = (
+            REPO_ROOT / "contracts" / "conversations-panel-v1.schema.json"
+        )
+        audit_schema_path = REPO_ROOT / "contracts" / "audit-event-v1.schema.json"
+        panel_schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        audit_schema = json.loads(audit_schema_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            panel_schema["$defs"]["CorrelationId"]["pattern"],
+            audit_schema["properties"]["correlation_id"]["pattern"],
+        )
+
+    def test_message_item_carries_no_document_or_citation_specific_fields(
+        self,
+    ) -> None:
+        # MessageItem is deliberately minimal (role/content only) -- it is
+        # read live from managed Conversations and never persisted to
+        # Cosmos; the schema must not grow implementation-specific fields
+        # that would encourage caching content elsewhere.
+        schema_path = (
+            REPO_ROOT / "contracts" / "conversations-panel-v1.schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        message_item = schema["$defs"]["MessageItem"]
+
+        self.assertEqual(set(message_item["properties"]), {"role", "content"})
+
+    def test_no_content_or_message_body_fields_in_metadata_shapes(self) -> None:
+        # Cosmos-backed shapes must never define a field that could carry
+        # chat content (ADR-0004 content-confinement).
+        schema_path = (
+            REPO_ROOT / "contracts" / "conversations-panel-v1.schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        forbidden_field_names = {
+            "content",
+            "message_body",
+            "transcript",
+            "citation",
+            "citations",
+        }
+        metadata_shapes = (
+            "ConversationSummary",
+            "FeedbackRecord",
+            "CorpusCurationItem",
+        )
+        for name in metadata_shapes:
+            with self.subTest(shape=name):
+                fields = set(schema["$defs"][name]["properties"])
+                self.assertEqual(fields & forbidden_field_names, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/config/panel/tests/test_settings.py
+++ b/config/panel/tests/test_settings.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import unittest
+
+from config.panel import settings
+
+
+class PanelSettingsTests(unittest.TestCase):
+    def test_defaults_are_safe_when_panel_disabled(self) -> None:
+        published = settings.public_settings({})
+
+        self.assertEqual(published["PANEL_HISTORY_ENABLED"], "false")
+        self.assertEqual(
+            published["PANEL_HISTORY_OWNER_BINDING_VALIDATED"], "false"
+        )
+        self.assertEqual(
+            published["PANEL_CONVERSATION_ENUMERATION_MODE"], "owner_index"
+        )
+        self.assertEqual(published["PANEL_CONVERSATIONS_TOKEN_AUDIENCE"], "")
+        self.assertEqual(published["PANEL_CONVERSATIONS_TENANT_ID"], "")
+        self.assertEqual(
+            published[settings.OWNER_INDEX_CONTAINER_CONFIG_KEY],
+            settings.OWNER_INDEX_CONTAINER_NAME,
+        )
+        self.assertEqual(
+            published[settings.FEEDBACK_CONTAINER_CONFIG_KEY],
+            settings.FEEDBACK_CONTAINER_NAME,
+        )
+        self.assertEqual(published["PANEL_CURSOR_TTL_SECONDS"], "600")
+        self.assertEqual(published["PANEL_OVERVIEW_MIN_CARDINALITY"], "5")
+
+    def test_owner_binding_validated_gate_forced_false_even_if_set(self) -> None:
+        published = settings.public_settings(
+            {
+                "PANEL_HISTORY_OWNER_BINDING_VALIDATED": "true",
+                "PANEL_CONVERSATION_ENUMERATION_MODE": "delegated",
+            }
+        )
+
+        self.assertEqual(
+            published["PANEL_HISTORY_OWNER_BINDING_VALIDATED"], "false"
+        )
+        # The enumeration-mode selector itself is a plain pass-through; only
+        # the live-evidence gate is force-disabled.
+        self.assertEqual(
+            published["PANEL_CONVERSATION_ENUMERATION_MODE"], "delegated"
+        )
+
+    def test_container_names_are_overridable(self) -> None:
+        published = settings.public_settings(
+            {
+                settings.OWNER_INDEX_CONTAINER_CONFIG_KEY: "custom-owner-index",
+                settings.FEEDBACK_CONTAINER_CONFIG_KEY: "custom-feedback",
+            }
+        )
+
+        self.assertEqual(
+            published[settings.OWNER_INDEX_CONTAINER_CONFIG_KEY],
+            "custom-owner-index",
+        )
+        self.assertEqual(
+            published[settings.FEEDBACK_CONTAINER_CONFIG_KEY], "custom-feedback"
+        )
+
+    def test_container_names_are_partitioned_by_principal_never_session(
+        self,
+    ) -> None:
+        # ADR-0004's threat model: never store unpartitioned
+        # container/session-keyed data. This is a static assertion that the
+        # canonical container names are distinct from the classic
+        # conversation-content container and match the /principal_id
+        # partition convention documented alongside them.
+        self.assertNotEqual(
+            settings.OWNER_INDEX_CONTAINER_NAME, "conversations"
+        )
+        self.assertNotEqual(settings.FEEDBACK_CONTAINER_NAME, "conversations")
+        self.assertNotEqual(
+            settings.OWNER_INDEX_CONTAINER_NAME, settings.FEEDBACK_CONTAINER_NAME
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/config/panel/tests/test_setup.py
+++ b/config/panel/tests/test_setup.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+
+from config.panel import setup
+
+
+ENVIRONMENT_BASE = {
+    "AZURE_SUBSCRIPTION_ID": "11111111-1111-1111-1111-111111111111",
+    "AZURE_RESOURCE_GROUP": "rg-test",
+    "DATABASE_ACCOUNT_NAME": "cosmos-test",
+    "DATABASE_NAME": "gpt-rag-db",
+    "RESOURCE_TOKEN": "abc123",
+}
+
+
+class PanelContainerGrantsTests(unittest.TestCase):
+    def test_grants_cover_frontend_and_ingestion_only(self) -> None:
+        grants = setup.panel_container_grants()
+        service_names = {grant.service_name for grant in grants}
+
+        self.assertEqual(
+            service_names,
+            {setup.FRONTEND_APP_SERVICE_NAME, setup.DATA_INGEST_APP_SERVICE_NAME},
+        )
+        # The hosted agent/orchestrator identity must never appear here.
+        self.assertNotIn("orchestrator", service_names)
+
+    def test_frontend_gets_contributor_ingestion_gets_reader(self) -> None:
+        grants = setup.panel_container_grants()
+
+        frontend_roles = {
+            grant.role_definition_guid
+            for grant in grants
+            if grant.service_name == setup.FRONTEND_APP_SERVICE_NAME
+        }
+        ingestion_roles = {
+            grant.role_definition_guid
+            for grant in grants
+            if grant.service_name == setup.DATA_INGEST_APP_SERVICE_NAME
+        }
+
+        self.assertEqual(frontend_roles, {setup.COSMOS_DATA_CONTRIBUTOR_ROLE_GUID})
+        self.assertEqual(ingestion_roles, {setup.COSMOS_DATA_READER_ROLE_GUID})
+
+    def test_every_grant_targets_a_panel_only_container(self) -> None:
+        from config.panel.settings import (
+            FEEDBACK_CONTAINER_NAME,
+            OWNER_INDEX_CONTAINER_NAME,
+        )
+
+        grants = setup.panel_container_grants()
+        container_names = {grant.container_name for grant in grants}
+
+        self.assertEqual(
+            container_names, {OWNER_INDEX_CONTAINER_NAME, FEEDBACK_CONTAINER_NAME}
+        )
+        self.assertNotIn("conversations", container_names)
+        self.assertNotIn("datasources", container_names)
+        self.assertNotIn("prompts", container_names)
+        self.assertNotIn("mcp", container_names)
+
+
+class ScopePathTests(unittest.TestCase):
+    def test_container_scope_path_is_narrower_than_account_scope(self) -> None:
+        scope = setup.container_scope_path(
+            "sub", "rg", "acct", "db", "panel-feedback"
+        )
+
+        self.assertTrue(scope.endswith("/dbs/db/colls/panel-feedback"))
+        self.assertIn(
+            "/providers/Microsoft.DocumentDB/databaseAccounts/acct", scope
+        )
+
+    def test_container_scope_path_requires_every_component(self) -> None:
+        with self.assertRaises(setup.PanelRbacError):
+            setup.container_scope_path("", "rg", "acct", "db", "container")
+
+
+class ConfigurePanelRbacTests(unittest.TestCase):
+    def test_noop_when_panel_not_deployed(self) -> None:
+        with patch.object(setup, "_run_az") as run_az:
+            created = setup.configure_panel_rbac({"DEPLOY_ADMINISTRATIVE_PANEL": "false"})
+
+        self.assertEqual(created, 0)
+        run_az.assert_not_called()
+
+    def test_raises_when_deployed_but_missing_required_values(self) -> None:
+        # No AZURE_RESOURCE_GROUP/DATABASE_ACCOUNT_NAME/RESOURCE_TOKEN, and no
+        # mocked _run_az: this must fail on the pure environment-variable
+        # check before ever attempting an Azure CLI call (including the
+        # AZURE_SUBSCRIPTION_ID fallback), so the test never depends on a
+        # live `az` invocation.
+        with patch.object(setup, "_run_az") as run_az:
+            with self.assertRaises(setup.PanelRbacError):
+                setup.configure_panel_rbac({"DEPLOY_ADMINISTRATIVE_PANEL": "true"})
+        run_az.assert_not_called()
+
+    def test_falls_back_to_az_account_show_when_subscription_id_unset(self) -> None:
+        environment = {
+            key: value
+            for key, value in ENVIRONMENT_BASE.items()
+            if key != "AZURE_SUBSCRIPTION_ID"
+        }
+
+        with patch.object(
+            setup, "_run_az", return_value="22222222-2222-2222-2222-222222222222"
+        ) as run_az:
+            subscription_id = setup.resolve_subscription_id(environment)
+
+        self.assertEqual(subscription_id, "22222222-2222-2222-2222-222222222222")
+        run_az.assert_called_once_with(
+            ["account", "show", "--query", "id", "--output", "tsv"]
+        )
+
+    def test_creates_four_scoped_assignments_when_none_exist(self) -> None:
+        environment = {**ENVIRONMENT_BASE, "DEPLOY_ADMINISTRATIVE_PANEL": "true"}
+
+        def fake_run_az(arguments, required=True):
+            if arguments[:2] == ["containerapp", "show"]:
+                name = arguments[arguments.index("--name") + 1]
+                return f"11111111-0000-0000-0000-0000000000{'01' if 'frontend' in name else '02'}"
+            if arguments[:4] == ["cosmosdb", "sql", "role", "assignment"] and (
+                arguments[4] == "list"
+            ):
+                return json.dumps([])
+            if arguments[:4] == ["cosmosdb", "sql", "role", "assignment"] and (
+                arguments[4] == "create"
+            ):
+                return ""
+            raise AssertionError(f"Unexpected az invocation: {arguments}")
+
+        with patch.object(setup, "_run_az", side_effect=fake_run_az) as run_az:
+            created = setup.configure_panel_rbac(environment)
+
+        self.assertEqual(created, 4)
+        create_calls = [
+            call
+            for call in run_az.call_args_list
+            if call.args[0][:4] == ["cosmosdb", "sql", "role", "assignment"]
+            and call.args[0][4] == "create"
+        ]
+        self.assertEqual(len(create_calls), 4)
+        # Every create call's --scope must reference exactly one container,
+        # never the bare account root.
+        for call in create_calls:
+            arguments = call.args[0]
+            scope = arguments[arguments.index("--scope") + 1]
+            self.assertIn("/dbs/", scope)
+            self.assertIn("/colls/", scope)
+
+    def test_skips_already_existing_assignment(self) -> None:
+        environment = {**ENVIRONMENT_BASE, "DEPLOY_ADMINISTRATIVE_PANEL": "true"}
+        frontend_principal = "11111111-0000-0000-0000-000000000001"
+
+        def fake_run_az(arguments, required=True):
+            if arguments[:2] == ["containerapp", "show"]:
+                name = arguments[arguments.index("--name") + 1]
+                return (
+                    frontend_principal
+                    if "frontend" in name
+                    else "11111111-0000-0000-0000-000000000002"
+                )
+            if arguments[:4] == ["cosmosdb", "sql", "role", "assignment"] and (
+                arguments[4] == "list"
+            ):
+                scope = setup.container_scope_path(
+                    ENVIRONMENT_BASE["AZURE_SUBSCRIPTION_ID"],
+                    ENVIRONMENT_BASE["AZURE_RESOURCE_GROUP"],
+                    ENVIRONMENT_BASE["DATABASE_ACCOUNT_NAME"],
+                    ENVIRONMENT_BASE["DATABASE_NAME"],
+                    setup.panel_container_grants()[0].container_name,
+                )
+                return json.dumps(
+                    [{"principalId": frontend_principal, "scope": scope}]
+                )
+            if arguments[:4] == ["cosmosdb", "sql", "role", "assignment"] and (
+                arguments[4] == "create"
+            ):
+                return ""
+            raise AssertionError(f"Unexpected az invocation: {arguments}")
+
+        with patch.object(setup, "_run_az", side_effect=fake_run_az) as run_az:
+            created = setup.configure_panel_rbac(environment)
+
+        # Only the frontend's first-container grant is already present; the
+        # other three grants (frontend/second-container,
+        # ingestion/first-container, ingestion/second-container) still get
+        # created.
+        self.assertEqual(created, 3)
+        create_calls = [
+            call
+            for call in run_az.call_args_list
+            if call.args[0][:4] == ["cosmosdb", "sql", "role", "assignment"]
+            and call.args[0][4] == "create"
+        ]
+        self.assertEqual(len(create_calls), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -61,3 +61,123 @@ HMAC key. The key must be in a dedicated UI BFF vault selected with
 `hosted-conversation-capability-v1.sha256` pins the exact LF-encoded schema
 bytes. Capability consumers must reject unknown schema versions, invalid or
 expired signatures, mismatched owners, and non-canonical framing.
+
+## Conversations panel v1 (issue #611, ADR-0004)
+
+`conversations-panel-v1.schema.json` is the shared wire contract for the
+optional hosted administrative panel: user-facing history/feedback/deletion
+(consumed by `gpt-rag-ui`) and operator-facing overview/corpus-curation
+(consumed by `gpt-rag-ingestion`). It has no single top-level instance;
+every shape lives under `$defs` and is referenced by a JSON Pointer fragment
+(for example `#/$defs/ConversationsListResponse`). Every object shape is
+strict (`additionalProperties: false`); an unknown field is a schema
+violation, mapped to HTTP 422, never silently ignored.
+
+`conversations-panel-v1.sha256` pins the exact LF-encoded schema bytes.
+
+Non-negotiables carried over from ADR-0001/0003/0004 and reflected directly
+in the schema:
+
+- The hosted agent/container never implements or consumes any shape here.
+  It is stateless and holds **zero** managed-Conversations RBAC; only the
+  `gpt-rag-ui` BFF (user surfaces) and `gpt-rag-ingestion` admin app
+  (operator surfaces) ever produce or consume these payloads.
+- `MessageItem.content` is read live from Foundry managed Conversations
+  (the system of record) after the owner gate passes — it is never
+  persisted to Cosmos. Cosmos-backed shapes (`ConversationSummary`,
+  `FeedbackRecord`, `CorpusCurationItem`, the overview counts) carry
+  metadata only: identifiers, titles, timestamps, ratings, category codes,
+  and counts — never message bodies, citations, or document content.
+- `correlation_id` reuses the exact `audit-event-v1` pattern
+  (`^req_[0-9a-f]{32}$`) so panel requests join the same operator audit
+  trail; it is always server-generated, never accepted from client input.
+- `Cursor` is opaque, signed, expiring, and bound to the authenticated
+  caller's principal — never a raw offset or caller-supplied identifier. A
+  tampered, expired, or cross-principal cursor is a 422, not a 401/403/404.
+- Panel `{id}` path segments (`/panel/conversations/{id}/...`) are accepted
+  only as a lookup key: every per-conversation endpoint re-checks ownership
+  (the owner-index row or an equivalent delegated per-user authorization)
+  before ever reading the managed-Conversations store. A failed owner check
+  and a missing conversation return the identical `404` — never a
+  distinguishable `403` — so there is no existence oracle.
+- `OperatorOverviewMetricsResponse` counts are aggregate-only and each
+  bucket is suppressed (`null`) below `PANEL_OVERVIEW_MIN_CARDINALITY`
+  rather than disclosing a small exact count. `CorpusCurationItem` never
+  carries or is derived from conversation content.
+- Error matrix (`ErrorResponse`, `{detail, correlation_id?}`): 401
+  missing/invalid bearer; 403 wrong token type/audience (app-only token on a
+  user surface, or a missing operator role); 404 not-owner or missing; 422
+  schema/bounds violation (including a bad cursor); 502 the
+  managed-Conversations or panel-metadata store actually failing; 503 the
+  surface itself is undeployed. 503 is never used for an unmet
+  owner-binding evidence gate — that falls back to `owner_index`
+  transparently with no error at all.
+
+Panel Cosmos containers (provisioned only when
+`DEPLOY_ADMINISTRATIVE_PANEL=true`, via
+`config.deployment.composition.panel_database_containers`):
+
+| Container | Canonical App Configuration key | Partition key | Purpose |
+| --- | --- | --- | --- |
+| `panel-conversation-owner-index` | `PANEL_OWNER_INDEX_DATABASE_CONTAINER` | `/principal_id` | `principal_id -> {conversation_id, title, timestamps}`; the sole authorization check before any per-conversation read/feedback/delete. |
+| `panel-feedback` | `PANEL_FEEDBACK_DATABASE_CONTAINER` | `/principal_id` | Feedback metadata (rating/category/comment/message reference). |
+
+Both containers use the AI Landing Zone's generic `defaultTtl: -1` (no
+automatic item expiration) — GPT-RAG performs no automatic scheduled
+deletion; retention is operator/owner-initiated hard delete only
+(`DELETE /panel/conversations/{id}`). Hosted/panel provisions *only* these
+two containers, never the classic `conversations`/`datasources`/`prompts`/
+`mcp` list, so switching topologies can never mix protected chat content
+with panel metadata in the shared Cosmos account/database. Reversal is a
+config flip (`DEPLOY_ADMINISTRATIVE_PANEL=false`) plus re-provisioning; no
+destructive migration of classic conversation content is ever performed.
+
+RBAC is intentionally **not** granted through the generic, account-scope
+`containerAppsList` role loop (which would also reach any other container
+in the shared account, including a still-present classic `conversations`
+chat-content container after a topology migration). Instead,
+`config.panel.setup` assigns exactly two **container-scoped** Cosmos SQL
+role assignments per container (`/dbs/{database}/colls/{container}`, never
+the account root):
+
+| Identity | Role | Scope |
+| --- | --- | --- |
+| `gpt-rag-ui` (frontend, the only component holding the user token) | Cosmos DB Built-in Data Contributor | Both panel containers |
+| `gpt-rag-ingestion` (dataingest, operator overview counts only) | Cosmos DB Built-in Data Reader | Both panel containers |
+| `gpt-rag-orchestrator` (hosted agent/container) | *(none)* | *(none — never resolved or assigned by this script)* |
+
+The panel's opaque pagination cursor is signed with the UI's existing
+`CHAINLIT_AUTH_SECRET` (already Key-Vault-backed, with `frontend` already
+holding `KeyVaultSecretsUser`) — no new Key Vault secret, reference, or RBAC
+is introduced for cursor signing.
+
+App Configuration keys (label `gpt-rag`, published unconditionally and
+safely inert by `config.panel.settings.public_settings`; matches the merged
+`gpt-rag-ui` `panel_config.py` exactly — no invented duplicates):
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `DEPLOY_ADMINISTRATIVE_PANEL` | `false` | Existing key; provisions panel Cosmos containers and enables panel routers, including cross-conversation enumeration. |
+| `PANEL_HISTORY_ENABLED` | `false` | User-facing history/feedback/deletion gate. |
+| `PANEL_HISTORY_OWNER_BINDING_VALIDATED` | `false` (forced) | This ADR's own environment-evidence gate for the panel's list/read call path; independent of ADR-0003's `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED`. Forced `false` here because no live verification procedure ships in this change — flipping it is future work once such a procedure exists. |
+| `PANEL_CONVERSATION_ENUMERATION_MODE` | `owner_index` | Panel-only listing backend selector (`owner_index` pre-gate/fallback vs. `delegated`). |
+| `PANEL_CONVERSATIONS_TOKEN_AUDIENCE` | `""` | Expected `aud` claim on the delegated user bearer; required once `PANEL_HISTORY_ENABLED=true`. |
+| `PANEL_CONVERSATIONS_TENANT_ID` | `""` | Falls back to `OAUTH_AZURE_AD_TENANT_ID` when unset. |
+| `PANEL_OWNER_INDEX_DATABASE_CONTAINER` | `panel-conversation-owner-index` | Published by the generic AILZ database-container-list mechanism. |
+| `PANEL_FEEDBACK_DATABASE_CONTAINER` | `panel-feedback` | Published by the generic AILZ database-container-list mechanism. |
+| `PANEL_CURSOR_TTL_SECONDS` | `600` | Pagination cursor lifetime (bounded 30–3600 by the UI). |
+| `PANEL_OVERVIEW_MIN_CARDINALITY` | `5` | Operator overview metric bucket-suppression threshold. |
+
+Operator-role authorization for the ingestion admin surfaces reuses
+ingestion's existing admin-dashboard bearer/role pattern; this repository
+does not introduce a separate config key for it, to avoid inventing a
+duplicate the ingestion implementation does not (yet) define.
+
+As of this change, hosted-panel topology selection (`DEPLOY_ADMINISTRATIVE_PANEL=true`)
+still fails closed at `config.deployment.topology`/`composition` pending the
+remaining `gpt-rag-ingestion` operator-surface work tracked by
+[issue #611](https://github.com/Azure/gpt-rag/issues/611); this contract,
+the Cosmos container/RBAC composition helpers, and the App Configuration
+keys are the platform-layer prerequisites that let that gate lift without
+further GPT-RAG-repository changes once the remaining component work lands.
+

--- a/contracts/conversations-panel-v1.schema.json
+++ b/contracts/conversations-panel-v1.schema.json
@@ -1,0 +1,247 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Azure/GPT-RAG/contracts/conversations-panel-v1.schema.json",
+  "title": "GPT-RAG conversations-panel v1",
+  "description": "Shared wire contract for the optional hosted administrative panel (issue #611, ADR-0004). This document has no single top-level instance; every shape is defined under $defs and referenced by consumers via a JSON Pointer fragment, e.g. '#/$defs/ConversationsListResponse'. Every object shape is strict (additionalProperties: false); unknown fields are a schema violation (HTTP 422), never silently ignored. Consumed by gpt-rag-ui (user-facing surfaces) and gpt-rag-ingestion (operator-facing surfaces); the hosted agent/container never implements or consumes any shape here (it holds zero managed-Conversations RBAC and is stateless). Cosmos-backed shapes (owner index, feedback, corpus curation, overview) carry metadata only -- identifiers, titles, timestamps, ratings, category codes, counts -- and never message bodies, citations, or document content. Managed Conversations remains the sole store of chat content; MessageItem.content is read live from Foundry managed Conversations, not from Cosmos.",
+  "$defs": {
+    "CorrelationId": {
+      "type": "string",
+      "pattern": "^req_[0-9a-f]{32}$",
+      "description": "Reused verbatim from audit-event-v1's correlation_id so panel requests join operator audit trails. Server-generated; never accepted from client input."
+    },
+    "Cursor": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048,
+      "description": "Opaque, signed, expiring pagination cursor bound to the authenticated caller's principal (oid) or, for operator surfaces, the requesting operator session. Never a raw offset or caller-supplied identifier. An invalid, expired, or cross-principal cursor is a 422 schema/bounds violation, not a 401/403/404."
+    },
+    "ConversationSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "created_at", "updated_at"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Owner-index lookup key equal to the managed Conversation's opaque conversation_resource_id. Never self-authorizing: every per-conversation endpoint re-checks ownership before using it to reach the managed-Conversations store."
+        },
+        "title": { "type": "string", "maxLength": 256 },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "ConversationsListResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "maxItems": 50,
+          "items": { "$ref": "#/$defs/ConversationSummary" }
+        },
+        "next_cursor": {
+          "anyOf": [{ "$ref": "#/$defs/Cursor" }, { "type": "null" }]
+        }
+      },
+      "description": "GET /panel/conversations response. Rows are always filtered server-side to the authenticated principal (owner-index principal_id == live oid, or an equivalent delegated per-user authorization); a caller never sees another principal's rows, and disabling the panel omits this endpoint entirely (503) rather than returning an empty page."
+    },
+    "MessageItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "content"],
+      "properties": {
+        "role": { "type": "string", "enum": ["user", "assistant", "system", "tool"] },
+        "content": { "type": "string", "maxLength": 20000 }
+      },
+      "description": "One ordered item read live from managed Conversations (the system of record) after the owner gate passes. Never persisted to Cosmos."
+    },
+    "MessagesResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "maxItems": 200,
+          "items": { "$ref": "#/$defs/MessageItem" }
+        }
+      },
+      "description": "GET /panel/conversations/{id}/messages response. {id} is accepted only as a lookup key: the owner gate (owner-index row principal_id == live oid, or delegated per-user authorization) must pass before this endpoint ever reads the managed-Conversations store. A failed gate (missing row, foreign owner, forged/expired capability) returns the identical 404 used for a genuinely missing conversation -- never a distinguishable 403 -- to avoid an existence oracle."
+    },
+    "FeedbackCreateRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["feedback_id", "message_ref"],
+      "properties": {
+        "feedback_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Client-chosen idempotency key. Re-posting the same feedback_id upserts the identical record instead of creating a duplicate."
+        },
+        "message_ref": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "rating": {
+          "anyOf": [
+            { "type": "integer", "minimum": -5, "maximum": 5 },
+            { "type": "null" }
+          ]
+        },
+        "category": {
+          "anyOf": [
+            { "type": "string", "maxLength": 64 },
+            { "type": "null" }
+          ]
+        },
+        "comment": {
+          "anyOf": [
+            { "type": "string", "maxLength": 2000 },
+            { "type": "null" }
+          ],
+          "description": "Genuine user-authored feedback text, bounded and sanitized. Must never carry the underlying chat transcript, a citation, or document content -- a violation is a governance/content-confinement defect, not merely a schema one."
+        }
+      }
+    },
+    "FeedbackRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["feedback_id", "message_ref", "rating", "category", "comment", "created_at"],
+      "properties": {
+        "feedback_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "message_ref": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "rating": {
+          "anyOf": [
+            { "type": "integer", "minimum": -5, "maximum": 5 },
+            { "type": "null" }
+          ]
+        },
+        "category": {
+          "anyOf": [{ "type": "string", "maxLength": 64 }, { "type": "null" }]
+        },
+        "comment": {
+          "anyOf": [{ "type": "string", "maxLength": 2000 }, { "type": "null" }]
+        },
+        "created_at": { "type": "string", "format": "date-time" }
+      },
+      "description": "POST .../feedback response body and one item of FeedbackListResponse. Stored in the panel feedback Cosmos container (partition key /principal_id) -- metadata only."
+    },
+    "FeedbackListResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/FeedbackRecord" }
+        }
+      },
+      "description": "GET /panel/conversations/{id}/feedback response, gated by the same owner check as MessagesResponse."
+    },
+    "DeleteConversationResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["deleted", "partial"] },
+        "detail": { "type": "string", "maxLength": 512 }
+      },
+      "description": "DELETE /panel/conversations/{id} response. 'deleted' only after the managed-Conversation delete itself succeeds. A subsequent panel-metadata cleanup failure (feedback rows, owner-index row) is reported as 'partial' with a human-readable detail -- never silently reported as a plain success."
+    },
+    "OperatorOverviewMetricsResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "generated_at", "correlation_id", "counts"],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "generated_at": { "type": "string", "format": "date-time" },
+        "correlation_id": { "$ref": "#/$defs/CorrelationId" },
+        "counts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "conversation_count",
+            "feedback_count",
+            "corpus_pending_count",
+            "corpus_decided_count"
+          ],
+          "properties": {
+            "conversation_count": { "$ref": "#/$defs/SuppressibleCount" },
+            "feedback_count": { "$ref": "#/$defs/SuppressibleCount" },
+            "corpus_pending_count": { "$ref": "#/$defs/SuppressibleCount" },
+            "corpus_decided_count": { "$ref": "#/$defs/SuppressibleCount" }
+          }
+        }
+      },
+      "description": "GET /panel/overview/metrics response (gpt-rag-ingestion, operator role only). Aggregate counts over panel metadata; never a content join. Each bucket below PANEL_OVERVIEW_MIN_CARDINALITY is suppressed (null) rather than disclosing a small exact count."
+    },
+    "SuppressibleCount": {
+      "anyOf": [
+        { "type": "integer", "minimum": 0 },
+        { "type": "null" }
+      ],
+      "description": "Null means the underlying bucket is below PANEL_OVERVIEW_MIN_CARDINALITY and has been suppressed, not that the count is zero."
+    },
+    "CorpusCurationItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_id", "document_id", "title", "reason_code", "submitted_at"],
+      "properties": {
+        "item_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "document_id": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "title": { "type": "string", "maxLength": 512 },
+        "reason_code": { "type": "string", "maxLength": 64 },
+        "submitted_at": { "type": "string", "format": "date-time" }
+      },
+      "description": "A document/knowledge-base curation item ingestion already indexes and has content access to. Never derived from, or referencing, conversation content."
+    },
+    "CorpusCurationQueueResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["items"],
+      "properties": {
+        "items": {
+          "type": "array",
+          "maxItems": 100,
+          "items": { "$ref": "#/$defs/CorpusCurationItem" }
+        },
+        "next_cursor": {
+          "anyOf": [{ "$ref": "#/$defs/Cursor" }, { "type": "null" }]
+        }
+      },
+      "description": "GET /panel/corpus-curation/queue response (gpt-rag-ingestion, operator role only)."
+    },
+    "CorpusCurationDecisionRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision"],
+      "properties": {
+        "decision": { "enum": ["approve", "reject", "defer"] },
+        "note": {
+          "anyOf": [{ "type": "string", "maxLength": 2000 }, { "type": "null" }]
+        }
+      },
+      "description": "POST /panel/corpus-curation/{item_id}/decision request body."
+    },
+    "CorpusCurationDecisionResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_id", "decision", "decided_at"],
+      "properties": {
+        "item_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "decision": { "enum": ["approve", "reject", "defer"] },
+        "decided_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["detail"],
+      "properties": {
+        "detail": { "type": "string", "maxLength": 512 },
+        "correlation_id": { "$ref": "#/$defs/CorrelationId" }
+      },
+      "description": "Uniform error body for every non-2xx panel response. Error-code matrix: 401 missing/invalid bearer; 403 wrong token type/audience (app-only token on a user surface, or an end-user token lacking the operator role on an operator surface); 404 not-owner or missing (identical for both -- never 403 for ownership, to avoid an existence oracle); 422 schema/bounds violation (includes a tampered/expired/cross-principal cursor); 502 the managed-Conversations store or panel metadata store actually failing (never used for gate state); 503 the surface itself is undeployed (DEPLOY_ADMINISTRATIVE_PANEL / PANEL_HISTORY_ENABLED false, or the operator admin app undeployed) -- never used for an unmet owner-binding evidence gate, which instead falls back to owner_index with no error at all."
+    }
+  }
+}

--- a/contracts/conversations-panel-v1.sha256
+++ b/contracts/conversations-panel-v1.sha256
@@ -1,0 +1,1 @@
+af432a8c17d217af539a92088dc4372b9270eef7f5331b0195eddbd01da00dc4  conversations-panel-v1.schema.json

--- a/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
+++ b/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
@@ -2,9 +2,17 @@
 
 **Status:** Accepted (contract frozen; the container zero-RBAC / stateless
 boundary is merged in gpt-rag-orchestrator **PR #308**, merge
-`a828253b85c6ed7a63f6085c1666f75a9ca2b7d8`; the gpt-rag-ui panel/owner-index and
-gpt-rag-ingestion operator surfaces, the `conversations-panel-v1` contract, and
-infra wiring remain pending as adoption work — see "Adoption and migration")<br>
+`a828253b85c6ed7a63f6085c1666f75a9ca2b7d8`; the gpt-rag-ui user-facing
+history/feedback/deletion surfaces are merged in gpt-rag-ui **PR #99**, merge
+`ee3b53b29019e675c1e9ff19ee607cea361e5a8e` (not yet reflected in
+`manifest.json`'s pin); the Azure/GPT-RAG platform layer — the versioned
+`contracts/conversations-panel-v1` schema, the panel Cosmos container/RBAC
+composition helpers (`config.deployment.composition.panel_database_containers`,
+`config.panel.setup`), and the App Configuration keys — is implemented as of
+this revision; the gpt-rag-ingestion operator surfaces and the coordinated
+`manifest.json` pin bump that lifts the `DEPLOY_ADMINISTRATIVE_PANEL=true`
+fail-closed gate remain pending as adoption work — see "Adoption and
+migration")<br>
 **Date:** 2026-08-07<br>
 **Owners:** GPT-RAG maintainer (Paulo), architecture analysis, with gpt-rag-ui,
 gpt-rag-orchestrator, and gpt-rag-ingestion component owners
@@ -726,6 +734,35 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    data-plane roles to the **BFF identity only** and **removing any such role from
    the hosted agent/container identity**. Publish this ADR. No runtime behavior
    change yet.
+
+   **Status (this revision):** done. `contracts/conversations-panel-v1.schema.json`
+   + `.sha256` are published (see `contracts/README.md`). The panel App
+   Configuration keys (`PANEL_HISTORY_ENABLED`,
+   `PANEL_HISTORY_OWNER_BINDING_VALIDATED`,
+   `PANEL_CONVERSATION_ENUMERATION_MODE`, `PANEL_CONVERSATIONS_TOKEN_AUDIENCE`,
+   `PANEL_CONVERSATIONS_TENANT_ID`, `PANEL_OWNER_INDEX_DATABASE_CONTAINER`,
+   `PANEL_FEEDBACK_DATABASE_CONTAINER`, `PANEL_CURSOR_TTL_SECONDS`,
+   `PANEL_OVERVIEW_MIN_CARDINALITY`) are published by
+   `config.panel.settings.public_settings`, merged into
+   `compose_parameters`'s `additionalAppConfigurationSettings`. The panel Cosmos
+   containers (owner index, feedback — metadata only, `/principal_id`
+   partitioned) are composed by
+   `config.deployment.composition.panel_database_containers`/
+   `resolve_database_containers` for `DeploymentMode.HOSTED_PANEL`, reusing the
+   generic AILZ database-container-list mechanism (no `infra` submodule edit).
+   Container-scoped (never account-scope) Cosmos RBAC — Data Contributor for
+   the `gpt-rag-ui` BFF identity, Data Reader for `gpt-rag-ingestion` (operator
+   overview counts only), and nothing for the hosted agent/container identity —
+   is assigned by the new `config.panel.setup` postProvision hook, invoked from
+   both `scripts/postProvision.ps1` and `.sh`. The continuity capability
+   signing key (`HOSTED_CONVERSATION_CAPABILITY_KEY`) was already provisioned
+   by `config.continuity.setup` in an earlier revision and needed no change
+   here. **`DEPLOY_ADMINISTRATIVE_PANEL=true` (hosted-panel topology
+   selection) still fails closed** at `config.deployment.topology`/
+   `composition` (`HostedPanelUnsupportedError`) and `manifest.json` is not
+   repinned in this revision — both remain gated on the still-pending
+   gpt-rag-ingestion operator-surface work below, consistent with "no runtime
+   behavior change yet."
 2. **gpt-rag-orchestrator** — make the hosted agent/container **stateless**:
    remove any managed-Conversations read/append/persist from the container and
    confirm it consumes only the BFF-supplied complete ordered input. Remove any

--- a/scripts/postProvision.ps1
+++ b/scripts/postProvision.ps1
@@ -786,6 +786,19 @@ if (-not $missing.Contains('APP_CONFIG_ENDPOINT')) {
 }
 
 #-------------------------------------------------------------------------------
+# 6) Administrative panel Cosmos RBAC (issue #611, ADR-0004)
+#-------------------------------------------------------------------------------
+if (-not $missing.Contains('APP_CONFIG_ENDPOINT')) {
+    Write-Host "`n🔐 Administrative panel Cosmos RBAC..."
+    Write-Host "🚀 Running config.panel.setup..."
+    Invoke-PythonModule -ModuleName 'config.panel.setup'
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    Write-Host "✅ Administrative panel Cosmos RBAC finished (no-op unless DEPLOY_ADMINISTRATIVE_PANEL=true)."
+} else {
+    Write-Host "⏭️  Skipping administrative panel Cosmos RBAC (missing APP_CONFIG_ENDPOINT)."
+}
+
+#-------------------------------------------------------------------------------
 # Cleaning up
 #-------------------------------------------------------------------------------
 # Write-Host "`n🧹 Cleaning Python environment up..."

--- a/scripts/postProvision.sh
+++ b/scripts/postProvision.sh
@@ -175,6 +175,19 @@ echo "🔍 AI Search setup…"
 }
 
 ###############################################################################
+# 6) Administrative panel Cosmos RBAC (issue #611, ADR-0004)
+###############################################################################
+echo
+echo "🔐 Administrative panel Cosmos RBAC…"
+{
+  echo "🚀 Running config.panel.setup…"
+  python -m config.panel.setup
+  echo "✅ Administrative panel Cosmos RBAC finished (no-op unless DEPLOY_ADMINISTRATIVE_PANEL=true)."
+} || {
+  echo "❗️ Error during administrative panel Cosmos RBAC setup. Skipping it."
+}
+
+###############################################################################
 # Cleaning up
 ###############################################################################
 echo

--- a/tests/test_deployment_modes.py
+++ b/tests/test_deployment_modes.py
@@ -14,12 +14,20 @@ from config.deployment.composition import (
     compose_parameters,
     describe_mode,
     materialized_settings,
+    panel_database_containers,
+    resolve_database_containers,
     resolve_explicit_topology,
     resolve_mode,
     resolve_topology,
     selected_components,
 )
 from config.deployment.hosted import invocations_base_url
+from config.panel.settings import (
+    FEEDBACK_CONTAINER_CONFIG_KEY,
+    FEEDBACK_CONTAINER_NAME,
+    OWNER_INDEX_CONTAINER_CONFIG_KEY,
+    OWNER_INDEX_CONTAINER_NAME,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -462,6 +470,176 @@ class DeploymentCompositionTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "delegated-user data-plane scope"):
             compose_parameters(source_parameters(), environment)
+
+
+class PanelPlatformContractTests(unittest.TestCase):
+    """Issue #611 / ADR-0004 platform-contract composition.
+
+    ``DeploymentMode.HOSTED_PANEL`` still cannot be reached through
+    ``resolve_mode``/``compose_parameters`` (hosted-panel topology selection
+    fails closed pending the remaining gpt-rag-ingestion operator work), so
+    these tests exercise the pure, directly-testable composition helpers
+    with ``mode`` passed explicitly -- exactly like the existing
+    ``describe_mode``/``materialized_settings`` tests elsewhere in this
+    module -- to prove the container/RBAC/App-Configuration contract is
+    correct and ready without changing any currently reachable behavior.
+    """
+
+    def test_panel_database_containers_are_metadata_only_and_distinct(self) -> None:
+        containers = panel_database_containers()
+        names = {container["name"] for container in containers}
+        canonical_names = {container["canonical_name"] for container in containers}
+
+        self.assertEqual(names, {OWNER_INDEX_CONTAINER_NAME, FEEDBACK_CONTAINER_NAME})
+        self.assertEqual(
+            canonical_names,
+            {OWNER_INDEX_CONTAINER_CONFIG_KEY, FEEDBACK_CONTAINER_CONFIG_KEY},
+        )
+        # Never the classic chat-content/orchestrator containers.
+        self.assertNotIn("conversations", names)
+        self.assertNotIn("datasources", names)
+        self.assertNotIn("prompts", names)
+        self.assertNotIn("mcp", names)
+        for container in containers:
+            self.assertEqual(container["partitionKey"], "/principal_id")
+
+    def test_resolve_database_containers_classic_keeps_existing_list(self) -> None:
+        existing = [{"name": "conversations", "canonical_name": "X"}]
+
+        result = resolve_database_containers(DeploymentMode.CLASSIC, existing)
+
+        self.assertEqual(result, existing)
+
+    def test_resolve_database_containers_hosted_no_panel_has_zero_cosmos(self) -> None:
+        existing = [{"name": "conversations", "canonical_name": "X"}]
+
+        result = resolve_database_containers(
+            DeploymentMode.HOSTED_NO_PANEL, existing
+        )
+
+        self.assertEqual(result, [])
+
+    def test_resolve_database_containers_hosted_panel_uses_only_panel_containers(
+        self,
+    ) -> None:
+        existing = [{"name": "conversations", "canonical_name": "X"}]
+
+        result = resolve_database_containers(DeploymentMode.HOSTED_PANEL, existing)
+
+        self.assertEqual(result, panel_database_containers())
+        names = {container["name"] for container in result}
+        self.assertNotIn("conversations", names)
+
+    def test_resolve_database_containers_preserving_classic_runtime_wins(self) -> None:
+        existing = [{"name": "conversations", "canonical_name": "X"}]
+
+        result = resolve_database_containers(
+            DeploymentMode.HOSTED_PANEL,
+            existing,
+            preserving_classic_runtime=True,
+        )
+
+        self.assertEqual(result, existing)
+
+    def test_container_app_gets_no_cosmos_conversations_role(self) -> None:
+        # The hosted agent/orchestrator identity is unconditionally removed
+        # from containerAppsList in every hosted mode (no-panel and panel
+        # share this same code path), so it can never receive
+        # CosmosDBBuiltInDataContributor (or any other role) through the
+        # generic account-scope role loop.
+        environment = {
+            "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
+            "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+            "HOSTED_AGENT_IMAGE_VERSION": DIGEST,
+            "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+        }
+
+        composed = compose_parameters(source_parameters(), environment)
+        apps = composed["parameters"]["containerAppsList"]["value"]
+
+        service_names = {app["service_name"] for app in apps}
+        self.assertNotIn("orchestrator", service_names)
+
+    def test_dataingest_loses_account_scope_cosmos_role_in_hosted_mode(self) -> None:
+        environment = {
+            "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
+            "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+            "HOSTED_AGENT_IMAGE_VERSION": DIGEST,
+            "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+        }
+
+        composed = compose_parameters(source_parameters(), environment)
+        apps = composed["parameters"]["containerAppsList"]["value"]
+        dataingest = next(app for app in apps if app["service_name"] == "dataingest")
+
+        self.assertNotIn("CosmosDBBuiltInDataContributor", dataingest["roles"])
+
+    def test_panel_app_configuration_defaults_are_published_and_safe(self) -> None:
+        environment = {
+            "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "false",
+            "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+        }
+
+        composed = compose_parameters(source_parameters(), environment)
+        settings = settings_by_name(composed)
+
+        self.assertEqual(settings["PANEL_HISTORY_ENABLED"], "false")
+        self.assertEqual(settings["PANEL_HISTORY_OWNER_BINDING_VALIDATED"], "false")
+        self.assertEqual(
+            settings["PANEL_CONVERSATION_ENUMERATION_MODE"], "owner_index"
+        )
+        self.assertEqual(
+            settings[OWNER_INDEX_CONTAINER_CONFIG_KEY], OWNER_INDEX_CONTAINER_NAME
+        )
+        self.assertEqual(
+            settings[FEEDBACK_CONTAINER_CONFIG_KEY], FEEDBACK_CONTAINER_NAME
+        )
+        self.assertEqual(settings["PANEL_CURSOR_TTL_SECONDS"], "600")
+        self.assertEqual(settings["PANEL_OVERVIEW_MIN_CARDINALITY"], "5")
+
+    def test_panel_owner_binding_validated_gate_cannot_be_set_via_environment(
+        self,
+    ) -> None:
+        environment = {
+            "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "false",
+            "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+            "PANEL_HISTORY_OWNER_BINDING_VALIDATED": "true",
+        }
+
+        composed = compose_parameters(source_parameters(), environment)
+        settings = settings_by_name(composed)
+
+        self.assertEqual(settings["PANEL_HISTORY_OWNER_BINDING_VALIDATED"], "false")
+
+    def test_no_panel_containers_or_settings_leak_into_classic_composition(
+        self,
+    ) -> None:
+        composed = compose_parameters(
+            source_parameters(),
+            {
+                "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "false",
+                "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+            },
+        )
+        containers = composed["parameters"]["databaseContainersList"]["value"]
+        names = {container["name"] for container in containers}
+
+        self.assertNotIn(OWNER_INDEX_CONTAINER_NAME, names)
+        self.assertNotIn(FEEDBACK_CONTAINER_NAME, names)
+
+    def test_no_panel_containers_leak_into_hosted_no_panel_composition(self) -> None:
+        environment = {
+            "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
+            "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+            "HOSTED_AGENT_IMAGE_VERSION": DIGEST,
+            "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+        }
+
+        composed = compose_parameters(source_parameters(), environment)
+
+        self.assertEqual(
+            [], composed["parameters"]["databaseContainersList"]["value"]
+        )
 
 
 class EnvironmentTopologyResolutionTests(unittest.TestCase):

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -248,6 +248,18 @@ class LifecycleParityTests(unittest.TestCase):
                     (scripts / shell).read_text(encoding="utf-8-sig"),
                 )
 
+    def test_postprovision_hooks_invoke_panel_setup_module(self) -> None:
+        # Issue #611 / ADR-0004: the container-scoped panel Cosmos RBAC
+        # script must run from both the PowerShell and POSIX shell
+        # postProvision hooks, with parity, exactly like every other
+        # config.*.setup module.
+        scripts = ROOT / "scripts"
+        ps1 = (scripts / "postProvision.ps1").read_text(encoding="utf-8-sig")
+        sh = (scripts / "postProvision.sh").read_text(encoding="utf-8-sig")
+
+        self.assertIn("config.panel.setup", ps1)
+        self.assertIn("config.panel.setup", sh)
+
     def test_preprovision_hooks_fetch_and_checkout_exact_manifest_commit(
         self,
     ) -> None:


### PR DESCRIPTION
## Purpose

Implements the Azure/GPT-RAG **platform-layer** prerequisites for issue
[#611](https://github.com/Azure/gpt-rag/issues/611) (complete the optional
hosted administrative panel), per the accepted **ADR-0004** and the already
merged `gpt-rag-ui` panel surfaces (PR #99,
`ee3b53b29019e675c1e9ff19ee607cea361e5a8e`):

- Versioned `contracts/conversations-panel-v1` JSON Schema (+ `.sha256` pin):
  user-facing list/messages/feedback/delete and operator-facing
  overview/corpus-curation wire shapes, strict `extra=forbid`, a uniform
  error matrix, opaque signed/expiring cursors, and `audit-event-v1`
  -compatible correlation IDs. No content fields anywhere.
- `config.panel.settings` — App Configuration defaults matching the merged
  `gpt-rag-ui` `panel_config.py` exactly (no invented/duplicate keys), merged
  into `compose_parameters`'s `additionalAppConfigurationSettings`.
- `config.deployment.composition.panel_database_containers` /
  `resolve_database_containers` — hosted/panel provisions exactly two
  metadata-only, `/principal_id`-partitioned Cosmos containers (owner index,
  feedback) via the generic AILZ database-container-list mechanism, never the
  classic `conversations`/`datasources`/`prompts`/`mcp` list and never chat
  content. Hosted/no-panel remains zero-Cosmos (unchanged).
- `config.panel.setup` — a new `postProvision` hook (wired into both
  `scripts/postProvision.ps1` and `.sh`) assigning **container-scoped**
  (never account-scope) Cosmos SQL role assignments: Data Contributor for the
  `gpt-rag-ui` BFF identity and Data Reader for `gpt-rag-ingestion` (operator
  overview counts only) on the two panel containers. The hosted
  agent/container identity is never resolved or granted a role.
- Reuses the UI's existing `CHAINLIT_AUTH_SECRET` for cursor signing — no new
  Key Vault secret or RBAC.
- Keeps the `infra` (AI Landing Zone) submodule untouched and generic; all
  GPT-RAG-specific narrowing lives in `config/` hooks per `AGENTS.md`.

`DEPLOY_ADMINISTRATIVE_PANEL=true` (hosted-panel topology selection) still
fails closed pending the remaining `gpt-rag-ingestion` operator-surface work —
this PR is the platform-layer prerequisite with **no other runtime behavior
change**. No `manifest.json` pin bump, no release/tag.

## Contributing guidelines

Please see [Contributing Guidelines](https://azure.github.io/GPT-RAG/contributing) before creating your Pull Request.

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Related Backlog Item or Issue

[Azure/gpt-rag#611](https://github.com/Azure/gpt-rag/issues/611) — see
`docs/adr/ADR-0004-hosted-panel-conversations-contract.md` (Status/Adoption
section updated in this PR to reflect what is now implemented).

## Is this change disruptive or does it break existing applications?

- [ ] Yes
- [x] No

`DEPLOY_ADMINISTRATIVE_PANEL` still defaults to `false` and hosted-panel
topology selection still fails closed with the pre-existing
`HostedPanelUnsupportedError` (unchanged, tests still pass unmodified). All
new container/RBAC/App-Configuration logic is additive and only reachable
today via direct unit tests against the pure composition helpers (mirroring
the existing `describe_mode`/`materialized_settings` testing pattern), not
through any currently reachable deployment path.

## Cross-Repository Dependencies

- [ ] [gpt-rag-orchestrator](https://github.com/azure/gpt-rag-orchestrator) — no change needed (container stays stateless/zero-RBAC per ADR-0001/0003, already merged).
- [ ] [gpt-rag-ingestion](https://github.com/azure/gpt-rag-ingestion) — operator overview/corpus-curation surfaces are in progress; this PR does not depend on them for review/merge, but the `DEPLOY_ADMINISTRATIVE_PANEL` gate stays closed until that work lands.
- [x] [gpt-rag-ui](https://github.com/azure/gpt-rag-ui) — user-facing panel surfaces already merged in PR #99 (`ee3b53b`); this PR's Cosmos container names/App Configuration keys/RBAC were verified directly against that merged code so nothing here duplicates or conflicts with it. `manifest.json` is **not** repinned in this PR.
- [ ] [gpt-rag-mcp](https://github.com/azure/gpt-rag-mcp)

## Does this require changes to project documentation?

- [ ] Yes
- [x] No

`docs/adr/ADR-0004-hosted-panel-conversations-contract.md` (this repo,
`develop` branch) is updated in this PR to record what is now implemented.
User-facing documentation on the `docs` branch is deferred until the panel is
actually enable-able (`DEPLOY_ADMINISTRATIVE_PANEL=true` reachable), per the
repository's documentation-consistency rule.

## Documentation Link

N/A — see `contracts/README.md` (updated in this PR) for the contract and
RBAC/container reference.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I have tested the new functionality and ensured existing features still work
- [x] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request

## Tests

`python -m pytest tests config -q` → **337 passed** (was 318 on `develop`),
including:

- `config/panel/tests/test_settings.py` — safe App Configuration defaults;
  the `PANEL_HISTORY_OWNER_BINDING_VALIDATED` evidence gate is forced
  `false` even if an operator sets it; container names distinct from the
  classic `conversations` container.
- `config/panel/tests/test_setup.py` — grants cover only frontend
  (Contributor) and ingestion (Reader) on the two panel containers, never
  the orchestrator; container-scoped (not account-scope) scope-path
  construction; idempotent create-if-absent; fails fast on missing
  environment without any live Azure CLI call; `AZURE_SUBSCRIPTION_ID`
  fallback to `az account show` is itself unit-tested (mocked).
- `config/panel/tests/test_contract.py` — schema/`.sha256` pin match, every
  `$defs` shape present, every object shape forbids extra properties,
  `correlation_id` pattern matches `audit-event-v1`, no content/message-body
  fields in any metadata shape.
- `tests/test_deployment_modes.py::PanelPlatformContractTests` — panel
  containers are metadata-only and distinct from
  conversations/datasources/prompts/mcp; `resolve_database_containers`
  returns the right list for classic/hosted-no-panel/hosted-panel/migrating;
  the orchestrator container app never gets a Cosmos role in hosted mode;
  dataingest loses the account-scope Cosmos role in hosted mode; panel App
  Configuration defaults are safe and the evidence gate cannot be flipped via
  environment; no panel containers leak into classic or hosted-no-panel
  composition.
- `tests/test_release_contracts.py` — PowerShell/shell postProvision parity
  for the new `config.panel.setup` invocation.
- All pre-existing `#611` fail-closed tests
  (`test_hosted_with_panel_fails_closed_until_611`,
  `test_deployment_topology_hosted_panel_fails_closed_until_611`) pass
  unmodified — this PR does not change that behavior.

## Residual risks / follow-ups

- `PANEL_HISTORY_OWNER_BINDING_VALIDATED` has no live-evidence verification
  procedure yet (forced `false`); a dedicated verification script (mirroring
  `config.continuity.setup`'s ADR-0003 evidence gate) is future work once the
  panel's delegated call path can be exercised live.
- `existing_cosmos_sql_role_assignment` treats *any* existing role assignment
  at the exact (principal, scope) pair as "already configured" rather than
  verifying the specific role GUID matches; acceptable given this script is
  the only writer of that scope, but worth tightening if that invariant ever
  changes.
- Lifting `DEPLOY_ADMINISTRATIVE_PANEL`'s `HostedPanelUnsupportedError` gate
  and bumping `manifest.json` pins are explicitly out of scope here and
  depend on the `gpt-rag-ingestion` operator-surface work landing.
