### PR TITLE
docs: record HTTP 424 readiness root cause and fix; validation still pending

### DIFF
--- a/docs/hosted_agent_release_matrix.md
+++ b/docs/hosted_agent_release_matrix.md
@@ -13,9 +13,15 @@ that remain fail closed.
     `PANEL_HISTORY_OWNER_BINDING_VALIDATED`, and
     `PANEL_OPERATOR_SURFACES_ENABLED` remain deployment-published `false`.
     This documentation does not claim that their separate live evidence and
-    authorization procedures have completed. The hosted agent version became
-    active during validation, but session readiness returned HTTP 424. Treat the
-    matrix as implemented configuration, not as a validated or shipped umbrella
+    authorization procedures have completed. A prior validation attempt saw
+    the hosted agent version become active while session readiness returned
+    HTTP 424; that crash was root-caused to a `gpt-rag-orchestrator` circular
+    import and fixed in
+    [orchestrator `v4.0.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.1)
+    (pinned below). Fixing that crash is a code-level correction, not a
+    substitute for the network-isolated live validation matrix below, which
+    has not yet been re-run. Treat the matrix as implemented and
+    crash-fixed configuration, not as a validated or shipped umbrella
     release.
 
 ## Exact integrated matrix
@@ -23,7 +29,7 @@ that remain fail closed.
 | Component | Release | Reviewed release commit | Relevant contract |
 | --- | --- | --- | --- |
 | GPT-RAG UI | [`v2.6.0`](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.6.0) | [`81d6515`](https://github.com/Azure/gpt-rag-ui/commit/81d6515d8fc365402e958e861b671af037a4cc75) | Hosted/no-panel is the fresh UI default when `CHAT_BACKEND` is absent; continuity and panel surfaces remain opt-in and fail closed. |
-| GPT-RAG orchestrator | [`v4.0.0`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.0) | [`1033d06`](https://github.com/Azure/gpt-rag-orchestrator/commit/1033d0690736f9787e5f227559dc4071d2043b79) | Canonical hosted `/responses` is stateless and requires caller-supplied ordered input. |
+| GPT-RAG orchestrator | [`v4.0.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.1) | [`7e22840`](https://github.com/Azure/gpt-rag-orchestrator/commit/7e22840ba0e96a5ce237cf2657795768f88e3955) | Canonical hosted `/responses` is stateless and requires caller-supplied ordered input. Fixes the `dependencies`/`connectors` circular import that crashed the hosted entrypoint on startup ([PR #311](https://github.com/Azure/gpt-rag-orchestrator/pull/311)). |
 | GPT-RAG ingestion | [`v2.7.0`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.7.0) | [`84b9277`](https://github.com/Azure/gpt-rag-ingestion/commit/84b927769ef0839110f2d68e3ca471e2260567cf) | Metadata-only operator overview and document/corpus curation APIs. |
 | AI Landing Zone | [`v2.5.0`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.5.0) | [`cacf418`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/cacf418216ce7381d06263e0dd704a86b8a6f225) | Two-phase hosted-agent prerequisite/handoff support; both hosted flags default to `false`. |
 
@@ -57,7 +63,7 @@ remove them and then assume the UI fallback values are equivalent.
 
 ## Stateless hosted runtime contract
 
-Orchestrator `v4.0.0` performs no managed-Conversations create, read, append, or
+Orchestrator `v4.0.1` performs no managed-Conversations create, read, append, or
 delete operation in the hosted container. The caller supplies the complete,
 bounded, oldest-to-newest history on every request.
 
@@ -298,10 +304,20 @@ Before those independent live surfaces can be enabled, validation must:
 8. separately validate panel user auth and the ingestion browser operator-token
    path before enabling panel flags.
 
-The latest runtime attempt does not satisfy item 1: the agent version reached
-active state, but session readiness returned HTTP 424. Preserve the fail-closed
-flags and do not describe this integration as runtime-validated or shipped until
-readiness and the remaining evidence steps succeed.
+The prior runtime attempt did not satisfy item 1: the agent version reached
+active state, but session readiness returned HTTP 424. That specific crash
+was root-caused to a `dependencies`/`connectors` circular import in the
+hosted entrypoint (`src/api/hosted_entrypoint.py` imports `dependencies`
+before anything else in the process has "warmed up" `connectors`, unlike
+the classic entrypoint) and fixed in
+[orchestrator `v4.0.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.1)
+([PR #311](https://github.com/Azure/gpt-rag-orchestrator/pull/311)), pinned
+above. Fixing the crash is necessary but not sufficient: item 1 and the
+remaining evidence steps must still be re-run against a live,
+network-isolated deployment before this integration can be described as
+validated. Preserve the fail-closed flags and do not describe this
+integration as runtime-validated or shipped until readiness and the
+remaining evidence steps succeed.
 
 The configuration contract uses:
 

--- a/docs/hosted_continuity_platform_contract.md
+++ b/docs/hosted_continuity_platform_contract.md
@@ -10,7 +10,7 @@ preferred and default continuity architecture.
     The OQ-OWN platform pivot merged in
     [PR #633](https://github.com/Azure/GPT-RAG/pull/633) at
     [`86b17b0`](https://github.com/Azure/GPT-RAG/commit/86b17b0af672edefe6842cba0f1a8ff77ab23038),
-    and the umbrella integration now pins UI `v2.6.0`, orchestrator `v4.0.0`,
+    and the umbrella integration now pins UI `v2.6.0`, orchestrator `v4.0.1`,
     ingestion `v2.7.0`, and AILZ `v2.5.0` at their exact release commits.
     Keep `HOSTED_CONTINUITY_ENABLED=false` until deployment proves the exact
     owner-binding role and protocol contract and records


### PR DESCRIPTION
## Summary

Update the hosted-agent release matrix and continuity contract pages to
record that the previously-documented HTTP 424 `session_not_ready`
session-readiness blocker has been root-caused and fixed:

- `gpt-rag-orchestrator`'s hosted entrypoint (`src/api/hosted_entrypoint.py`)
  imports `dependencies` before anything else in the process has "warmed up"
  `connectors`. `dependencies.py` eagerly imported `connectors.appconfig` at
  module level, and `connectors/__init__.py` eagerly imports several
  submodules that import `dependencies` back at module level -- a circular
  import that crashed the container's Python process before uvicorn could
  bind a port or serve `GET /readiness`, matching Foundry's documented
  `424 session_not_ready` failure mode exactly.
- Fixed in [gpt-rag-orchestrator#311](https://github.com/Azure/gpt-rag-orchestrator/pull/311),
  released as [`v4.0.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.1).
- Bumped the orchestrator pin shown on these pages from `v4.0.0` to `v4.0.1`
  (matching the umbrella `manifest.json` update in
  [Azure/GPT-RAG#642](https://github.com/Azure/GPT-RAG/pull/642)).

**This documentation continues to state that the integration is not
validated or shipped.** Fixing the crash is necessary but not sufficient --
the full network-isolated live validation matrix (protocol/role evidence,
two-user owner-binding negative tests, panel authorization, rollback) has
not been re-run and remains a documented open blocker. No warning banner is
removed or weakened; only the specific technical explanation of the prior
424 is updated from "unresolved" to "root-caused and fixed in code, live
validation still pending."

## Validation

- `python -m mkdocs build --strict --clean` -> clean, no warnings/errors.
- `git diff --check` -> no whitespace issues.
- Manual review of both edited pages for internal consistency (matrix table,
  warning banners, "must still validate" gate list).