### PR TITLE
feat(panel): publish ingestion operator App Configuration keys (issue #611, ADR-0004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,30 @@
   fails closed pending the remaining gpt-rag-ingestion operator-surface work;
   this change is the platform-layer prerequisite, with no other runtime
   behavior change.
+- **Hosted panel operator-surface App Configuration keys (issue #611,
+  ADR-0004, reconciling gpt-rag-ingestion PR #274, merge
+  `5569dd6af3ecb317e1037108cb21859f1b2185a1`).** Added
+  `PANEL_OPERATOR_SURFACES_ENABLED` (forced `false`, mirroring
+  `PANEL_HISTORY_OWNER_BINDING_VALIDATED`'s no-evidence-gate-yet pattern),
+  `PANEL_OPERATOR_APP_ROLE` (`""`), and `PANEL_OPERATOR_GROUP_ID` (`""`) to
+  `config.panel.settings`, matching exactly the App Configuration keys the
+  now-merged `gpt-rag-ingestion` operator overview/corpus-curation surfaces
+  consume — no invented keys, no key set true. `PANEL_OVERVIEW_MIN_CARDINALITY`
+  (`5`), `PANEL_CURSOR_TTL_SECONDS` (`600`), and the panel Cosmos container
+  keys were already published with matching defaults and needed no change.
+  `DATABASE_ACCOUNT_NAME`/`DATABASE_NAME`/`STORAGE_ACCOUNT_NAME` and the
+  reserved per-app `DATA_INGEST_APP_APIKEY` Key Vault reference are already
+  published unconditionally by the AI Landing Zone submodule and are not
+  duplicated here. Added `config/panel/tests/test_operator_contract.py`, an
+  explicit expected-key-set fixture guarding against future drift between
+  this repository's published defaults and what `gpt-rag-ingestion` (PR #274)
+  and `gpt-rag-ui` (PR #99) actually consume. Updated ADR-0004's adoption
+  status: the ingestion operator-surface component work is now done: the
+  `DEPLOY_ADMINISTRATIVE_PANEL=true` topology gate remains fail-closed
+  (`HostedPanelUnsupportedError`) as a deliberate, separate decision gated on
+  the still-open live evidence-gate procedures, not on any remaining
+  component implementation. No manifest/pin or release change in this
+  revision.
 - **Deterministic deployment topologies.** Classic, hosted/no-panel, and
   hosted/panel remain recognized topology values, but only classic and
   hosted/no-panel are currently deployable. `DEPLOY_ADMINISTRATIVE_PANEL`

--- a/config/panel/settings.py
+++ b/config/panel/settings.py
@@ -17,6 +17,28 @@ versioned schema). Flipping it to ``true`` is out of scope until a
 dedicated verification procedure exists; until then the panel safely stays
 on its ``owner_index`` pre-gate/fallback mechanism, which is fully
 functional and never itself returns an error for the unmet gate.
+
+``PANEL_OPERATOR_SURFACES_ENABLED``, ``PANEL_OPERATOR_APP_ROLE``, and
+``PANEL_OPERATOR_GROUP_ID`` mirror the exact key names and safe defaults the
+merged ``gpt-rag-ingestion`` operator-facing overview/corpus-curation
+surfaces consume (PR #274, merge ``5569dd6af3ecb317e1037108cb21859f1b2185a1``
+-- see ``api/panel_operator.py``'s ``_require_gate_enabled`` and
+``dependencies.operator_role_or_group_configured``/
+``_operator_role_or_group_config``): those endpoints fail closed (503)
+unless ``DEPLOY_ADMINISTRATIVE_PANEL=true``,
+``PANEL_OPERATOR_SURFACES_ENABLED=true``, and an explicit operator app role
+or group is configured. ``PANEL_OPERATOR_SURFACES_ENABLED`` is forced to
+``false`` here the same way ``PANEL_HISTORY_OWNER_BINDING_VALIDATED`` is:
+no dedicated evidence-gate verification procedure for the operator surfaces
+ships in this change, so the safe default stays force-published regardless
+of what an operator may set locally, even though the ingestion component
+work itself has landed. ``PANEL_OPERATOR_APP_ROLE``/``PANEL_OPERATOR_GROUP_ID``
+are plain operator inputs (like ``PANEL_CONVERSATIONS_TOKEN_AUDIENCE``/
+``PANEL_CONVERSATIONS_TENANT_ID`` above) -- published empty and safely
+overridable once an operator is ready to name a real app role or group.
+``PANEL_CURSOR_TTL_SECONDS`` and ``PANEL_OVERVIEW_MIN_CARDINALITY`` (below)
+are shared verbatim with ingestion's own cursor/suppression defaults --
+no separate ingestion-only copy is published.
 """
 
 from __future__ import annotations
@@ -53,12 +75,15 @@ DEFAULT_SETTINGS: Mapping[str, str] = {
     FEEDBACK_CONTAINER_CONFIG_KEY: FEEDBACK_CONTAINER_NAME,
     "PANEL_CURSOR_TTL_SECONDS": DEFAULT_CURSOR_TTL_SECONDS,
     "PANEL_OVERVIEW_MIN_CARDINALITY": DEFAULT_OVERVIEW_MIN_CARDINALITY,
+    "PANEL_OPERATOR_SURFACES_ENABLED": "false",
+    "PANEL_OPERATOR_APP_ROLE": "",
+    "PANEL_OPERATOR_GROUP_ID": "",
 }
 
 
 def public_settings(environment: Mapping[str, str]) -> dict[str, str]:
-    """Return the panel settings to publish, keeping the evidence-gated flag
-    fail closed regardless of what an operator may have set locally.
+    """Return the panel settings to publish, keeping every evidence-gated
+    flag fail closed regardless of what an operator may have set locally.
 
     While ``DEPLOY_ADMINISTRATIVE_PANEL``/``PANEL_HISTORY_ENABLED`` are
     ``false`` (today's default and only supported state -- hosted-panel
@@ -74,4 +99,5 @@ def public_settings(environment: Mapping[str, str]) -> dict[str, str]:
         for key, default in DEFAULT_SETTINGS.items()
     }
     settings["PANEL_HISTORY_OWNER_BINDING_VALIDATED"] = "false"
+    settings["PANEL_OPERATOR_SURFACES_ENABLED"] = "false"
     return settings

--- a/config/panel/tests/test_operator_contract.py
+++ b/config/panel/tests/test_operator_contract.py
@@ -1,0 +1,144 @@
+"""Cross-repo drift guard: the exact App Configuration keys the merged
+``gpt-rag-ingestion`` operator-facing panel surfaces (PR #274, merge
+``5569dd6af3ecb317e1037108cb21859f1b2185a1``) and the merged ``gpt-rag-ui``
+user-facing panel surfaces (PR #99, merge
+``ee3b53b29019e675c1e9ff19ee607cea361e5a8e``) actually consume.
+
+This umbrella repository does not vendor either component's source, so this
+fixture is an explicit, reviewed snapshot of every ``config.get(...)``/
+``environ.get(...)`` key name each consumer reads, captured directly from
+those two merge commits (see the docstring of each key group below for the
+exact source reference). If either consumer adds, renames, or removes a
+config key, this test (and the umbrella's own ``config.panel.settings``)
+must be updated together -- silent drift between the umbrella's published
+defaults and what a consumer actually reads is exactly the failure mode this
+guards against.
+
+Keys intentionally excluded here because they are *not* panel-specific and
+are already published unconditionally by other mechanisms (never duplicated
+by ``config.panel.settings``):
+
+- ``DEPLOY_ADMINISTRATIVE_PANEL`` -- published by
+  ``config.deployment.composition.compose_parameters`` directly (reflects
+  resolved topology; see ``tests/test_deployment_modes.py``).
+- ``DATABASE_ACCOUNT_NAME`` / ``DATABASE_NAME`` / ``STORAGE_ACCOUNT_NAME`` --
+  published unconditionally by the AI Landing Zone submodule for every
+  topology (``infra/main.bicep``), regardless of the panel.
+- ``DATA_INGEST_APP_APIKEY`` -- the reserved per-app ``<APP>_APIKEY`` Key
+  Vault reference the AI Landing Zone submodule publishes automatically for
+  every ``containerAppsList`` entry; republishing it here would create a
+  duplicate key-value and fail deployment (see ``infra/main.bicep``'s
+  ``additionalAppConfigurationSettings`` description).
+- ``JOBS_LOG_CONTAINER`` -- ingestion's existing per-file-log blob control
+  store container name (defaults to ``"jobs"`` in ``tools/admin.py`` /
+  ``tools/corpus_curation_store.py`` even when unset); reused verbatim by
+  corpus curation, never a new blob container or secret.
+- ``OAUTH_AZURE_AD_TENANT_ID`` / ``OAUTH_AZURE_AD_CLIENT_ID`` -- ingestion's
+  existing admin-dashboard bearer/audience configuration, reused as-is by
+  ``validate_delegated_operator_bearer`` (no new auth config key).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from config.panel import settings
+
+
+# Every App Configuration key `api/panel_operator.py` (and its
+# `dependencies.py` auth helpers) reads directly, captured from
+# gpt-rag-ingestion PR #274, merge 5569dd6af3ecb317e1037108cb21859f1b2185a1.
+EXPECTED_INGESTION_OPERATOR_KEYS = frozenset(
+    {
+        "DEPLOY_ADMINISTRATIVE_PANEL",
+        "PANEL_OPERATOR_SURFACES_ENABLED",
+        "PANEL_OPERATOR_APP_ROLE",
+        "PANEL_OPERATOR_GROUP_ID",
+        "PANEL_OVERVIEW_MIN_CARDINALITY",
+        "PANEL_CURSOR_TTL_SECONDS",
+        "PANEL_OWNER_INDEX_DATABASE_CONTAINER",
+        "PANEL_FEEDBACK_DATABASE_CONTAINER",
+    }
+)
+
+# Every App Configuration key `panel_config.py`'s `load_panel_settings`
+# reads directly, captured from gpt-rag-ui PR #99, merge
+# ee3b53b29019e675c1e9ff19ee607cea361e5a8e.
+EXPECTED_UI_PANEL_KEYS = frozenset(
+    {
+        "DEPLOY_ADMINISTRATIVE_PANEL",
+        "PANEL_HISTORY_ENABLED",
+        "PANEL_HISTORY_OWNER_BINDING_VALIDATED",
+        "PANEL_CONVERSATION_ENUMERATION_MODE",
+        "PANEL_CONVERSATIONS_TOKEN_AUDIENCE",
+        "PANEL_CONVERSATIONS_TENANT_ID",
+        "PANEL_OWNER_INDEX_DATABASE_CONTAINER",
+        "PANEL_FEEDBACK_DATABASE_CONTAINER",
+        "PANEL_CURSOR_TTL_SECONDS",
+        # PANEL_CONVERSATIONS_TENANT_ID has a fallback, not a hard read:
+        "OAUTH_AZURE_AD_TENANT_ID",
+        # Cosmos identifiers, published unconditionally (see module docstring).
+        "DATABASE_ACCOUNT_NAME",
+        "DATABASE_NAME",
+    }
+)
+
+
+class OperatorContractDriftTests(unittest.TestCase):
+    def test_umbrella_publishes_every_key_ingestion_consumes(self) -> None:
+        published = settings.public_settings({})
+        panel_specific = EXPECTED_INGESTION_OPERATOR_KEYS - {
+            # Published elsewhere; see module docstring exclusions.
+            "DEPLOY_ADMINISTRATIVE_PANEL",
+        }
+        missing = panel_specific - set(published)
+        self.assertEqual(
+            missing,
+            set(),
+            "config.panel.settings no longer publishes a key "
+            "gpt-rag-ingestion's operator surfaces (PR #274) consume; "
+            "either this fixture is stale or a real drift was introduced.",
+        )
+
+    def test_umbrella_publishes_every_key_ui_consumes(self) -> None:
+        published = settings.public_settings({})
+        panel_specific = EXPECTED_UI_PANEL_KEYS - {
+            "DEPLOY_ADMINISTRATIVE_PANEL",
+            "OAUTH_AZURE_AD_TENANT_ID",
+            "DATABASE_ACCOUNT_NAME",
+            "DATABASE_NAME",
+        }
+        missing = panel_specific - set(published)
+        self.assertEqual(
+            missing,
+            set(),
+            "config.panel.settings no longer publishes a key gpt-rag-ui's "
+            "user-facing panel surfaces (PR #99) consume; either this "
+            "fixture is stale or a real drift was introduced.",
+        )
+
+    def test_no_invented_operator_keys_beyond_the_reviewed_set(self) -> None:
+        # The inverse guard: config.panel.settings must never publish an
+        # operator-surface-shaped key (PANEL_OPERATOR_*) that ingestion does
+        # not actually consume -- that would be an invented key.
+        published = settings.public_settings({})
+        operator_shaped = {
+            key for key in published if key.startswith("PANEL_OPERATOR_")
+        }
+        self.assertEqual(
+            operator_shaped,
+            {"PANEL_OPERATOR_SURFACES_ENABLED", "PANEL_OPERATOR_APP_ROLE", "PANEL_OPERATOR_GROUP_ID"},
+        )
+        self.assertTrue(operator_shaped.issubset(EXPECTED_INGESTION_OPERATOR_KEYS))
+
+    def test_operator_defaults_never_enable_the_feature(self) -> None:
+        published = settings.public_settings({})
+        self.assertEqual(
+            published["PANEL_OPERATOR_SURFACES_ENABLED"], "false"
+        )
+        self.assertEqual(published["PANEL_OPERATOR_APP_ROLE"], "")
+        self.assertEqual(published["PANEL_OPERATOR_GROUP_ID"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/config/panel/tests/test_settings.py
+++ b/config/panel/tests/test_settings.py
@@ -28,6 +28,13 @@ class PanelSettingsTests(unittest.TestCase):
         )
         self.assertEqual(published["PANEL_CURSOR_TTL_SECONDS"], "600")
         self.assertEqual(published["PANEL_OVERVIEW_MIN_CARDINALITY"], "5")
+        # gpt-rag-ingestion operator surfaces (PR #274, merge 5569dd6): safe
+        # defaults, never invented as enabled/populated.
+        self.assertEqual(
+            published["PANEL_OPERATOR_SURFACES_ENABLED"], "false"
+        )
+        self.assertEqual(published["PANEL_OPERATOR_APP_ROLE"], "")
+        self.assertEqual(published["PANEL_OPERATOR_GROUP_ID"], "")
 
     def test_owner_binding_validated_gate_forced_false_even_if_set(self) -> None:
         published = settings.public_settings(
@@ -44,6 +51,33 @@ class PanelSettingsTests(unittest.TestCase):
         # the live-evidence gate is force-disabled.
         self.assertEqual(
             published["PANEL_CONVERSATION_ENUMERATION_MODE"], "delegated"
+        )
+
+    def test_operator_surfaces_enabled_gate_forced_false_even_if_set(
+        self,
+    ) -> None:
+        # Mirrors PANEL_HISTORY_OWNER_BINDING_VALIDATED: no dedicated
+        # evidence-gate verification procedure for the operator surfaces
+        # ships in this change, so this stays force-published false even if
+        # an operator sets it locally, regardless of the ingestion component
+        # work (PR #274) having landed.
+        published = settings.public_settings(
+            {
+                "PANEL_OPERATOR_SURFACES_ENABLED": "true",
+                "PANEL_OPERATOR_APP_ROLE": "PanelOperator",
+                "PANEL_OPERATOR_GROUP_ID": "11111111-1111-1111-1111-111111111111",
+            }
+        )
+
+        self.assertEqual(
+            published["PANEL_OPERATOR_SURFACES_ENABLED"], "false"
+        )
+        # The role/group are plain operator inputs -- pass through
+        # unmodified, unlike the forced-false enabled gate above.
+        self.assertEqual(published["PANEL_OPERATOR_APP_ROLE"], "PanelOperator")
+        self.assertEqual(
+            published["PANEL_OPERATOR_GROUP_ID"],
+            "11111111-1111-1111-1111-111111111111",
         )
 
     def test_container_names_are_overridable(self) -> None:

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -169,15 +169,32 @@ safely inert by `config.panel.settings.public_settings`; matches the merged
 | `PANEL_OVERVIEW_MIN_CARDINALITY` | `5` | Operator overview metric bucket-suppression threshold. |
 
 Operator-role authorization for the ingestion admin surfaces reuses
-ingestion's existing admin-dashboard bearer/role pattern; this repository
-does not introduce a separate config key for it, to avoid inventing a
-duplicate the ingestion implementation does not (yet) define.
+ingestion's existing admin-dashboard bearer/role pattern (the same
+`OAUTH_AZURE_AD_TENANT_ID`/`OAUTH_AZURE_AD_CLIENT_ID` pair `require_admin`
+validates); this repository does not introduce a separate audience/config
+key for token validation. `gpt-rag-ingestion` PR #274 (merge
+`5569dd6af3ecb317e1037108cb21859f1b2185a1`) does define the operator
+authorization *inputs* below (`PANEL_OPERATOR_SURFACES_ENABLED`,
+`PANEL_OPERATOR_APP_ROLE`, `PANEL_OPERATOR_GROUP_ID`), which this repository
+now publishes with matching names and safe defaults -- no invented
+duplicates.
 
-As of this change, hosted-panel topology selection (`DEPLOY_ADMINISTRATIVE_PANEL=true`)
-still fails closed at `config.deployment.topology`/`composition` pending the
-remaining `gpt-rag-ingestion` operator-surface work tracked by
-[issue #611](https://github.com/Azure/gpt-rag/issues/611); this contract,
-the Cosmos container/RBAC composition helpers, and the App Configuration
-keys are the platform-layer prerequisites that let that gate lift without
-further GPT-RAG-repository changes once the remaining component work lands.
+| Key | Default | Notes |
+| --- | --- | --- |
+| `PANEL_OPERATOR_SURFACES_ENABLED` | `false` (forced) | Gates the ingestion operator overview/corpus-curation endpoints (fail-closed 503). Forced `false` here the same way `PANEL_HISTORY_OWNER_BINDING_VALIDATED` is: no dedicated evidence-gate verification procedure ships in this change, even though the ingestion component work itself (PR #274) has landed. |
+| `PANEL_OPERATOR_APP_ROLE` | `""` | Operator Entra app role name (`roles` claim); a plain operator input, published empty and safely overridable once an operator is ready to name a real role. |
+| `PANEL_OPERATOR_GROUP_ID` | `""` | Operator Entra group object id (`groups` claim); same as above. At least one of role/group must be set (in addition to `PANEL_OPERATOR_SURFACES_ENABLED=true`) before ingestion's operator surfaces stop returning 503. |
+
+As of this change, hosted-panel topology selection
+(`DEPLOY_ADMINISTRATIVE_PANEL=true`) still fails closed at
+`config.deployment.topology`/`composition`
+(`HostedPanelUnsupportedError`); this is now a **deliberate, separate**
+decision distinct from component readiness -- the `gpt-rag-ingestion`
+operator-surface component work this platform contract was blocking on has
+landed (PR #274). Lifting the topology gate and repinning `manifest.json`
+for all changed components together remain their own coordinated follow-up,
+gated on the still-pending live evidence procedures for
+`PANEL_HISTORY_OWNER_BINDING_VALIDATED` and `PANEL_OPERATOR_SURFACES_ENABLED`
+(see ADR-0004's "Adoption and migration" and "Review trigger" sections),
+not on any further GPT-RAG-repository platform-contract change.
 

--- a/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
+++ b/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
@@ -4,14 +4,20 @@
 boundary is merged in gpt-rag-orchestrator **PR #308**, merge
 `a828253b85c6ed7a63f6085c1666f75a9ca2b7d8`; the gpt-rag-ui user-facing
 history/feedback/deletion surfaces are merged in gpt-rag-ui **PR #99**, merge
-`ee3b53b29019e675c1e9ff19ee607cea361e5a8e` (not yet reflected in
+`ee3b53b29019e675c1e9ff19ee607cea361e5a8e`; the gpt-rag-ingestion
+operator-facing overview/corpus-curation surfaces are merged in
+gpt-rag-ingestion **PR #274**, merge
+`5569dd6af3ecb317e1037108cb21859f1b2185a1` (neither is yet reflected in
 `manifest.json`'s pin); the Azure/GPT-RAG platform layer — the versioned
 `contracts/conversations-panel-v1` schema, the panel Cosmos container/RBAC
 composition helpers (`config.deployment.composition.panel_database_containers`,
-`config.panel.setup`), and the App Configuration keys — is implemented as of
-this revision; the gpt-rag-ingestion operator surfaces and the coordinated
-`manifest.json` pin bump that lifts the `DEPLOY_ADMINISTRATIVE_PANEL=true`
-fail-closed gate remain pending as adoption work — see "Adoption and
+`config.panel.setup`), and the App Configuration keys, including the
+ingestion operator-surface keys (`PANEL_OPERATOR_SURFACES_ENABLED`,
+`PANEL_OPERATOR_APP_ROLE`, `PANEL_OPERATOR_GROUP_ID`) — is implemented as of
+this revision; the coordinated `manifest.json` pin bump that would lift the
+`DEPLOY_ADMINISTRATIVE_PANEL=true` fail-closed gate remains pending as
+adoption work, now gated on the still-open evidence-gate procedures below
+rather than on any remaining component implementation — see "Adoption and
 migration")<br>
 **Date:** 2026-08-07<br>
 **Owners:** GPT-RAG maintainer (Paulo), architecture analysis, with gpt-rag-ui,
@@ -742,8 +748,11 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    `PANEL_CONVERSATION_ENUMERATION_MODE`, `PANEL_CONVERSATIONS_TOKEN_AUDIENCE`,
    `PANEL_CONVERSATIONS_TENANT_ID`, `PANEL_OWNER_INDEX_DATABASE_CONTAINER`,
    `PANEL_FEEDBACK_DATABASE_CONTAINER`, `PANEL_CURSOR_TTL_SECONDS`,
-   `PANEL_OVERVIEW_MIN_CARDINALITY`) are published by
-   `config.panel.settings.public_settings`, merged into
+   `PANEL_OVERVIEW_MIN_CARDINALITY`, and — matching the now-merged
+   gpt-rag-ingestion operator surfaces (PR #274) exactly —
+   `PANEL_OPERATOR_SURFACES_ENABLED` (forced `false`),
+   `PANEL_OPERATOR_APP_ROLE` (`""`), `PANEL_OPERATOR_GROUP_ID` (`""`)) are
+   published by `config.panel.settings.public_settings`, merged into
    `compose_parameters`'s `additionalAppConfigurationSettings`. The panel Cosmos
    containers (owner index, feedback — metadata only, `/principal_id`
    partitioned) are composed by
@@ -760,9 +769,12 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    here. **`DEPLOY_ADMINISTRATIVE_PANEL=true` (hosted-panel topology
    selection) still fails closed** at `config.deployment.topology`/
    `composition` (`HostedPanelUnsupportedError`) and `manifest.json` is not
-   repinned in this revision — both remain gated on the still-pending
-   gpt-rag-ingestion operator-surface work below, consistent with "no runtime
-   behavior change yet."
+   repinned in this revision. Unlike the previous revision, this is no longer
+   blocked on remaining `gpt-rag-ingestion` component work — that work has
+   landed (PR #274) — but on the still-open evidence-gate procedures for
+   `PANEL_HISTORY_OWNER_BINDING_VALIDATED` and the newly forced-false
+   `PANEL_OPERATOR_SURFACES_ENABLED` (see "Review trigger" below), consistent
+   with "no runtime behavior change yet."
 2. **gpt-rag-orchestrator** — make the hosted agent/container **stateless**:
    remove any managed-Conversations read/append/persist from the container and
    confirm it consumes only the BFF-supplied complete ordered input. Remove any
@@ -793,6 +805,30 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    replacing the 501 for those surfaces; **no conversation-content access or
    conversation-content curation**; fail-closed 503 when gated off; operator-role
    check plus existing bearer patterns.
+
+   **Status (this revision): done.** Merged in gpt-rag-ingestion **PR #274**,
+   merge `5569dd6af3ecb317e1037108cb21859f1b2185a1`: `GET
+   /panel/overview/metrics` (aggregate `COUNT(1)` Cosmos Data Reader reads
+   over the owner-index/feedback panel containers, suppressed below
+   `PANEL_OVERVIEW_MIN_CARDINALITY`), `GET /panel/corpus-curation/queue`, and
+   `POST /panel/corpus-curation/{item_id}/decision` (decisions persisted to
+   the existing per-file-log blob control store via Blob Storage ETag
+   optimistic concurrency, not Cosmos — this identity's Cosmos grant is
+   Data Reader only). Fails closed (503) unless
+   `DEPLOY_ADMINISTRATIVE_PANEL=true`, `PANEL_OPERATOR_SURFACES_ENABLED=true`,
+   and an explicit `PANEL_OPERATOR_APP_ROLE`/`PANEL_OPERATOR_GROUP_ID` is
+   configured; every endpoint requires a validated delegated operator bearer
+   (app-only tokens always rejected). No new Conversations-data-plane RBAC
+   or Key Vault secret was introduced (cursor signing reuses
+   `DATA_INGEST_APP_APIKEY`). This platform repository now publishes
+   `PANEL_OPERATOR_SURFACES_ENABLED` (forced `false`), `PANEL_OPERATOR_APP_ROLE`,
+   and `PANEL_OPERATOR_GROUP_ID` with matching names and safe defaults (see
+   `contracts/README.md`); the ingestion identity's Cosmos RBAC (Data Reader
+   only, container-scoped, no Conversations role) is asserted structurally by
+   `config.panel.setup`/`tests/test_deployment_modes.py`
+   (`test_dataingest_loses_account_scope_cosmos_role_in_hosted_mode`) and
+   `config/panel/tests/test_setup.py`
+   (`test_frontend_gets_contributor_ingestion_gets_reader`).
 5. Revalidate in Basic and network-isolated topologies; run the two-user negative
    suite, the direct-caller anti-spoof test, the **capability
    theft/expiry/rotation** test, and (once each ADR's own gate is met)

--- a/tests/test_deployment_modes.py
+++ b/tests/test_deployment_modes.py
@@ -574,6 +574,32 @@ class PanelPlatformContractTests(unittest.TestCase):
 
         self.assertNotIn("CosmosDBBuiltInDataContributor", dataingest["roles"])
 
+    def test_dataingest_keeps_existing_blob_role_for_corpus_curation(self) -> None:
+        # gpt-rag-ingestion's corpus-curation decisions (PR #274) are written
+        # to the existing per-file-log blob control store this identity
+        # already owns, via Blob Storage ETag optimistic concurrency -- never
+        # Cosmos. This asserts that identity's existing blob RBAC (already
+        # sufficient for the classic Files tab's blocked/unblock flow) is
+        # untouched by the hosted-mode Cosmos-role stripping above.
+        # (Hosted-panel itself still fails closed -- see
+        # test_hosted_with_panel_fails_closed_until_611 -- so only
+        # hosted-no-panel is reachable through compose_parameters today; the
+        # role list dataingest would carry under hosted-panel is unaffected
+        # by this stripping code path either way, since it only ever removes
+        # CosmosDBBuiltInDataContributor.)
+        environment = {
+            "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
+            "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+            "HOSTED_AGENT_IMAGE_VERSION": DIGEST,
+            "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
+        }
+
+        composed = compose_parameters(source_parameters(), environment)
+        apps = composed["parameters"]["containerAppsList"]["value"]
+        dataingest = next(app for app in apps if app["service_name"] == "dataingest")
+
+        self.assertIn("StorageBlobDataContributor", dataingest["roles"])
+
     def test_panel_app_configuration_defaults_are_published_and_safe(self) -> None:
         environment = {
             "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "false",
@@ -596,6 +622,11 @@ class PanelPlatformContractTests(unittest.TestCase):
         )
         self.assertEqual(settings["PANEL_CURSOR_TTL_SECONDS"], "600")
         self.assertEqual(settings["PANEL_OVERVIEW_MIN_CARDINALITY"], "5")
+        # gpt-rag-ingestion operator surfaces (PR #274, merge 5569dd6):
+        # exact key names, safe defaults, feature never set true here.
+        self.assertEqual(settings["PANEL_OPERATOR_SURFACES_ENABLED"], "false")
+        self.assertEqual(settings["PANEL_OPERATOR_APP_ROLE"], "")
+        self.assertEqual(settings["PANEL_OPERATOR_GROUP_ID"], "")
 
     def test_panel_owner_binding_validated_gate_cannot_be_set_via_environment(
         self,
@@ -610,6 +641,28 @@ class PanelPlatformContractTests(unittest.TestCase):
         settings = settings_by_name(composed)
 
         self.assertEqual(settings["PANEL_HISTORY_OWNER_BINDING_VALIDATED"], "false")
+
+    def test_panel_operator_surfaces_enabled_gate_cannot_be_set_via_environment(
+        self,
+    ) -> None:
+        environment = {
+            "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "false",
+            "DEPLOY_ADMINISTRATIVE_PANEL": "false",
+            "PANEL_OPERATOR_SURFACES_ENABLED": "true",
+            "PANEL_OPERATOR_APP_ROLE": "PanelOperator",
+            "PANEL_OPERATOR_GROUP_ID": "11111111-1111-1111-1111-111111111111",
+        }
+
+        composed = compose_parameters(source_parameters(), environment)
+        settings = settings_by_name(composed)
+
+        self.assertEqual(settings["PANEL_OPERATOR_SURFACES_ENABLED"], "false")
+        # Role/group are plain operator inputs -- pass through unmodified.
+        self.assertEqual(settings["PANEL_OPERATOR_APP_ROLE"], "PanelOperator")
+        self.assertEqual(
+            settings["PANEL_OPERATOR_GROUP_ID"],
+            "11111111-1111-1111-1111-111111111111",
+        )
 
     def test_no_panel_containers_or_settings_leak_into_classic_composition(
         self,


### PR DESCRIPTION
## Summary

Reconciles the umbrella hosted-panel platform contract
([PR #637](https://github.com/Azure/GPT-RAG/pull/637), merge `3db57ded`)
with the now-merged `gpt-rag-ingestion` operator-facing panel surfaces
([PR #274](https://github.com/Azure/gpt-rag-ingestion/pull/274), merge
`5569dd6af3ecb317e1037108cb21859f1b2185a1`), per issue #611 / ADR-0004.

Inspected the exact ingestion-side `config.get(...)` reads at commit
`5569dd6` (`api/panel_operator.py`, `dependencies.py`) and the merged
`gpt-rag-ui` `panel_config.py` (PR #99, `ee3b53b`) to confirm which App
Configuration keys (label `gpt-rag`) each consumer actually reads.

## What changed

- **`config/panel/settings.py`** — added the three operator-surface keys
  ingestion actually consumes, safe defaults, no feature ever set true:
  - `PANEL_OPERATOR_SURFACES_ENABLED` — forced `"false"` (mirrors
    `PANEL_HISTORY_OWNER_BINDING_VALIDATED`'s no-evidence-gate-yet pattern).
  - `PANEL_OPERATOR_APP_ROLE` / `PANEL_OPERATOR_GROUP_ID` — `""` (plain
    operator inputs, safely overridable, like
    `PANEL_CONVERSATIONS_TOKEN_AUDIENCE`).
  - `DEPLOY_ADMINISTRATIVE_PANEL` already reflects resolved topology only
    (unchanged); `PANEL_OWNER_INDEX_DATABASE_CONTAINER`,
    `PANEL_FEEDBACK_DATABASE_CONTAINER`, `PANEL_CURSOR_TTL_SECONDS`
    (`600`), `PANEL_OVERVIEW_MIN_CARDINALITY` (`5`) were already published
    with matching defaults — no change needed.
  - `DATABASE_ACCOUNT_NAME`/`DATABASE_NAME`/`STORAGE_ACCOUNT_NAME` and the
    reserved per-app `DATA_INGEST_APP_APIKEY` Key Vault reference are
    already published unconditionally by the AI Landing Zone submodule —
    not duplicated here.
- **`config/panel/tests/test_operator_contract.py`** (new) — an explicit,
  reviewed expected-key-set fixture (sourced directly from the two merge
  commits) guarding against future drift between this repository's
  published defaults and what `gpt-rag-ingestion`/`gpt-rag-ui` actually
  consume.
- **`tests/test_deployment_modes.py`** / **`config/panel/tests/test_settings.py`**
  — extended existing coverage for the new keys' safe defaults and
  forced-false override, plus a new
  `test_dataingest_keeps_existing_blob_role_for_corpus_curation` confirming
  ingestion's existing `StorageBlobDataContributor` role (unchanged) stays
  sufficient for corpus-curation decisions.
- **`contracts/README.md`** / **`docs/adr/ADR-0004-hosted-panel-conversations-contract.md`**
  — updated the App Configuration key table and adoption status to reflect
  PR #274 landing; the `DEPLOY_ADMINISTRATIVE_PANEL=true` topology gate
  (`HostedPanelUnsupportedError`) remains fail-closed as a **deliberate,
  separate** decision (not component-readiness-blocked anymore), pending
  its own live evidence-gate procedures — not touched by this PR.
- **`CHANGELOG.md`** — new `[Unreleased]` entry.

## Confirmed by inspection (no code change needed — already correct)

- `config.panel.setup` grants `gpt-rag-ingestion` only **container-scoped
  Cosmos Data Reader** on the two panel metadata containers (owner-index,
  feedback) — never a Conversations role, never account-scope.
- The hosted agent/container identity is **never** resolved or granted any
  role by `config.panel.setup` (`FRONTEND_APP_SERVICE_NAME`/
  `DATA_INGEST_APP_SERVICE_NAME` only).
- `dataingest`'s existing `StorageBlobDataContributor` role (unchanged,
  `main.parameters.json`) is sufficient for the corpus-curation decisions
  ingestion PR #274 writes to its existing per-file-log blob control store
  (Blob ETag optimistic concurrency, never Cosmos) — no new secret or role.
- Ingestion's own merged code already fails closed (503) whenever
  `DEPLOY_ADMINISTRATIVE_PANEL`, `PANEL_OPERATOR_SURFACES_ENABLED`, or an
  operator role/group is absent/false — this PR's safe defaults guarantee
  that's the out-of-the-box state for every freshly provisioned
  environment.
- `contracts/conversations-panel-v1.schema.json` is byte-identical between
  this repository and the vendored copy at ingestion commit `5569dd6`
  (matching `.sha256`) — no schema divergence, no schema/checksum update
  needed.

## No manifest/pins/release

No `manifest.json` pin bump and no release in this change, per instructions.
The hosted-panel topology gate remains closed; this is purely the
App-Configuration-key reconciliation layer.

## Tests

Full existing suite + new tests: **344 passed** (was 337), 113 subtests.

```
python -m pytest -q
344 passed, 113 subtests passed
```

## Residual risks

- `PANEL_OPERATOR_SURFACES_ENABLED`/`PANEL_HISTORY_OWNER_BINDING_VALIDATED`
  remain forced `false` pending a dedicated live-evidence verification
  procedure for each call path (ADR-0004 "Review trigger"); flipping either
  is explicitly out of scope here.
- Lifting `HostedPanelUnsupportedError` and the coordinated `manifest.json`
  pin bump for all changed components remain their own future, separate
  change.