### PR TITLE
feat: integrate hosted-agent release matrix; fix HTTP 424 readiness blocker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "infra"]
 	path = infra
 	url = https://github.com/Azure/bicep-ptn-aiml-landing-zone.git
-	branch = develop
+	branch = v2.5.0
 	ignore = dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,10 @@
   console and resolve their immutable output digest from the management-plane
   ACR run record, so digest materialization does not require public registry
   data-plane access.
+- **Foundry IQ ingestion honors the Search managed-identity mode.**
+  Blob knowledge sources now bind the Search service's configured
+  user-assigned identity instead of implicitly selecting a nonexistent system
+  identity in UAI-based deployments.
 - **Regional prerequisite checks resolve Azure CLI on Windows.**
   `util.prereqs` now uses the same explicit Azure CLI executable resolution as
   deployment configuration, so the `az.cmd` shim no longer fails with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,9 @@
   agent/container identity is never resolved or granted any role. The panel's
   pagination cursor reuses the UI's existing `CHAINLIT_AUTH_SECRET`
   (already Key-Vault-backed); no new secret or Key Vault RBAC was introduced.
-  `DEPLOY_ADMINISTRATIVE_PANEL=true` (hosted-panel topology selection) still
-  fails closed pending the remaining gpt-rag-ingestion operator-surface work;
-  this change is the platform-layer prerequisite, with no other runtime
-  behavior change.
+  This platform-layer prerequisite remained inert until the coordinated
+  integration matrix below lifted the topology block; the independent
+  history and operator evidence gates remain disabled by default.
 - **Hosted panel operator-surface App Configuration keys (issue #611,
   ADR-0004, reconciling gpt-rag-ingestion PR #274, merge
   `5569dd6af3ecb317e1037108cb21859f1b2185a1`).** Added
@@ -53,17 +52,15 @@
   explicit expected-key-set fixture guarding against future drift between
   this repository's published defaults and what `gpt-rag-ingestion` (PR #274)
   and `gpt-rag-ui` (PR #99) actually consume. Updated ADR-0004's adoption
-  status: the ingestion operator-surface component work is now done: the
-  `DEPLOY_ADMINISTRATIVE_PANEL=true` topology gate remains fail-closed
-  (`HostedPanelUnsupportedError`) as a deliberate, separate decision gated on
-  the still-open live evidence-gate procedures, not on any remaining
-  component implementation. No manifest/pin or release change in this
-  revision.
+  status: the ingestion operator-surface component work is now done. The
+  coordinated matrix below lifts only the explicit hosted-panel topology
+  block; the separate live evidence and authorization gates remain fail
+  closed.
 - **Deterministic deployment topologies.** Classic, hosted/no-panel, and
-  hosted/panel remain recognized topology values, but only classic and
-  hosted/no-panel are currently deployable. `DEPLOY_ADMINISTRATIVE_PANEL`
-  defaults to `false`, and any signal that would select
-  hosted-panel mode fails closed until [issue #611](https://github.com/Azure/gpt-rag/issues/611) lands.
+  hosted/panel are deployable topology values. Hosted-panel requires explicit
+  operator selection; `DEPLOY_ADMINISTRATIVE_PANEL` defaults to `false`.
+  Panel history and operator routes remain independently fail closed behind
+  their disabled-by-default evidence and authorization gates.
 - **Hosted-no-panel is now the fresh-deployment default (ADR-0001 revision
   5).** A genuinely new environment (no existing resource group) provisions
   `hosted-no-panel` with `CHAT_BACKEND=hosted_agent` and no orchestrator
@@ -88,9 +85,13 @@
   a later explicit provision.
 - **Shared, deterministic topology resolver.** `config/deployment/topology.py`
   centralizes the fresh-vs-existing/sticky/conflict decision (resource-group
-  existence plus persisted App Configuration settings, when reachable) behind
-  a single pure function (`config.deployment.composition.resolve_topology`)
-  and a small CLI/integration wrapper, so `scripts/preProvision.ps1` and
+  existence and contents plus persisted App Configuration settings, when
+  reachable) behind a single pure function
+  (`config.deployment.composition.resolve_topology`) and a small
+  CLI/integration wrapper. An empty resource group pre-created by azd is
+  treated as fresh, so an unrelated process-level App Configuration endpoint
+  cannot influence first provision; groups with deployed resources retain
+  fail-closed persisted-state checks. `scripts/preProvision.ps1` and
   `scripts/preProvision.sh` resolve and materialize the same
   `DEPLOYMENT_TOPOLOGY` (and paired legacy flags/`CHAT_BACKEND`) into the azd
   environment before any later hook or Bicep composition runs.
@@ -124,6 +125,21 @@
 
 ### Changed
 
+- **Hosted administrative panel integration matrix (issue #611).** Explicit
+  hosted-panel topology selection is now composed with UI `v2.6.0`
+  (`81d6515d8fc365402e958e861b671af037a4cc75`), orchestrator `v4.0.0`
+  (`1033d0690736f9787e5f227559dc4071d2043b79`), ingestion `v2.7.0`
+  (`84b927769ef0839110f2d68e3ca471e2260567cf`), and AI Landing Zone
+  `v2.5.0` (`cacf418216ce7381d06263e0dd704a86b8a6f225`). The hosted
+  container remains stateless with zero Conversations RBAC; hosted-panel
+  provisions only the metadata-only owner-index and feedback containers.
+  `PANEL_HISTORY_ENABLED`, `PANEL_HISTORY_OWNER_BINDING_VALIDATED`, and
+  `PANEL_OPERATOR_SURFACES_ENABLED` remain deployment-published `false`, so
+  all user-history and operator surfaces stay fail closed until their
+  independent evidence and authorization gates are explicitly completed.
+  The released ingestion browser/operator path validates delegated bearer
+  tokens, rejects app-only identities, and requires exact configured app-role
+  or group membership.
 - **Hosted continuity ownership is delegated and fail closed.** The trusted UI
   BFF now derives `x-ms-user-identity` from the authenticated server-side
   principal, independently of OBO retrieval tokens. Continuity activates only
@@ -133,13 +149,9 @@
   ownership key. The HMAC capability contract remains an explicit disabled
   fallback and delegated mode provisions no capability secret, vault role, or
   App Configuration reference.
-- **Compatible hosted/no-panel component pins.** The unreleased integration
-  combination preserves UI `v2.5.1`, orchestrator `v3.10.0`, and ingestion
-  `v2.6.0` at their exact released commits. It temporarily pins AI Landing Zone
-  `develop` commit `1775f871641311868a15792bf3dc836024c9fb20`, which contains
-  the merged PR #130 additive `prepareHostedAgent` contract. Final release
-  preparation must replace this interim source pin with the new minor release
-  tag and matching commit.
+- **Released AI Landing Zone pin.** The temporary AI Landing Zone `develop`
+  source pin is replaced by released tag `v2.5.0` at exact commit
+  `cacf418216ce7381d06263e0dd704a86b8a6f225`.
 
 ### Fixed
 
@@ -157,7 +169,12 @@
   hook now exports the equivalent repository-root import path.
 - **Hosted-image builds resolve the Azure CLI launcher on Windows.**
   The ACR Tasks helper resolves both `az` and the Windows `az.cmd` shim before
-  calling `subprocess.run`, and fails clearly when Azure CLI is unavailable.
+  calling `subprocess.run`, uses an absolute Dockerfile path for temporary
+  pinned-source contexts, and fails clearly when Azure CLI is unavailable.
+  Private builds queue without streaming Unicode logs through the Windows
+  console and resolve their immutable output digest from the management-plane
+  ACR run record, so digest materialization does not require public registry
+  data-plane access.
 - **Regional prerequisite checks resolve Azure CLI on Windows.**
   `util.prereqs` now uses the same explicit Azure CLI executable resolution as
   deployment configuration, so the `az.cmd` shim no longer fails with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,8 +127,8 @@
 
 - **Hosted administrative panel integration matrix (issue #611).** Explicit
   hosted-panel topology selection is now composed with UI `v2.6.0`
-  (`81d6515d8fc365402e958e861b671af037a4cc75`), orchestrator `v4.0.0`
-  (`1033d0690736f9787e5f227559dc4071d2043b79`), ingestion `v2.7.0`
+  (`81d6515d8fc365402e958e861b671af037a4cc75`), orchestrator `v4.0.1`
+  (`7e22840ba0e96a5ce237cf2657795768f88e3955`), ingestion `v2.7.0`
   (`84b927769ef0839110f2d68e3ca471e2260567cf`), and AI Landing Zone
   `v2.5.0` (`cacf418216ce7381d06263e0dd704a86b8a6f225`). The hosted
   container remains stateless with zero Conversations RBAC; hosted-panel
@@ -190,6 +190,33 @@
   test now verifies the preserved `v3.7.0` component combination in
   `config/deployment/rollback.json` instead of incorrectly requiring the live
   unreleased manifest to remain frozen on the prior release.
+- **Root-caused and fixed the hosted-agent session-readiness HTTP 424
+  blocker (issue #576).** The previous integration attempt's network-isolated
+  live validation reached agent-version `active` state but every session
+  invoke returned HTTP 424 `session_not_ready`. Root-caused to a circular
+  import in `gpt-rag-orchestrator`: `src/api/hosted_entrypoint.py` imports
+  `dependencies` first (it is intentionally Cosmos-free and never "warms up"
+  `connectors` first, unlike the classic `main.py` entrypoint); `dependencies.py`
+  eagerly imported `connectors.appconfig` at module level, and
+  `connectors/__init__.py` eagerly imports several submodules
+  (`cosmosdb`, `search`, `aifoundry`) that each import `dependencies` back at
+  *their* module level — an import-time cycle that crashed the container's
+  Python process before uvicorn could ever bind a port or serve
+  `GET /readiness`, exactly matching Microsoft Foundry's documented
+  `424 session_not_ready` failure mode ("container started but `/readiness`
+  didn't return HTTP 200 within the timeout"). Reproduced deterministically
+  with a fresh-interpreter import test mirroring the container's startup
+  command (no live Azure deployment required to diagnose or confirm the fix).
+  Fixed upstream in
+  [gpt-rag-orchestrator PR #311](https://github.com/Azure/gpt-rag-orchestrator/pull/311)
+  by deferring `AppConfigClient` construction into `get_config()`, released as
+  [`v4.0.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.1)
+  (patch, no behavior change beyond the import fix; 720 tests passing). The
+  umbrella pin above is bumped to `v4.0.1` accordingly. **This fixes the
+  specific crash that produced the HTTP 424 symptom; it does not by itself
+  constitute the network-isolated live validation this integration still
+  requires** — see the "Migration and rollback" note below for the current
+  validation status.
 
 ### Migration and rollback
 

--- a/config/continuity/setup.py
+++ b/config/continuity/setup.py
@@ -1306,8 +1306,17 @@ def reconcile_disabled_continuity(
             "identity.principalId",
             "--output",
             "tsv",
-        ]
+        ],
+        required=False,
     )
+    if not frontend_principal_id:
+        if capability_reference is not None:
+            raise RuntimeError(
+                "The frontend managed identity is unavailable while a hosted "
+                "conversation capability reference still exists; refusing "
+                "incomplete continuity cleanup."
+            )
+        return
     assignments = _all_direct_role_assignments(frontend_principal_id)
 
     project_resource_id = (

--- a/config/continuity/tests/test_setup.py
+++ b/config/continuity/tests/test_setup.py
@@ -18,6 +18,51 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class ContinuitySetupTests(TestCase):
+    @patch.object(setup, "get_configuration_setting_or_none", return_value=None)
+    @patch.object(setup, "_run_az", return_value="")
+    def test_disabled_continuity_allows_fresh_frontend_without_identity(
+        self,
+        run_az,
+        get_setting,
+    ):
+        setup.reconcile_disabled_continuity(
+            Mock(),
+            {
+                "AZURE_RESOURCE_GROUP": "rg",
+                "FRONTEND_APP_NAME": "frontend",
+            },
+        )
+
+        run_az.assert_called_once()
+        self.assertFalse(run_az.call_args.kwargs["required"])
+        get_setting.assert_called_once()
+
+    @patch.object(
+        setup,
+        "get_configuration_setting_or_none",
+        return_value=SimpleNamespace(value="reference"),
+    )
+    @patch.object(setup, "_run_az", return_value="")
+    def test_disabled_continuity_fails_closed_without_identity_when_capability_exists(
+        self,
+        run_az,
+        get_setting,
+    ):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "capability reference still exists",
+        ):
+            setup.reconcile_disabled_continuity(
+                Mock(),
+                {
+                    "AZURE_RESOURCE_GROUP": "rg",
+                    "FRONTEND_APP_NAME": "frontend",
+                },
+            )
+
+        run_az.assert_called_once()
+        get_setting.assert_called_once()
+
     def test_safe_defaults_disable_continuity_and_prefer_delegation(self):
         values = dict(setup.DEFAULT_SETTINGS)
 

--- a/config/deployment/composition.py
+++ b/config/deployment/composition.py
@@ -52,16 +52,6 @@ class DeploymentTopologyError(ValueError):
     """
 
 
-class HostedPanelUnsupportedError(DeploymentTopologyError):
-    """Raised when a signal would select hosted-panel mode.
-
-    The administrative-panel data plane is not implemented yet; it is
-    tracked by https://github.com/Azure/gpt-rag/issues/611. Until that lands,
-    any request that would actually select hosted-panel mode must fail
-    closed rather than silently downgrading to hosted-no-panel or classic.
-    """
-
-
 class ConflictingTopologySignalsError(DeploymentTopologyError):
     """Raised when explicit or persisted topology signals disagree.
 
@@ -178,9 +168,8 @@ def _explicit_flag_topology(
     the legacy explicit ``DEPLOY_HOSTED_AGENT_ORCHESTRATION=false`` flag as a
     compatible way to select the classic Container Apps topology.
 
-    A panel flag is only subject to the #611 hard-failure gate when it would
-    actually select hosted-panel mode (``hosted=true and panel=true``); a
-    stray/incidental panel flag alongside ``hosted=false`` is ignored and the
+    A panel flag selects hosted-panel only when hosted orchestration is also
+    enabled. A stray panel flag alongside ``hosted=false`` is ignored and the
     result stays classic, matching pre-ADR-0001 behavior.
     """
     hosted_raw = environment.get("DEPLOY_HOSTED_AGENT_ORCHESTRATION")
@@ -192,13 +181,7 @@ def _explicit_flag_topology(
     if not hosted:
         return DeploymentMode.CLASSIC
     if panel:
-        raise HostedPanelUnsupportedError(
-            "DEPLOY_ADMINISTRATIVE_PANEL=true (hosted-panel) is not "
-            "supported yet; the administrative-panel data plane is tracked "
-            "by https://github.com/Azure/gpt-rag/issues/611. Deploy with "
-            "DEPLOY_ADMINISTRATIVE_PANEL=false (or unset) to use "
-            "hosted-no-panel."
-        )
+        return DeploymentMode.HOSTED_PANEL
     return DeploymentMode.HOSTED_NO_PANEL
 
 
@@ -209,14 +192,6 @@ def _explicit_topology_value(
     raw = (environment.get("DEPLOYMENT_TOPOLOGY") or "").strip().lower()
     if not raw:
         return None
-    if raw == DeploymentMode.HOSTED_PANEL.value:
-        raise HostedPanelUnsupportedError(
-            "DEPLOYMENT_TOPOLOGY=hosted-panel is not supported yet; the "
-            "administrative-panel data plane is tracked by "
-            "https://github.com/Azure/gpt-rag/issues/611. Use "
-            "DEPLOYMENT_TOPOLOGY=hosted-no-panel or DEPLOYMENT_TOPOLOGY="
-            "classic instead."
-        )
     if raw not in _KNOWN_TOPOLOGY_VALUES:
         raise DeploymentTopologyError(
             f"Unknown DEPLOYMENT_TOPOLOGY={raw!r}; expected one of: "
@@ -342,7 +317,19 @@ def resolve_topology(
                 f"{backend_raw!r}. Set an explicit DEPLOYMENT_TOPOLOGY after "
                 "reviewing the ADR-0001 migration procedure."
             )
-    if persisted is not None and backend_mode is not None and persisted is not backend_mode:
+    persisted_backend = (
+        "orchestrator"
+        if persisted is DeploymentMode.CLASSIC
+        else "hosted_agent"
+        if persisted is not None
+        else None
+    )
+    if (
+        persisted_backend is not None
+        and backend_mode is not None
+        and persisted_backend
+        != ("orchestrator" if backend_mode is DeploymentMode.CLASSIC else "hosted_agent")
+    ):
         raise ConflictingTopologySignalsError(
             "The existing deployment has conflicting persisted topology and "
             "CHAT_BACKEND settings in App Configuration. Resolve the conflict "
@@ -435,9 +422,7 @@ def resolve_database_containers(
     A small, directly-testable pure function (mirrors ``describe_mode``/
     ``materialized_settings`` in this module, which also take ``mode`` as a
     plain argument) so the panel/no-panel container-list contract can be unit
-    tested without needing ``resolve_mode`` to accept a hosted-panel
-    environment signal, which still fails closed pending the remaining
-    https://github.com/Azure/gpt-rag/issues/611 component work.
+    tested directly.
 
     - Classic (or a migrating hosted deployment still preserving the classic
       runtime): the static classic list is unchanged.

--- a/config/deployment/hosted_image.py
+++ b/config/deployment/hosted_image.py
@@ -26,11 +26,13 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 from util.azure_cli import resolve_az_command
@@ -42,6 +44,8 @@ HOSTED_PORT_DEFAULT = 8088
 BASE_IMAGE_NAME_DEFAULT = "azure-gpt-rag/orchestrator"
 DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 COMMIT_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
+ACR_BUILD_TIMEOUT_SECONDS = 8 * 60 * 60
+ACR_BUILD_POLL_SECONDS = 5
 
 
 def resolve_azure_cli_executable() -> str:
@@ -120,12 +124,94 @@ def build_acr_build_args(
     return args
 
 
+def run_acr_build_and_wait(
+    args: list[str],
+    *,
+    registry: str,
+    image_name: str,
+    image_tag: str,
+    azure_cli: str = "az",
+    poll_interval: float = ACR_BUILD_POLL_SECONDS,
+    timeout: float = ACR_BUILD_TIMEOUT_SECONDS,
+) -> str:
+    """Queue an ACR build and resolve its digest through management-plane state."""
+    environment = os.environ.copy()
+    environment.setdefault("PYTHONUTF8", "1")
+    environment.setdefault("PYTHONIOENCODING", "utf-8")
+    queued = subprocess.run(
+        [*args, "--no-logs", "--output", "json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    try:
+        run_id = str(json.loads(queued.stdout).get("runId") or "").strip()
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("ACR build did not return valid run metadata.") from exc
+    if not run_id:
+        raise RuntimeError("ACR build did not return a run ID.")
+
+    deadline = time.monotonic() + timeout
+    terminal_failures = {"Canceled", "Cancelled", "Error", "Failed", "Timeout"}
+    while True:
+        result = subprocess.run(
+            [
+                _resolved_azure_cli(azure_cli),
+                "acr",
+                "task",
+                "show-run",
+                "--registry",
+                registry,
+                "--run-id",
+                run_id,
+                "--output",
+                "json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        try:
+            run = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"ACR build run {run_id!r} returned invalid metadata."
+            ) from exc
+
+        status = str(run.get("status") or "").strip()
+        if status == "Succeeded":
+            for image in run.get("outputImages") or []:
+                if (
+                    image.get("repository") == image_name
+                    and image.get("tag") == image_tag
+                ):
+                    return validate_digest(
+                        str(image.get("digest") or ""),
+                        name="ACR build output digest",
+                    )
+            raise RuntimeError(
+                f"ACR build run {run_id!r} succeeded without the expected "
+                f"image {image_name}:{image_tag}."
+            )
+        if status in terminal_failures:
+            detail = run.get("error") or run.get("statusMessage") or status
+            raise RuntimeError(
+                f"ACR build run {run_id!r} ended with {status}: {detail}"
+            )
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"Timed out waiting for ACR build run {run_id!r} after "
+                f"{timeout:g} seconds."
+            )
+        time.sleep(poll_interval)
+
+
 def parse_digest_from_build_output(output: str) -> str | None:
     """Best-effort extraction of the pushed manifest digest from ``az acr
-    build`` text output (used when ``--query``/JSON parsing of the run isn't
-    available; callers should prefer looking up the digest via
-    ``az acr repository show-manifests`` after a successful build, which is
-    what the CLI entrypoint below does)."""
+    build`` text output. The managed build path uses the ACR management-plane
+    run record instead so it also works with private registry data planes."""
     match = re.search(r"sha256:[0-9a-fA-F]{64}", output)
     return match.group(0) if match else None
 
@@ -269,14 +355,14 @@ def build_source_image(
         registry=registry,
         image_name=image_name,
         image_tag=image_tag,
-        dockerfile_path="Dockerfile",
+        dockerfile_path=str(dockerfile_path),
         context_dir=str(source_dir),
         agent_pool=agent_pool,
         azure_cli=azure_cli,
     )
     args[0] = _resolved_azure_cli(azure_cli)
-    subprocess.run(args, check=True, stdout=sys.stderr)
-    return resolve_pushed_digest(
+    return run_acr_build_and_wait(
+        args,
         registry=registry,
         image_name=image_name,
         image_tag=image_tag,
@@ -381,13 +467,13 @@ def build_hosted_image(
             azure_cli=azure_cli,
         )
         args[0] = _resolved_azure_cli(azure_cli)
-        subprocess.run(args, check=True, stdout=sys.stderr)
-    return resolve_pushed_digest(
-        registry=registry,
-        image_name=image_name,
-        image_tag=image_tag,
-        azure_cli=azure_cli,
-    )
+        return run_acr_build_and_wait(
+            args,
+            registry=registry,
+            image_name=image_name,
+            image_tag=image_tag,
+            azure_cli=azure_cli,
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/config/deployment/topology.py
+++ b/config/deployment/topology.py
@@ -126,9 +126,9 @@ def resource_group_exists(
 ) -> bool:
     """Return ``True`` only when ``name`` is non-empty and Azure confirms it exists.
 
-    A genuinely fresh azd environment has no resource-group name at all yet
-    (Bicep has not run), so this short-circuits to ``False`` without any
-    Azure CLI call in that case.
+    A fresh azd environment may already have an empty resource group because
+    azd creates it before running preprovision. Call
+    ``resource_group_has_resources`` when that distinction matters.
     """
     name = (name or "").strip()
     if not name:
@@ -149,6 +149,36 @@ def resource_group_exists(
             f"{stdout!r}."
         )
     return normalized == "true"
+
+
+def resource_group_has_resources(
+    name: str | None,
+    subscription_id: str | None = None,
+) -> bool:
+    """Return whether an existing resource group contains deployed resources."""
+    name = (name or "").strip()
+    if not name:
+        return False
+    arguments = [
+        "resource",
+        "list",
+        "--resource-group",
+        name,
+        "--query",
+        "[0].id",
+        "--output",
+        "tsv",
+    ]
+    if (subscription_id or "").strip():
+        arguments.extend(["--subscription", subscription_id.strip()])
+    returncode, stdout, stderr = _run_az(arguments)
+    if returncode != 0:
+        raise DeploymentTopologyError(
+            "Unable to determine whether the Azure resource group contains "
+            f"resources; topology selection cannot safely continue: "
+            f"{stderr or stdout}"
+        )
+    return bool(stdout.strip())
 
 
 def read_persisted_settings(endpoint: str | None) -> dict[str, str]:
@@ -226,9 +256,9 @@ def resolve_environment_plan(
 ) -> TopologyResolution:
     """I/O-aware wrapper around ``resolve_topology`` for use at preProvision time.
 
-    Detects whether the environment is fresh (no resource group yet) or
-    existing, reads any persisted topology markers for existing
-    environments, and delegates the actual decision to the pure
+    Detects whether the environment is fresh (no resource group or an empty
+    group pre-created by azd) or existing, reads any persisted topology markers
+    for existing environments, and delegates the actual decision to the pure
     ``resolve_topology`` function. Explicit classic remains a direct rollback.
     Explicit hosted additionally classifies the current deployed runtime so a
     classic-to-hosted migration can retain classic during its prepare-only
@@ -243,6 +273,18 @@ def resolve_environment_plan(
         (environment.get(key) or "").strip()
         for key in _LOCAL_RUNTIME_MARKERS
     )
+    if (
+        explicit is not None
+        and rg_exists
+        and not has_local_runtime_marker
+        and not resource_group_has_resources(
+            resource_group_name, subscription_id
+        )
+    ):
+        # azd creates the target resource group before running preprovision.
+        # An empty group is therefore still a fresh environment and must not
+        # inherit an unrelated process-level App Configuration endpoint.
+        return TopologyResolution(explicit)
     if explicit is None and rg_exists and not has_local_runtime_marker:
         # ADR-0001 defines an existing environment without any local topology
         # marker as pre-cutover classic. In particular, do not require a

--- a/config/panel/settings.py
+++ b/config/panel/settings.py
@@ -86,11 +86,8 @@ def public_settings(environment: Mapping[str, str]) -> dict[str, str]:
     flag fail closed regardless of what an operator may have set locally.
 
     While ``DEPLOY_ADMINISTRATIVE_PANEL``/``PANEL_HISTORY_ENABLED`` are
-    ``false`` (today's default and only supported state -- hosted-panel
-    topology selection itself still fails closed pending
-    https://github.com/Azure/gpt-rag/issues/611's remaining component work),
-    every value here stays at its safe default and no Cosmos container or
-    RBAC assignment is provisioned (see
+    ``false`` (the safe defaults), every value here stays inert and no panel
+    Cosmos container or RBAC assignment is provisioned (see
     ``config.deployment.composition.panel_database_containers`` and
     ``config.panel.setup``).
     """

--- a/config/panel/setup.py
+++ b/config/panel/setup.py
@@ -190,15 +190,45 @@ def resolve_container_app_principal_id(resource_group: str, app_name: str) -> st
             "identity.principalId",
             "--output",
             "tsv",
-        ]
+        ],
+        required=False,
     )
     principal_id = output.strip()
-    if not principal_id or principal_id.lower() == "none":
+    if principal_id and principal_id.lower() != "none":
+        return principal_id
+
+    identities_json = _run_az(
+        [
+            "containerapp",
+            "show",
+            "--resource-group",
+            resource_group,
+            "--name",
+            app_name,
+            "--query",
+            "identity.userAssignedIdentities",
+            "--output",
+            "json",
+        ]
+    )
+    try:
+        identities = json.loads(identities_json)
+    except json.JSONDecodeError as exc:
         raise PanelRbacError(
-            f"Container app {app_name!r} has no principal ID; cannot assign "
-            "panel Cosmos RBAC without a resolvable managed identity."
+            f"Container app {app_name!r} returned malformed managed identities."
+        ) from exc
+    principal_ids = {
+        str(identity.get("principalId") or "").strip()
+        for identity in identities.values()
+        if isinstance(identity, Mapping)
+    }
+    principal_ids.discard("")
+    if len(principal_ids) != 1:
+        raise PanelRbacError(
+            f"Container app {app_name!r} must expose exactly one managed-identity "
+            "principal for panel Cosmos RBAC."
         )
-    return principal_id
+    return principal_ids.pop()
 
 
 def existing_cosmos_sql_role_assignment(

--- a/config/panel/setup.py
+++ b/config/panel/setup.py
@@ -42,11 +42,8 @@ Reversible: deleting the two container-scoped assignments (or simply setting
 calls this script) fully revokes panel Cosmos access without touching any
 other container, account, or identity.
 
-No-op unless ``DEPLOY_ADMINISTRATIVE_PANEL`` is ``true`` -- which, as of this
-change, cannot yet be reached through normal topology resolution (hosted-panel
-topology selection still fails closed pending the remaining
-https://github.com/Azure/gpt-rag/issues/611 component work in
-gpt-rag-ingestion). This script exists so the platform contract -- the exact,
+No-op unless ``DEPLOY_ADMINISTRATIVE_PANEL`` is ``true``. This script implements
+the platform contract -- the exact,
 reviewed, narrow-scope RBAC shape -- is ready the moment that gate lifts.
 """
 

--- a/config/panel/tests/test_setup.py
+++ b/config/panel/tests/test_setup.py
@@ -80,6 +80,49 @@ class ScopePathTests(unittest.TestCase):
 
 
 class ConfigurePanelRbacTests(unittest.TestCase):
+    def test_resolves_single_user_assigned_container_app_identity(self) -> None:
+        identity = {
+            "/subscriptions/sub/resourceGroups/rg/providers/"
+            "Microsoft.ManagedIdentity/userAssignedIdentities/frontend": {
+                "clientId": "client",
+                "principalId": "frontend-principal",
+            }
+        }
+        with patch.object(
+            setup,
+            "_run_az",
+            side_effect=["", json.dumps(identity)],
+        ) as run_az:
+            principal_id = setup.resolve_container_app_principal_id(
+                "rg",
+                "frontend",
+            )
+
+        self.assertEqual(principal_id, "frontend-principal")
+        self.assertFalse(run_az.call_args_list[0].kwargs["required"])
+        self.assertEqual(
+            run_az.call_args_list[1].args[0][
+                run_az.call_args_list[1].args[0].index("--query") + 1
+            ],
+            "identity.userAssignedIdentities",
+        )
+
+    def test_rejects_ambiguous_user_assigned_container_app_identities(self) -> None:
+        identities = {
+            "first": {"principalId": "principal-1"},
+            "second": {"principalId": "principal-2"},
+        }
+        with patch.object(
+            setup,
+            "_run_az",
+            side_effect=["", json.dumps(identities)],
+        ):
+            with self.assertRaisesRegex(
+                setup.PanelRbacError,
+                "exactly one managed-identity principal",
+            ):
+                setup.resolve_container_app_principal_id("rg", "frontend")
+
     def test_noop_when_panel_not_deployed(self) -> None:
         with patch.object(setup, "_run_az") as run_az:
             created = setup.configure_panel_rbac({"DEPLOY_ADMINISTRATIVE_PANEL": "false"})

--- a/config/search/search.j2
+++ b/config/search/search.j2
@@ -385,7 +385,10 @@
         "folderPath": {% if FOUNDRY_IQ_STORAGE_FOLDER_PATH %}"{{FOUNDRY_IQ_STORAGE_FOLDER_PATH}}"{% else %}null{% endif %},
         "isADLSGen2": {{FOUNDRY_IQ_IS_ADLS_GEN2 | lower}},
         "ingestionParameters": {
-          "identity": null,
+          "identity": {% if SEARCH_SERVICE_UAI_RESOURCE_ID is defined and SEARCH_SERVICE_UAI_RESOURCE_ID %}{
+            "@odata.type": "#Microsoft.Azure.Search.DataUserAssignedIdentity",
+            "userAssignedIdentity": "{{SEARCH_SERVICE_UAI_RESOURCE_ID}}"
+          }{% else %}null{% endif %},
           "disableImageVerbalization": false,
           "chatCompletionModel": {% if is_foundry_iq_standard_blob and is_content_understanding_chat_model_supported %}{
             "kind": "azureOpenAI",

--- a/config/search/tests/test_foundry_iq_templates.py
+++ b/config/search/tests/test_foundry_iq_templates.py
@@ -90,6 +90,44 @@ class FoundryIqTemplateTests(unittest.TestCase):
         )
         self.assertIsNone(ingestion_parameters["chatCompletionModel"])
 
+    def test_blob_knowledge_source_uses_configured_search_uai(self):
+        settings = render_json_template(
+            "search.settings.j2",
+            {
+                "RESOURCE_TOKEN": "abc123",
+                "SEARCH_SERVICE_QUERY_ENDPOINT": "https://search.search.windows.net",
+                "AI_FOUNDRY_ACCOUNT_NAME": "aif-abc123",
+                "RETRIEVAL_BACKEND": "foundry_iq",
+            },
+        )
+        identity_resource_id = (
+            "/subscriptions/s/resourceGroups/rg/providers/"
+            "Microsoft.ManagedIdentity/userAssignedIdentities/search-uai"
+        )
+        context = {
+            **settings,
+            "SEARCH_SERVICE_UAI_RESOURCE_ID": identity_resource_id,
+            "STORAGE_ACCOUNT_RESOURCE_ID": (
+                "/subscriptions/s/resourceGroups/rg/providers/"
+                "Microsoft.Storage/storageAccounts/st"
+            ),
+            "EMBEDDING_MODEL_INFO": {},
+            "GPT_MODEL_INFO": {},
+        }
+
+        search_definitions = render_json_template("search.j2", context)
+        ingestion_parameters = search_definitions["knowledgeSources"][0][
+            "azureBlobParameters"
+        ]["ingestionParameters"]
+
+        self.assertEqual(
+            ingestion_parameters["identity"],
+            {
+                "@odata.type": "#Microsoft.Azure.Search.DataUserAssignedIdentity",
+                "userAssignedIdentity": identity_resource_id,
+            },
+        )
+
     def test_standard_blob_knowledge_source_includes_supported_chat_model(self):
         settings = render_json_template(
             "search.settings.j2",

--- a/docs/adr/ADR-0001-hosted-agents.md
+++ b/docs/adr/ADR-0001-hosted-agents.md
@@ -353,7 +353,9 @@ from an environment variable) select the topology:
   environments and preserve an existing environment's persisted topology.
 - DEPLOY_ADMINISTRATIVE_PANEL, default false. When true in hosted agent mode,
   brings up the smaller Container Apps only to serve history, feedback, and the
-  dashboard. It remains unsupported and blocked from promotion until #611.
+  dashboard. It is supported by the coordinated hosted-panel release matrix;
+  its history and operator surfaces remain independently disabled by default
+  and fail closed until their explicit evidence/configuration gates are met.
 
 Three resulting modes:
 - Classic (explicit fallback, and sticky for existing classic environments):
@@ -362,7 +364,7 @@ Three resulting modes:
   panel off. The hosted agent comes up, the
   UI points at it, the orchestrator Container Apps does not come up, history via
   Foundry Conversations. This is the field's "one less resource".
-- Hosted agent with panel (deferred until #611): flag on, panel on. Hosted agent
+- Hosted agent with panel: flag on, panel on. Hosted agent
   for chat, smaller data-ingestion Container Apps only as the administrative
   backend.
 
@@ -710,7 +712,7 @@ gates for implementation tracks.
 | --- | --- | --- |
 | Classic (explicit fallback and sticky upgrade mode) | `DEPLOY_HOSTED_AGENT_ORCHESTRATION=false`; orchestrator Container Apps deployed; UI `CHAT_BACKEND=orchestrator`; regression checks for history and feedback pass; pre-cutover classic upgrade remains classic. | Any regression in classic chat, history, or feedback, or an existing deployment changes topology without operator migration. |
 | Hosted / no-panel (fresh target default) | `DEPLOY_HOSTED_AGENT_ORCHESTRATION=true`, `DEPLOY_ADMINISTRATIVE_PANEL=false`; zero orchestrator Container Apps provisioned; UI `CHAT_BACKEND=hosted_agent`; two-user authorization negative test proves restricted user cannot retrieve protected content. | Unauthorized retrieval, missing hosted endpoint, orchestrator app unexpectedly provisioned, or silent runtime fallback. |
-| Hosted / panel (deferred to #611) | Not promotable while #611 is open. When enabled later: `DEPLOY_HOSTED_AGENT_ORCHESTRATION=true`, `DEPLOY_ADMINISTRATIVE_PANEL=true`; hosted path serves chat; panel endpoints serve history/feedback/dashboard; Cosmos contains panel feedback records only. | Panel enabled by default or presented as supported before #611; chat flow depends on Container Apps; panel APIs fail open or return success-shaped placeholders. |
+| Hosted / panel (issue #611 integration) | Explicit `DEPLOYMENT_TOPOLOGY=hosted-panel` materializes `DEPLOY_HOSTED_AGENT_ORCHESTRATION=true` and `DEPLOY_ADMINISTRATIVE_PANEL=true`; hosted compute serves chat while panel endpoints serve owner-bound history/feedback and authorized operator surfaces. Cosmos contains panel metadata only, and the independent history/operator evidence gates remain disabled until their live prerequisites pass. | Panel enabled by default; chat flow depends on Container Apps; hosted compute receives Conversations RBAC; panel APIs, owner binding, or operator authorization fail open or return success-shaped placeholders. |
 
 Cross-cutting hosted runtime gates:
 

--- a/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
+++ b/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
@@ -767,7 +767,7 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    by `config.continuity.setup` in an earlier revision and needed no change
    here. `DEPLOY_ADMINISTRATIVE_PANEL=true` now selects hosted-panel only when
    hosted orchestration is also explicitly selected. The coordinated manifest
-   pins UI `v2.6.0`, orchestrator `v4.0.0`, ingestion `v2.7.0`, and AI Landing
+   pins UI `v2.6.0`, orchestrator `v4.0.1`, ingestion `v2.7.0`, and AI Landing
    Zone `v2.5.0` at their exact released commits. This lifts only the topology
    composition block: `PANEL_HISTORY_ENABLED`,
    `PANEL_HISTORY_OWNER_BINDING_VALIDATED`, and

--- a/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
+++ b/docs/adr/ADR-0004-hosted-panel-conversations-contract.md
@@ -1,24 +1,23 @@
 # ADR-0004: Owner-bound managed-Conversations panel contract to finish the hosted-agent feature (issue #611)
 
-**Status:** Accepted (contract frozen; the container zero-RBAC / stateless
+**Status:** Implemented (contract frozen; the container zero-RBAC / stateless
 boundary is merged in gpt-rag-orchestrator **PR #308**, merge
 `a828253b85c6ed7a63f6085c1666f75a9ca2b7d8`; the gpt-rag-ui user-facing
 history/feedback/deletion surfaces are merged in gpt-rag-ui **PR #99**, merge
 `ee3b53b29019e675c1e9ff19ee607cea361e5a8e`; the gpt-rag-ingestion
-operator-facing overview/corpus-curation surfaces are merged in
+operator-facing overview/corpus-curation surfaces are released in
 gpt-rag-ingestion **PR #274**, merge
-`5569dd6af3ecb317e1037108cb21859f1b2185a1` (neither is yet reflected in
-`manifest.json`'s pin); the Azure/GPT-RAG platform layer — the versioned
+`5569dd6af3ecb317e1037108cb21859f1b2185a1`; the coordinated release pins are
+recorded in `manifest.json`; the Azure/GPT-RAG platform layer — the versioned
 `contracts/conversations-panel-v1` schema, the panel Cosmos container/RBAC
 composition helpers (`config.deployment.composition.panel_database_containers`,
 `config.panel.setup`), and the App Configuration keys, including the
 ingestion operator-surface keys (`PANEL_OPERATOR_SURFACES_ENABLED`,
-`PANEL_OPERATOR_APP_ROLE`, `PANEL_OPERATOR_GROUP_ID`) — is implemented as of
-this revision; the coordinated `manifest.json` pin bump that would lift the
-`DEPLOY_ADMINISTRATIVE_PANEL=true` fail-closed gate remains pending as
-adoption work, now gated on the still-open evidence-gate procedures below
-rather than on any remaining component implementation — see "Adoption and
-migration")<br>
+`PANEL_OPERATOR_APP_ROLE`, `PANEL_OPERATOR_GROUP_ID`) — is implemented.
+Hosted-panel topology composition is available only by explicit operator
+selection. User history and operator surfaces remain independently disabled by
+default and fail closed unless their documented evidence and authorization
+gates are met — see "Adoption and migration".)<br>
 **Date:** 2026-08-07<br>
 **Owners:** GPT-RAG maintainer (Paulo), architecture analysis, with gpt-rag-ui,
 gpt-rag-orchestrator, and gpt-rag-ingestion component owners
@@ -750,7 +749,7 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    `PANEL_FEEDBACK_DATABASE_CONTAINER`, `PANEL_CURSOR_TTL_SECONDS`,
    `PANEL_OVERVIEW_MIN_CARDINALITY`, and — matching the now-merged
    gpt-rag-ingestion operator surfaces (PR #274) exactly —
-   `PANEL_OPERATOR_SURFACES_ENABLED` (forced `false`),
+   `PANEL_OPERATOR_SURFACES_ENABLED` (deployment-published `false`),
    `PANEL_OPERATOR_APP_ROLE` (`""`), `PANEL_OPERATOR_GROUP_ID` (`""`)) are
    published by `config.panel.settings.public_settings`, merged into
    `compose_parameters`'s `additionalAppConfigurationSettings`. The panel Cosmos
@@ -766,15 +765,15 @@ Coordinated, ordered change (compatible-commit discipline per AGENTS.md):
    both `scripts/postProvision.ps1` and `.sh`. The continuity capability
    signing key (`HOSTED_CONVERSATION_CAPABILITY_KEY`) was already provisioned
    by `config.continuity.setup` in an earlier revision and needed no change
-   here. **`DEPLOY_ADMINISTRATIVE_PANEL=true` (hosted-panel topology
-   selection) still fails closed** at `config.deployment.topology`/
-   `composition` (`HostedPanelUnsupportedError`) and `manifest.json` is not
-   repinned in this revision. Unlike the previous revision, this is no longer
-   blocked on remaining `gpt-rag-ingestion` component work — that work has
-   landed (PR #274) — but on the still-open evidence-gate procedures for
-   `PANEL_HISTORY_OWNER_BINDING_VALIDATED` and the newly forced-false
-   `PANEL_OPERATOR_SURFACES_ENABLED` (see "Review trigger" below), consistent
-   with "no runtime behavior change yet."
+   here. `DEPLOY_ADMINISTRATIVE_PANEL=true` now selects hosted-panel only when
+   hosted orchestration is also explicitly selected. The coordinated manifest
+   pins UI `v2.6.0`, orchestrator `v4.0.0`, ingestion `v2.7.0`, and AI Landing
+   Zone `v2.5.0` at their exact released commits. This lifts only the topology
+   composition block: `PANEL_HISTORY_ENABLED`,
+   `PANEL_HISTORY_OWNER_BINDING_VALIDATED`, and
+   `PANEL_OPERATOR_SURFACES_ENABLED` remain deployment-published `false`, so
+   user-history and operator routes fail closed until their separate live
+   evidence and authorization procedures complete.
 2. **gpt-rag-orchestrator** — make the hosted agent/container **stateless**:
    remove any managed-Conversations read/append/persist from the container and
    confirm it consumes only the BFF-supplied complete ordered input. Remove any

--- a/hosted-agent/azure.yaml
+++ b/hosted-agent/azure.yaml
@@ -4,14 +4,16 @@ services:
   orchestrator-agent:
     host: azure.ai.agent
     project: .
-    image: ${AZURE_CONTAINER_REGISTRY_ENDPOINT}/${HOSTED_AGENT_IMAGE=gpt-rag-orchestrator}@${HOSTED_AGENT_IMAGE_VERSION}
+    image: ${HOSTED_AGENT_IMAGE_REFERENCE}
     kind: hosted
     # NOTE: The azure.ai.agent azd extension (v1.0.0-beta.8) reads name, container.resources,
     # protocols[].version and startupCommand directly from this file to build the Foundry
     # "Create Agent" REST payload, bypassing azd's core ${VAR=default} interpolation (confirmed
     # via "template.name not in valid format" and Go-struct type errors when templated). The
     # `image` field above and the `env:` block below use azd's separate, core/host-agnostic
-    # interpolation engine and resolve correctly, so they stay templated. These agent-definition
+    # interpolation engine and resolve correctly, so they stay templated. The deploy hooks
+    # materialize the complete digest-pinned image as one value because azd does not reliably
+    # compose multiple placeholders inside a container reference. These agent-definition
     # fields are hardcoded to composition.py's own defaults (config/deployment/composition.py) so
     # `azd deploy` from this directory works out of the box; to customize, edit this file directly
     # instead of `azd env set HOSTED_AGENT_*`, which only affects the separate `azd provision`

--- a/hosted-agent/azure.yaml
+++ b/hosted-agent/azure.yaml
@@ -4,16 +4,14 @@ services:
   orchestrator-agent:
     host: azure.ai.agent
     project: .
-    image: ${HOSTED_AGENT_IMAGE_REFERENCE}
+    image: ${AZURE_CONTAINER_REGISTRY_ENDPOINT}/${HOSTED_AGENT_IMAGE=gpt-rag-orchestrator}@${HOSTED_AGENT_IMAGE_VERSION}
     kind: hosted
     # NOTE: The azure.ai.agent azd extension (v1.0.0-beta.8) reads name, container.resources,
     # protocols[].version and startupCommand directly from this file to build the Foundry
     # "Create Agent" REST payload, bypassing azd's core ${VAR=default} interpolation (confirmed
     # via "template.name not in valid format" and Go-struct type errors when templated). The
     # `image` field above and the `env:` block below use azd's separate, core/host-agnostic
-    # interpolation engine and resolve correctly, so they stay templated. The deploy hooks
-    # materialize the complete digest-pinned image as one value because azd does not reliably
-    # compose multiple placeholders inside a container reference. These agent-definition
+    # interpolation engine and resolve correctly, so they stay templated. These agent-definition
     # fields are hardcoded to composition.py's own defaults (config/deployment/composition.py) so
     # `azd deploy` from this directory works out of the box; to customize, edit this file directly
     # instead of `azd env set HOSTED_AGENT_*`, which only affects the separate `azd provision`

--- a/hosted-agent/azure.yaml
+++ b/hosted-agent/azure.yaml
@@ -4,7 +4,10 @@ services:
   orchestrator-agent:
     host: azure.ai.agent
     project: .
+    language: docker
     image: ${AZURE_CONTAINER_REGISTRY_ENDPOINT}/${HOSTED_AGENT_IMAGE=gpt-rag-orchestrator}@${HOSTED_AGENT_IMAGE_VERSION}
+    docker:
+      remoteBuild: true
     kind: hosted
     # NOTE: The azure.ai.agent azd extension (v1.0.0-beta.8) reads name, container.resources,
     # protocols[].version and startupCommand directly from this file to build the Foundry

--- a/manifest.json
+++ b/manifest.json
@@ -13,8 +13,8 @@
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v4.0.0",
-      "commit": "1033d0690736f9787e5f227559dc4071d2043b79"
+      "tag": "v4.0.1",
+      "commit": "7e22840ba0e96a5ce237cf2657795768f88e3955"
     },
     {
       "name": "gpt-rag-ingestion",

--- a/manifest.json
+++ b/manifest.json
@@ -1,26 +1,26 @@
 {
   "tag": "unreleased",
   "repo": "https://github.com/azure/gpt-rag.git",
-  "ailz_tag": "develop",
-  "ailz_commit": "1775f871641311868a15792bf3dc836024c9fb20",
+  "ailz_tag": "v2.5.0",
+  "ailz_commit": "cacf418216ce7381d06263e0dd704a86b8a6f225",
   "components": [
     {
       "name": "gpt-rag-ui",
       "repo": "https://github.com/azure/gpt-rag-ui.git",
-      "tag": "v2.5.1",
-      "commit": "971d92a8affd1c859befa4783a26eebc899b425c"
+      "tag": "v2.6.0",
+      "commit": "81d6515d8fc365402e958e861b671af037a4cc75"
     },
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v3.10.0",
-      "commit": "eaa787340c27d8df5bb550147e95c5ecd02ad385"
+      "tag": "v4.0.0",
+      "commit": "1033d0690736f9787e5f227559dc4071d2043b79"
     },
     {
       "name": "gpt-rag-ingestion",
       "repo": "https://github.com/azure/gpt-rag-ingestion.git",
-      "tag": "v2.6.0",
-      "commit": "cb9f1a08a2e780c15ffd096f6e56c04b5e5bd4ca"
+      "tag": "v2.7.0",
+      "commit": "84b927769ef0839110f2d68e3ca471e2260567cf"
     }
   ]
 }

--- a/scripts/postProvision.ps1
+++ b/scripts/postProvision.ps1
@@ -135,6 +135,44 @@ function Invoke-AzTsv {
     return ($output | Select-Object -First 1).Trim()
 }
 
+function Get-UserAssignedIdentityResourceId {
+    param(
+        [AllowEmptyString()][string]$ResourceId,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+    if ([string]::IsNullOrWhiteSpace($ResourceId)) {
+        return ''
+    }
+
+    $identityJson = Invoke-NativeCommand {
+        & az resource show --ids $ResourceId --query identity.userAssignedIdentities -o json 2>$null
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to resolve the user-assigned identity for $Description."
+        exit 1
+    }
+    if ([string]::IsNullOrWhiteSpace($identityJson) -or $identityJson.Trim() -eq 'null') {
+        return ''
+    }
+
+    try {
+        $identityMap = $identityJson | ConvertFrom-Json
+        $identities = @($identityMap.PSObject.Properties)
+    }
+    catch {
+        Write-Error "The user-assigned identity response for $Description was malformed."
+        exit 1
+    }
+    if ($identities.Count -gt 1) {
+        Write-Error "Multiple user-assigned identities are attached to $Description; refusing an ambiguous selection."
+        exit 1
+    }
+    if ($identities.Count -eq 1) {
+        return $identities[0].Name
+    }
+    return ''
+}
+
 function Get-AppConfigResourceName {
     param([Parameter(Mandatory = $true)][string]$Endpoint)
     return (($Endpoint -replace '^https?://', '') -replace '\.azconfig\.io/?$', '')
@@ -478,6 +516,12 @@ function Set-GptRagAppConfiguration {
     else {
         ''
     }
+    $searchServiceUaiResourceId = Get-OptionalEnvValue 'SEARCH_SERVICE_UAI_RESOURCE_ID'
+    if (-not $searchServiceUaiResourceId) {
+        $searchServiceUaiResourceId = Get-UserAssignedIdentityResourceId `
+            -ResourceId $searchResourceId `
+            -Description 'Azure AI Search'
+    }
 
     $settings = [ordered]@{
         AZURE_TENANT_ID = $tenantId
@@ -577,7 +621,7 @@ function Set-GptRagAppConfiguration {
         CONTAINER_ENV_RESOURCE_ID = $containerEnvResourceId
         AI_FOUNDRY_ACCOUNT_RESOURCE_ID = $foundryResourceId
         AI_FOUNDRY_PROJECT_RESOURCE_ID = $foundryProjectResourceId
-        SEARCH_SERVICE_UAI_RESOURCE_ID = ''
+        SEARCH_SERVICE_UAI_RESOURCE_ID = $searchServiceUaiResourceId
         KNOWLEDGE_BASE_CONNECTION_ID = $knowledgeBaseConnectionId
         SEARCH_SERVICE_RESOURCE_ID = $searchResourceId
         AZURE_SPEECH_RESOURCE_ID = (Get-OptionalEnvValue 'AZURE_SPEECH_RESOURCE_ID')

--- a/scripts/postProvision.ps1
+++ b/scripts/postProvision.ps1
@@ -696,6 +696,9 @@ function Set-GptRagAppConfiguration {
         $value = $settings[$key]
         $flatSettings[$key] = if ($null -eq $value) { '' } else { "$value" }
     }
+    foreach ($key in $flatSettings.Keys) {
+        Set-Item -Path "Env:$key" -Value $flatSettings[$key]
+    }
 
     $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) "gpt-rag-appconfig-$([Guid]::NewGuid().ToString('N')).json"
     try {

--- a/scripts/preDeploy.ps1
+++ b/scripts/preDeploy.ps1
@@ -201,6 +201,14 @@ The preparation command builds the manifest-pinned image and stores only its imm
   }
 
   $hostedDigest = "$($globalEnv.HOSTED_AGENT_IMAGE_VERSION)".Trim()
+  $registryEndpoint = "$($globalEnv.AZURE_CONTAINER_REGISTRY_ENDPOINT)".Trim().TrimEnd('/')
+  $hostedImageName = "$($globalEnv.HOSTED_AGENT_IMAGE)".Trim().Trim('/')
+  if (-not $hostedImageName) { $hostedImageName = 'gpt-rag-orchestrator' }
+  if (-not $registryEndpoint) {
+    Write-Error "AZURE_CONTAINER_REGISTRY_ENDPOINT is required to materialize the hosted image reference."
+    exit 1
+  }
+  $hostedImageReference = "$registryEndpoint/$hostedImageName@$hostedDigest"
   Write-Host "Hosted-agent deploy handoff ready: $hostedDigest" -ForegroundColor Green
 
   if (Test-Path -LiteralPath $dotAzure) {
@@ -209,8 +217,8 @@ The preparation command builds the manifest-pinned image and stores only its imm
 
   Push-Location $hostedProject
   try {
-    & azd env set HOSTED_AGENT_IMAGE_VERSION $hostedDigest --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
-    if ($LASTEXITCODE -ne 0) { Write-Error "Failed to set hosted image digest in the child azd project."; exit $LASTEXITCODE }
+    & azd env set HOSTED_AGENT_IMAGE_REFERENCE $hostedImageReference --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
+    if ($LASTEXITCODE -ne 0) { Write-Error "Failed to set hosted image reference in the child azd project."; exit $LASTEXITCODE }
     & azd env set FOUNDRY_PROJECT_ENDPOINT "$($globalEnv.AZURE_AI_PROJECT_ENDPOINT)" --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
     if ($LASTEXITCODE -ne 0) { Write-Error "Failed to set Foundry endpoint in the child azd project."; exit $LASTEXITCODE }
     & azd env set AZURE_AI_PROJECT_ID "$($globalEnv.AZURE_AI_PROJECT_RESOURCE_ID)" --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null

--- a/scripts/preDeploy.ps1
+++ b/scripts/preDeploy.ps1
@@ -201,14 +201,6 @@ The preparation command builds the manifest-pinned image and stores only its imm
   }
 
   $hostedDigest = "$($globalEnv.HOSTED_AGENT_IMAGE_VERSION)".Trim()
-  $registryEndpoint = "$($globalEnv.AZURE_CONTAINER_REGISTRY_ENDPOINT)".Trim().TrimEnd('/')
-  $hostedImageName = "$($globalEnv.HOSTED_AGENT_IMAGE)".Trim().Trim('/')
-  if (-not $hostedImageName) { $hostedImageName = 'gpt-rag-orchestrator' }
-  if (-not $registryEndpoint) {
-    Write-Error "AZURE_CONTAINER_REGISTRY_ENDPOINT is required to materialize the hosted image reference."
-    exit 1
-  }
-  $hostedImageReference = "$registryEndpoint/$hostedImageName@$hostedDigest"
   Write-Host "Hosted-agent deploy handoff ready: $hostedDigest" -ForegroundColor Green
 
   if (Test-Path -LiteralPath $dotAzure) {
@@ -217,8 +209,10 @@ The preparation command builds the manifest-pinned image and stores only its imm
 
   Push-Location $hostedProject
   try {
-    & azd env set HOSTED_AGENT_IMAGE_REFERENCE $hostedImageReference --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
-    if ($LASTEXITCODE -ne 0) { Write-Error "Failed to set hosted image reference in the child azd project."; exit $LASTEXITCODE }
+    & azd env set HOSTED_AGENT_IMAGE_VERSION $hostedDigest --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
+    if ($LASTEXITCODE -ne 0) { Write-Error "Failed to set hosted image digest in the child azd project."; exit $LASTEXITCODE }
+    & azd env set AZD_AGENT_SKIP_ACR true --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
+    if ($LASTEXITCODE -ne 0) { Write-Error "Failed to select the pre-built hosted image deploy path."; exit $LASTEXITCODE }
     & azd env set FOUNDRY_PROJECT_ENDPOINT "$($globalEnv.AZURE_AI_PROJECT_ENDPOINT)" --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null
     if ($LASTEXITCODE -ne 0) { Write-Error "Failed to set Foundry endpoint in the child azd project."; exit $LASTEXITCODE }
     & azd env set AZURE_AI_PROJECT_ID "$($globalEnv.AZURE_AI_PROJECT_RESOURCE_ID)" --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt | Out-Null

--- a/scripts/preDeploy.sh
+++ b/scripts/preDeploy.sh
@@ -170,6 +170,9 @@ if [[ "$hosted_mode" =~ ^(1|true|t|yes|y)$ ]]; then
   hosted_prepared="$(get_azd_value "$repo_root" "HOSTED_AGENT_PREPARED" | tr '[:upper:]' '[:lower:]')"
   deploy_hosted="$(get_azd_value "$repo_root" "DEPLOY_HOSTED_AGENT" | tr '[:upper:]' '[:lower:]')"
   hosted_agent_digest="$(get_azd_value "$repo_root" "HOSTED_AGENT_IMAGE_VERSION")"
+  registry_endpoint="$(get_azd_value "$repo_root" "AZURE_CONTAINER_REGISTRY_ENDPOINT")"
+  hosted_image_name="$(get_azd_value "$repo_root" "HOSTED_AGENT_IMAGE")"
+  hosted_image_name="${hosted_image_name:-gpt-rag-orchestrator}"
 
   [ -f "$hosted_project/azure.yaml" ] || { red "Hosted agent azd project not found at $hosted_project."; exit 1; }
   if [ "$hosted_prepared" != "true" ] || [ "$deploy_hosted" != "true" ]; then
@@ -189,11 +192,13 @@ if [[ "$hosted_mode" =~ ^(1|true|t|yes|y)$ ]]; then
     exit 1
   }
   green "Hosted-agent deploy handoff ready: $hosted_agent_digest"
+  [ -n "$registry_endpoint" ] || { red "AZURE_CONTAINER_REGISTRY_ENDPOINT is required to materialize the hosted image reference."; exit 1; }
+  hosted_image_reference="${registry_endpoint%/}/${hosted_image_name#/}@${hosted_agent_digest}"
 
   copy_dot_azure "$dot_azure" "$hosted_project"
   (
     cd "$hosted_project"
-    azd env set HOSTED_AGENT_IMAGE_VERSION "$hosted_agent_digest" --environment "$environment_name" --no-prompt >/dev/null || exit 1
+    azd env set HOSTED_AGENT_IMAGE_REFERENCE "$hosted_image_reference" --environment "$environment_name" --no-prompt >/dev/null || exit 1
     azd env set FOUNDRY_PROJECT_ENDPOINT "$project_endpoint" --environment "$environment_name" --no-prompt >/dev/null || exit 1
     azd env set AZURE_AI_PROJECT_ID "$project_resource_id" --environment "$environment_name" --no-prompt >/dev/null || exit 1
     azd deploy orchestrator-agent --environment "$environment_name" --no-prompt

--- a/scripts/preDeploy.sh
+++ b/scripts/preDeploy.sh
@@ -170,9 +170,6 @@ if [[ "$hosted_mode" =~ ^(1|true|t|yes|y)$ ]]; then
   hosted_prepared="$(get_azd_value "$repo_root" "HOSTED_AGENT_PREPARED" | tr '[:upper:]' '[:lower:]')"
   deploy_hosted="$(get_azd_value "$repo_root" "DEPLOY_HOSTED_AGENT" | tr '[:upper:]' '[:lower:]')"
   hosted_agent_digest="$(get_azd_value "$repo_root" "HOSTED_AGENT_IMAGE_VERSION")"
-  registry_endpoint="$(get_azd_value "$repo_root" "AZURE_CONTAINER_REGISTRY_ENDPOINT")"
-  hosted_image_name="$(get_azd_value "$repo_root" "HOSTED_AGENT_IMAGE")"
-  hosted_image_name="${hosted_image_name:-gpt-rag-orchestrator}"
 
   [ -f "$hosted_project/azure.yaml" ] || { red "Hosted agent azd project not found at $hosted_project."; exit 1; }
   if [ "$hosted_prepared" != "true" ] || [ "$deploy_hosted" != "true" ]; then
@@ -192,13 +189,12 @@ if [[ "$hosted_mode" =~ ^(1|true|t|yes|y)$ ]]; then
     exit 1
   }
   green "Hosted-agent deploy handoff ready: $hosted_agent_digest"
-  [ -n "$registry_endpoint" ] || { red "AZURE_CONTAINER_REGISTRY_ENDPOINT is required to materialize the hosted image reference."; exit 1; }
-  hosted_image_reference="${registry_endpoint%/}/${hosted_image_name#/}@${hosted_agent_digest}"
 
   copy_dot_azure "$dot_azure" "$hosted_project"
   (
     cd "$hosted_project"
-    azd env set HOSTED_AGENT_IMAGE_REFERENCE "$hosted_image_reference" --environment "$environment_name" --no-prompt >/dev/null || exit 1
+    azd env set HOSTED_AGENT_IMAGE_VERSION "$hosted_agent_digest" --environment "$environment_name" --no-prompt >/dev/null || exit 1
+    azd env set AZD_AGENT_SKIP_ACR true --environment "$environment_name" --no-prompt >/dev/null || exit 1
     azd env set FOUNDRY_PROJECT_ENDPOINT "$project_endpoint" --environment "$environment_name" --no-prompt >/dev/null || exit 1
     azd env set AZURE_AI_PROJECT_ID "$project_resource_id" --environment "$environment_name" --no-prompt >/dev/null || exit 1
     azd deploy orchestrator-agent --environment "$environment_name" --no-prompt

--- a/tests/test_deployment_modes.py
+++ b/tests/test_deployment_modes.py
@@ -10,7 +10,6 @@ from config.deployment import appconfig
 from config.deployment.composition import (
     ConflictingTopologySignalsError,
     DeploymentMode,
-    HostedPanelUnsupportedError,
     compose_parameters,
     describe_mode,
     materialized_settings,
@@ -399,20 +398,33 @@ class DeploymentCompositionTests(unittest.TestCase):
                 expected_hosted_source_commit="a" * 40,
             )
 
-    def test_hosted_with_panel_fails_closed_until_611(self) -> None:
-        # Hosted-panel is not implemented yet (tracked by #611): any signal
-        # that would actually select it must fail closed rather than
-        # silently provisioning panel-adjacent resources.
+    def test_hosted_with_panel_composes_only_panel_resources(self) -> None:
         environment = {
             "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
             "DEPLOY_ADMINISTRATIVE_PANEL": "true",
             "HOSTED_AGENT_IMAGE_VERSION": DIGEST,
+            "HOSTED_AGENT_RESOURCE_SCOPE": "api://agent/.default",
         }
 
-        with self.assertRaisesRegex(HostedPanelUnsupportedError, "611"):
-            resolve_mode(environment)
-        with self.assertRaisesRegex(HostedPanelUnsupportedError, "611"):
-            compose_parameters(source_parameters(), environment)
+        composed = compose_parameters(source_parameters(), environment)
+        parameters = composed["parameters"]
+        apps = parameters["containerAppsList"]["value"]
+
+        self.assertEqual(DeploymentMode.HOSTED_PANEL, resolve_mode(environment))
+        self.assertEqual(
+            ["frontend", "dataingest"],
+            [app["service_name"] for app in apps],
+        )
+        self.assertTrue(parameters["deployCosmosDb"]["value"])
+        self.assertEqual(
+            panel_database_containers(),
+            parameters["databaseContainersList"]["value"],
+        )
+        settings = settings_by_name(composed)
+        self.assertEqual("hosted_agent", settings["CHAT_BACKEND"])
+        self.assertEqual("true", settings["DEPLOY_ADMINISTRATIVE_PANEL"])
+        self.assertEqual("false", settings["PANEL_HISTORY_ENABLED"])
+        self.assertEqual("false", settings["PANEL_OPERATOR_SURFACES_ENABLED"])
 
     def test_legacy_generated_digest_without_startup_provenance_remains_valid(
         self,
@@ -436,11 +448,10 @@ class DeploymentCompositionTests(unittest.TestCase):
 
         self.assertTrue(composed["parameters"]["deployHostedAgent"]["value"])
 
-    def test_deployment_topology_hosted_panel_fails_closed_until_611(self) -> None:
+    def test_deployment_topology_hosted_panel_resolves(self) -> None:
         environment = {"DEPLOYMENT_TOPOLOGY": "hosted-panel"}
 
-        with self.assertRaisesRegex(HostedPanelUnsupportedError, "611"):
-            resolve_mode(environment)
+        self.assertEqual(DeploymentMode.HOSTED_PANEL, resolve_mode(environment))
 
     def test_hosted_mode_rejects_mutable_image_reference(self) -> None:
         environment = {
@@ -475,14 +486,9 @@ class DeploymentCompositionTests(unittest.TestCase):
 class PanelPlatformContractTests(unittest.TestCase):
     """Issue #611 / ADR-0004 platform-contract composition.
 
-    ``DeploymentMode.HOSTED_PANEL`` still cannot be reached through
-    ``resolve_mode``/``compose_parameters`` (hosted-panel topology selection
-    fails closed pending the remaining gpt-rag-ingestion operator work), so
-    these tests exercise the pure, directly-testable composition helpers
-    with ``mode`` passed explicitly -- exactly like the existing
-    ``describe_mode``/``materialized_settings`` tests elsewhere in this
-    module -- to prove the container/RBAC/App-Configuration contract is
-    correct and ready without changing any currently reachable behavior.
+    The topology is deployable only with explicit operator selection. Its
+    user-history and operator surfaces remain independently fail closed behind
+    their disabled-by-default evidence gates.
     """
 
     def test_panel_database_containers_are_metadata_only_and_distinct(self) -> None:
@@ -581,12 +587,9 @@ class PanelPlatformContractTests(unittest.TestCase):
         # Cosmos. This asserts that identity's existing blob RBAC (already
         # sufficient for the classic Files tab's blocked/unblock flow) is
         # untouched by the hosted-mode Cosmos-role stripping above.
-        # (Hosted-panel itself still fails closed -- see
-        # test_hosted_with_panel_fails_closed_until_611 -- so only
-        # hosted-no-panel is reachable through compose_parameters today; the
-        # role list dataingest would carry under hosted-panel is unaffected
-        # by this stripping code path either way, since it only ever removes
-        # CosmosDBBuiltInDataContributor.)
+        # Hosted-panel uses the same hosted component path; this stripping
+        # removes only CosmosDBBuiltInDataContributor and leaves the existing
+        # blob role unchanged.
         environment = {
             "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
             "DEPLOY_ADMINISTRATIVE_PANEL": "false",
@@ -736,6 +739,22 @@ class EnvironmentTopologyResolutionTests(unittest.TestCase):
 
         self.assertEqual(DeploymentMode.HOSTED_NO_PANEL, mode)
 
+    def test_existing_environment_with_persisted_panel_topology_stays_panel(
+        self,
+    ) -> None:
+        mode = resolve_topology(
+            {},
+            resource_group_exists=True,
+            persisted_settings={
+                "DEPLOYMENT_TOPOLOGY": "hosted-panel",
+                "DEPLOY_HOSTED_AGENT_ORCHESTRATION": "true",
+                "DEPLOY_ADMINISTRATIVE_PANEL": "true",
+                "CHAT_BACKEND": "hosted_agent",
+            },
+        )
+
+        self.assertEqual(DeploymentMode.HOSTED_PANEL, mode)
+
     def test_existing_unmarked_pre_cutover_environment_is_classic(self) -> None:
         # A resource group exists (this is not a fresh deployment) but no
         # ADR-0001 topology markers were ever persisted -- this is a
@@ -844,7 +863,7 @@ class EnvironmentTopologyResolutionTests(unittest.TestCase):
             resolve_mode({"DEPLOYMENT_TOPOLOGY": "not-a-real-topology"})
 
     def test_materialized_settings_agree_with_describe_mode(self) -> None:
-        for mode in (DeploymentMode.CLASSIC, DeploymentMode.HOSTED_NO_PANEL):
+        for mode in DeploymentMode:
             materialized = materialized_settings(mode)
             description = describe_mode(mode)
 

--- a/tests/test_hosted_image.py
+++ b/tests/test_hosted_image.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import subprocess
 import tempfile
 import unittest
@@ -20,6 +21,7 @@ from config.deployment.hosted_image import (
     render_hosted_dockerfile,
     resolve_azure_cli_executable,
     resolve_pushed_digest,
+    run_acr_build_and_wait,
     validate_digest,
 )
 
@@ -186,18 +188,95 @@ class ResolvePushedDigestTests(unittest.TestCase):
             )
 
 
+class RunAcrBuildAndWaitTests(unittest.TestCase):
+    @patch("config.deployment.hosted_image.resolve_azure_cli_executable", return_value="az")
+    @patch("config.deployment.hosted_image.subprocess.run")
+    def test_returns_expected_digest_from_management_plane_run(
+        self, mock_run: MagicMock, _mock_cli: MagicMock
+    ) -> None:
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=json.dumps({"runId": "abc"}),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "status": "Succeeded",
+                        "outputImages": [
+                            {
+                                "repository": "gpt-rag-orchestrator",
+                                "tag": "v3.9.0-hosted",
+                                "digest": BASE_DIGEST,
+                            }
+                        ],
+                    }
+                ),
+                stderr="",
+            ),
+        ]
+
+        digest = run_acr_build_and_wait(
+            ["az", "acr", "build"],
+            registry="myregistry",
+            image_name="gpt-rag-orchestrator",
+            image_tag="v3.9.0-hosted",
+            poll_interval=0,
+        )
+
+        self.assertEqual(BASE_DIGEST, digest)
+        self.assertEqual(
+            ["--no-logs", "--output", "json"],
+            mock_run.call_args_list[0].args[0][-3:],
+        )
+        self.assertEqual(
+            ["az", "acr", "task", "show-run"],
+            mock_run.call_args_list[1].args[0][:4],
+        )
+
+    @patch("config.deployment.hosted_image.resolve_azure_cli_executable", return_value="az")
+    @patch("config.deployment.hosted_image.subprocess.run")
+    def test_fails_closed_when_build_run_fails(
+        self, mock_run: MagicMock, _mock_cli: MagicMock
+    ) -> None:
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=json.dumps({"runId": "abc"}),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=json.dumps({"status": "Failed", "error": "build failed"}),
+                stderr="",
+            ),
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "build failed"):
+            run_acr_build_and_wait(
+                ["az", "acr", "build"],
+                registry="myregistry",
+                image_name="gpt-rag-orchestrator",
+                image_tag="v3.9.0-hosted",
+                poll_interval=0,
+            )
+
+
 class BuildHostedImageTests(unittest.TestCase):
     @patch("config.deployment.hosted_image.resolve_azure_cli_executable", return_value="az")
-    @patch("config.deployment.hosted_image.resolve_pushed_digest")
-    @patch("config.deployment.hosted_image.subprocess.run")
+    @patch("config.deployment.hosted_image.run_acr_build_and_wait")
     def test_builds_then_resolves_digest(
         self,
-        mock_run: MagicMock,
-        mock_resolve: MagicMock,
+        mock_build: MagicMock,
         _mock_cli: MagicMock,
     ) -> None:
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
-        mock_resolve.return_value = BASE_DIGEST
+        mock_build.return_value = BASE_DIGEST
 
         digest = build_hosted_image(
             registry="myregistry",
@@ -208,17 +287,21 @@ class BuildHostedImageTests(unittest.TestCase):
         )
 
         self.assertEqual(BASE_DIGEST, digest)
-        mock_run.assert_called_once()
-        build_args = mock_run.call_args.args[0]
+        mock_build.assert_called_once()
+        build_args = mock_build.call_args.args[0]
         self.assertEqual(build_args[0:3], ["az", "acr", "build"])
         self.assertIn("--agent-pool", build_args)
         self.assertIn("build-pool", build_args)
-        mock_resolve.assert_called_once_with(
-            registry="myregistry",
-            image_name="gpt-rag-orchestrator",
-            image_tag="v3.9.0-hosted",
-            azure_cli="az",
+        self.assertEqual("myregistry", mock_build.call_args.kwargs["registry"])
+        self.assertEqual(
+            "gpt-rag-orchestrator",
+            mock_build.call_args.kwargs["image_name"],
         )
+        self.assertEqual(
+            "v3.9.0-hosted",
+            mock_build.call_args.kwargs["image_tag"],
+        )
+        self.assertEqual("az", mock_build.call_args.kwargs["azure_cli"])
 
     @patch("config.deployment.hosted_image.build_hosted_image")
     @patch(
@@ -252,15 +335,13 @@ class BuildHostedImageTests(unittest.TestCase):
 
 class BuildSourceImageTests(unittest.TestCase):
     @patch("config.deployment.hosted_image.resolve_azure_cli_executable", return_value="az")
-    @patch("config.deployment.hosted_image.resolve_pushed_digest")
-    @patch("config.deployment.hosted_image.subprocess.run")
+    @patch("config.deployment.hosted_image.run_acr_build_and_wait")
     def test_public_basic_build_uses_standard_acr_task(
         self,
-        mock_run: MagicMock,
-        mock_resolve: MagicMock,
+        mock_build: MagicMock,
         _mock_cli: MagicMock,
     ) -> None:
-        mock_resolve.return_value = BASE_DIGEST
+        mock_build.return_value = BASE_DIGEST
         with tempfile.TemporaryDirectory() as tmp:
             source_dir = Path(tmp)
             (source_dir / "Dockerfile").write_text("FROM scratch\n")
@@ -273,8 +354,10 @@ class BuildSourceImageTests(unittest.TestCase):
             )
 
         self.assertEqual(BASE_DIGEST, digest)
-        args = mock_run.call_args.args[0]
+        args = mock_build.call_args.args[0]
         self.assertEqual(["az", "acr", "build"], args[:3])
+        self.assertEqual(str(source_dir / "Dockerfile"), args[args.index("--file") + 1])
+        self.assertEqual(str(source_dir), args[args.index("--file") + 2])
         self.assertNotIn("--agent-pool", args)
 
 

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -566,6 +566,8 @@ class LifecycleParityTests(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertIn("host: azure.ai.agent", content)
+        self.assertIn("language: docker", content)
+        self.assertIn("remoteBuild: true", content)
         self.assertIn("protocol: responses", content)
         self.assertIn("protocol: invocations", content)
         self.assertNotIn("API_KEY", content)

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -325,6 +325,7 @@ class LifecycleParityTests(unittest.TestCase):
             content,
         )
         self.assertNotIn("SEARCH_SERVICE_UAI_RESOURCE_ID = ''", content)
+        self.assertIn('Set-Item -Path "Env:$key" -Value $flatSettings[$key]', content)
         self.assertIn("$foundryProjects.Count -ne 1", content)
         self.assertIn("AI_FOUNDRY_PROJECT_NAME", content)
         self.assertNotIn("aifoundry-default-project", content)

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -313,6 +313,18 @@ class LifecycleParityTests(unittest.TestCase):
             "Microsoft.CognitiveServices/accounts/projects",
             content,
         )
+
+    def test_postprovision_preserves_search_user_assigned_identity(self) -> None:
+        content = (ROOT / "scripts" / "postProvision.ps1").read_text(
+            encoding="utf-8-sig"
+        )
+
+        self.assertIn("Get-UserAssignedIdentityResourceId", content)
+        self.assertIn(
+            "SEARCH_SERVICE_UAI_RESOURCE_ID = $searchServiceUaiResourceId",
+            content,
+        )
+        self.assertNotIn("SEARCH_SERVICE_UAI_RESOURCE_ID = ''", content)
         self.assertIn("$foundryProjects.Count -ne 1", content)
         self.assertIn("AI_FOUNDRY_PROJECT_NAME", content)
         self.assertNotIn("aifoundry-default-project", content)

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -31,7 +31,7 @@ class IntegrationPinTests(unittest.TestCase):
             manifest["ailz_commit"],
         )
         self.assertEqual(
-            ("v4.0.0", "1033d0690736f9787e5f227559dc4071d2043b79"),
+            ("v4.0.1", "7e22840ba0e96a5ce237cf2657795768f88e3955"),
             (
                 components["gpt-rag-orchestrator"]["tag"],
                 components["gpt-rag-orchestrator"]["commit"],

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -420,7 +420,7 @@ class LifecycleParityTests(unittest.TestCase):
                 self.assertIn("--validate-hosted-deploy", content)
                 self.assertIn("deploy_hosted_agent_orchestration", content)
                 self.assertIn("azd deploy orchestrator-agent", content)
-                self.assertIn("HOSTED_AGENT_IMAGE_REFERENCE", content)
+                self.assertIn("AZD_AGENT_SKIP_ACR", content)
                 self.assertIn("PYTHONPATH", content)
                 if name == "preDeploy.ps1":
                     self.assertIn("runpy.run_module", content)
@@ -568,7 +568,6 @@ class LifecycleParityTests(unittest.TestCase):
         self.assertIn("host: azure.ai.agent", content)
         self.assertIn("protocol: responses", content)
         self.assertIn("protocol: invocations", content)
-        self.assertIn("image: ${HOSTED_AGENT_IMAGE_REFERENCE}", content)
         self.assertNotIn("API_KEY", content)
         self.assertNotIn("PASSWORD", content)
         self.assertNotIn("InstrumentationKey=", content)

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -23,29 +23,29 @@ class IntegrationPinTests(unittest.TestCase):
 
         self.assertEqual("unreleased", manifest["tag"])
         self.assertEqual(
-            "develop",
+            "v2.5.0",
             manifest["ailz_tag"],
         )
         self.assertEqual(
-            "1775f871641311868a15792bf3dc836024c9fb20",
+            "cacf418216ce7381d06263e0dd704a86b8a6f225",
             manifest["ailz_commit"],
         )
         self.assertEqual(
-            ("v3.10.0", "eaa787340c27d8df5bb550147e95c5ecd02ad385"),
+            ("v4.0.0", "1033d0690736f9787e5f227559dc4071d2043b79"),
             (
                 components["gpt-rag-orchestrator"]["tag"],
                 components["gpt-rag-orchestrator"]["commit"],
             ),
         )
         self.assertEqual(
-            ("v2.6.0", "cb9f1a08a2e780c15ffd096f6e56c04b5e5bd4ca"),
+            ("v2.7.0", "84b927769ef0839110f2d68e3ca471e2260567cf"),
             (
                 components["gpt-rag-ingestion"]["tag"],
                 components["gpt-rag-ingestion"]["commit"],
             ),
         )
         self.assertEqual(
-            ("v2.5.1", "971d92a8affd1c859befa4783a26eebc899b425c"),
+            ("v2.6.0", "81d6515d8fc365402e958e861b671af037a4cc75"),
             (
                 components["gpt-rag-ui"]["tag"],
                 components["gpt-rag-ui"]["commit"],
@@ -55,7 +55,7 @@ class IntegrationPinTests(unittest.TestCase):
     def test_gitmodule_and_gitlink_match_landing_zone_integration_pin(self) -> None:
         gitmodules = (ROOT / ".gitmodules").read_text(encoding="utf-8")
         self.assertIn(
-            "branch = develop",
+            "branch = v2.5.0",
             gitmodules,
         )
 
@@ -67,7 +67,7 @@ class IntegrationPinTests(unittest.TestCase):
             text=True,
         )
         self.assertIn(
-            "1775f871641311868a15792bf3dc836024c9fb20",
+            "cacf418216ce7381d06263e0dd704a86b8a6f225",
             completed.stdout.strip(),
         )
 

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -420,6 +420,7 @@ class LifecycleParityTests(unittest.TestCase):
                 self.assertIn("--validate-hosted-deploy", content)
                 self.assertIn("deploy_hosted_agent_orchestration", content)
                 self.assertIn("azd deploy orchestrator-agent", content)
+                self.assertIn("HOSTED_AGENT_IMAGE_REFERENCE", content)
                 self.assertIn("PYTHONPATH", content)
                 if name == "preDeploy.ps1":
                     self.assertIn("runpy.run_module", content)
@@ -567,6 +568,7 @@ class LifecycleParityTests(unittest.TestCase):
         self.assertIn("host: azure.ai.agent", content)
         self.assertIn("protocol: responses", content)
         self.assertIn("protocol: invocations", content)
+        self.assertIn("image: ${HOSTED_AGENT_IMAGE_REFERENCE}", content)
         self.assertNotIn("API_KEY", content)
         self.assertNotIn("PASSWORD", content)
         self.assertNotIn("InstrumentationKey=", content)

--- a/tests/test_topology_cli.py
+++ b/tests/test_topology_cli.py
@@ -57,6 +57,37 @@ class ResourceGroupExistsTests(unittest.TestCase):
             topology.resource_group_exists("rg-test")
 
 
+class ResourceGroupHasResourcesTests(unittest.TestCase):
+    @patch("config.deployment.topology.subprocess.run")
+    def test_true_when_resource_group_contains_resources(
+        self, mock_run: object
+    ) -> None:
+        mock_run.return_value = _completed(
+            0, "/subscriptions/test/resourceGroups/rg-test/providers/test"
+        )
+
+        self.assertTrue(
+            topology.resource_group_has_resources(
+                "rg-test", "subscription-test"
+            )
+        )
+
+    @patch("config.deployment.topology.subprocess.run")
+    def test_false_when_resource_group_is_empty(self, mock_run: object) -> None:
+        mock_run.return_value = _completed(0, "")
+
+        self.assertFalse(topology.resource_group_has_resources("rg-test"))
+
+    @patch("config.deployment.topology.subprocess.run")
+    def test_fails_closed_when_resource_query_fails(
+        self, mock_run: object
+    ) -> None:
+        mock_run.return_value = _completed(1, "", "ERROR: forbidden")
+
+        with self.assertRaisesRegex(Exception, "cannot safely continue"):
+            topology.resource_group_has_resources("rg-test")
+
+
 class ReadPersistedSettingsTests(unittest.TestCase):
     def test_empty_endpoint_short_circuits_without_calling_az(self) -> None:
         with patch("config.deployment.topology.subprocess.run") as mock_run:
@@ -133,19 +164,26 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
         mock_read_settings.assert_not_called()
 
     @patch("config.deployment.topology.read_persisted_settings")
+    @patch(
+        "config.deployment.topology.resource_group_has_resources",
+        return_value=False,
+    )
     @patch("config.deployment.topology.resource_group_exists")
-    def test_explicit_hosted_fresh_environment_skips_persisted_settings(
-        self, mock_rg_exists: object, mock_read_settings: object
+    def test_explicit_hosted_empty_azd_resource_group_is_fresh(
+        self,
+        mock_rg_exists: object,
+        _mock_has_resources: object,
+        mock_read_settings: object,
     ) -> None:
-        mock_rg_exists.return_value = False
+        mock_rg_exists.return_value = True
 
         mode = topology.resolve_environment_topology(
-            {"DEPLOYMENT_TOPOLOGY": "hosted-no-panel"},
+            {"DEPLOYMENT_TOPOLOGY": "hosted-panel"},
             resource_group_name="rg-test",
             app_config_endpoint="https://x",
         )
 
-        self.assertEqual(DeploymentMode.HOSTED_NO_PANEL, mode)
+        self.assertEqual(DeploymentMode.HOSTED_PANEL, mode)
         mock_read_settings.assert_not_called()
 
     @patch("config.deployment.topology.read_persisted_settings")
@@ -164,9 +202,16 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
         mock_read_settings.assert_not_called()
 
     @patch("config.deployment.topology.read_persisted_settings")
+    @patch(
+        "config.deployment.topology.resource_group_has_resources",
+        return_value=True,
+    )
     @patch("config.deployment.topology.resource_group_exists")
     def test_explicit_hosted_migration_preserves_existing_classic_runtime(
-        self, mock_rg_exists: object, mock_read_settings: object
+        self,
+        mock_rg_exists: object,
+        _mock_has_resources: object,
+        mock_read_settings: object,
     ) -> None:
         mock_rg_exists.return_value = True
         mock_read_settings.return_value = {
@@ -207,9 +252,16 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
         self.assertFalse(resolution.preserve_classic_runtime)
 
     @patch("config.deployment.topology.read_persisted_settings")
+    @patch(
+        "config.deployment.topology.resource_group_has_resources",
+        return_value=True,
+    )
     @patch("config.deployment.topology.resource_group_exists")
     def test_ambiguous_existing_hosted_request_preserves_persisted_classic(
-        self, mock_rg_exists: object, mock_read_settings: object
+        self,
+        mock_rg_exists: object,
+        _mock_has_resources: object,
+        mock_read_settings: object,
     ) -> None:
         mock_rg_exists.return_value = True
         mock_read_settings.return_value = {}
@@ -226,9 +278,16 @@ class ResolveEnvironmentTopologyTests(unittest.TestCase):
         )
 
     @patch("config.deployment.topology.read_persisted_settings")
+    @patch(
+        "config.deployment.topology.resource_group_has_resources",
+        return_value=True,
+    )
     @patch("config.deployment.topology.resource_group_exists")
     def test_ambiguous_explicit_hosted_request_fails_when_state_is_inaccessible(
-        self, mock_rg_exists: object, mock_read_settings: object
+        self,
+        mock_rg_exists: object,
+        _mock_has_resources: object,
+        mock_read_settings: object,
     ) -> None:
         mock_rg_exists.return_value = True
         mock_read_settings.side_effect = topology.DeploymentTopologyError(


### PR DESCRIPTION
## Purpose

Integrate the coordinated hosted-agent (Foundry) release matrix into
`develop`: UI `v2.6.0`, orchestrator `v4.0.1`, ingestion `v2.7.0`, and AI
Landing Zone `v2.5.0`, implementing ADR-0001 (hosted agents), ADR-0003
(delegated conversation continuity), and ADR-0004 (hosted panel contract).

This branch also root-causes and fixes the previously-documented HTTP 424
`session_not_ready` hosted-agent readiness blocker (see commit history and
`CHANGELOG.md`).

## What this integrates

- Hosted-agent `azd` service isolation with a two-phase prepare/deploy
  contract (`scripts/prepareHostedDeployment.*`, `config/deployment/hosted_image.py`).
- Deterministic topology resolution (classic / hosted-no-panel / hosted-panel)
  shared by all lifecycle hooks.
- Delegated hosted-conversation continuity (ADR-0003) and the hosted panel
  platform contract (ADR-0004), both fail-closed by default.
- Windows jumpbox / Azure CLI resolution fixes for hosted-image ACR builds
  and regional preflight checks.
- Foundry IQ ingestion identity fix (binds the Search service's configured
  UAI instead of a nonexistent system identity).
- Panel user-assigned identity resolution and Search UAI propagation fixes.
- Prebuilt hosted image deploy path (`AZD_AGENT_SKIP_ACR`, remote-build
  contract in `hosted-agent/azure.yaml`).

## Root cause found and fixed: HTTP 424 `session_not_ready`

Network-isolated live validation previously reached hosted agent-version
`active` state, but every session invoke returned HTTP 424
`session_not_ready`. Root-caused to a circular import in
`gpt-rag-orchestrator`'s hosted entrypoint (`dependencies` <-> `connectors`)
that crashed the container's Python process before uvicorn could bind a
port or serve `GET /readiness` — exactly Microsoft Foundry's documented
`424 session_not_ready` failure mode. Fixed upstream in
[gpt-rag-orchestrator#311](https://github.com/Azure/gpt-rag-orchestrator/pull/311),
released as [`v4.0.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.1).
The manifest pin in this branch is updated to `v4.0.1` accordingly. See
`CHANGELOG.md` for the full root-cause writeup.

**This fixes the specific crash that produced the HTTP 424 symptom. It does
not by itself constitute the network-isolated live validation this
integration still requires** (two-user Entra owner-binding/RBAC evidence,
panel authorization, protocol/role gates, rollback, etc.) — that full
validation matrix remains blocked in this session: no Azure subscription
with resource-creation rights or Entra tenant admin access is available.
The umbrella manifest `tag` remains `unreleased`; **no umbrella release is
published by this PR**, and hosted-panel evidence flags
(`HOSTED_CONTINUITY_ENABLED`, `PANEL_HISTORY_ENABLED`,
`PANEL_HISTORY_OWNER_BINDING_VALIDATED`, `PANEL_OPERATOR_SURFACES_ENABLED`)
remain `false`.

## Validation

- `pytest tests/ config/ -q` -> **356 passed, 113 subtests passed**, zero
  failures (includes the updated `test_release_contracts.py` pin assertion).
- Root-cause reproduction: a fresh-interpreter import test mirroring the
  hosted container's `uvicorn api.hosted_entrypoint:app` startup fails with
  the documented `ImportError`/circular-import on orchestrator `v4.0.0` and
  succeeds in ~4s on `v4.0.1` (see `gpt-rag-orchestrator` PR #311 for the
  regression test and full orchestrator suite: 720 passed).
- Live network-isolated deployment validation: **not performed** in this
  session (no Azure/Entra provisioning access available) — reported as a
  concrete blocker rather than fabricated.

## Follow-up (not done by this PR)

- Complete the live network-isolated validation matrix (two-user Entra
  owner-binding/RBAC gate, panel authorization, protocol/role evidence,
  rollback) in an environment with Azure provisioning and Entra tenant admin
  access.
- Only after that validation passes: remove "blocked" wording from the
  `docs` branch's hosted-agent pages, and prepare/publish umbrella release
  `v3.8.0`.
- Do not close Azure/GPT-RAG#589, #591, #592, #597, or the parent #576 until
  that validation evidence exists.