### PR TITLE
fix(hosted-agent): disable azure_vm OTel resource detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,26 @@
   requires** — see the "Migration and rollback" note below for the current
   validation status.
 
+- **Hosted agent no longer crashes every live request with HTTP 500 under
+  Foundry's hosted-agent sandbox.** Live network-isolated validation (issue
+  #592) reproduced a deterministic HTTP 500 (`{"detail":"internal server
+  error"}`) on every `/responses` and `/invocations` call against a
+  successfully created, `active` hosted agent. Root-caused via Application
+  Insights exception traces to `azure-monitor-opentelemetry>=1.8`, which
+  `environ.setdefault`s `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` to
+  `azure_app_service,azure_vm` unless that variable is already present. The
+  Foundry hosted-agent sandbox is neither an Azure VM nor an App Service, so
+  the `azure_vm` detector's IMDS probe
+  (`http://169.254.169.254/metadata/instance/compute`) always fails with
+  connection-refused; that failure was observed to escape
+  `azure-ai-agentserver-core`'s own `try`/`except` around
+  `configure_observability()` and surface later as an unhandled exception
+  during live request handling. `hosted-agent/azure.yaml` now pins
+  `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS: ""` in the hosted agent's `env:`
+  block so `environ.setdefault` never applies it; this is a deployment
+  configuration fix in this repository, not a `gpt-rag-orchestrator` code
+  change. No behavior change for classic-mode telemetry.
+
 ### Migration and rollback
 
 No existing environment is migrated by this change: an already-provisioned

--- a/hosted-agent/azure.yaml
+++ b/hosted-agent/azure.yaml
@@ -40,3 +40,15 @@ services:
       # name for Foundry hosted agents (all FOUNDRY_*/AGENT_* vars, plus this one, are reserved
       # per the container-image-spec) and the Create Agent API rejects it if present. The
       # platform auto-injects telemetry wiring for hosted agents.
+      # OTEL_EXPERIMENTAL_RESOURCE_DETECTORS is set to empty to disable
+      # azure-monitor-opentelemetry's default Azure resource detectors ("azure_app_service",
+      # "azure_vm"). azure-monitor-opentelemetry>=1.8 unconditionally enables both via
+      # environ.setdefault(...) unless this variable is already present. The Foundry
+      # hosted-agent sandbox is neither an App Service nor a VM, so the "azure_vm" detector's
+      # IMDS probe (http://169.254.169.254/metadata/instance/compute) always fails with
+      # "Connection refused"; that failure was observed to escape the SDK's own
+      # try/except around configure_observability() and surface later as an unhandled
+      # exception during live request handling (HTTP 500 on every /responses and
+      # /invocations call). Setting this explicitly here -- before the SDK's
+      # environ.setdefault runs -- prevents both detectors from ever being registered.
+      OTEL_EXPERIMENTAL_RESOURCE_DETECTORS: ""

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -575,6 +575,21 @@ class LifecycleParityTests(unittest.TestCase):
         self.assertNotIn("InstrumentationKey=", content)
         self.assertNotIn("AccountKey=", content)
 
+    def test_hosted_manifest_disables_azure_vm_resource_detector(self) -> None:
+        # Live validation (see docs/adr history and issue #592) reproduced HTTP 500
+        # on every hosted /responses and /invocations call: azure-monitor-opentelemetry
+        # defaults OTEL_EXPERIMENTAL_RESOURCE_DETECTORS to "azure_app_service,azure_vm"
+        # via environ.setdefault(...) whenever the variable is not already present.
+        # The Foundry hosted-agent sandbox exposes neither IMDS (169.254.169.254) nor
+        # the App Service resource detector's expected environment, so both detectors
+        # fail; that failure was observed escaping the SDK's own configure_observability
+        # guard and crashing live request handling. Pinning this env var explicitly
+        # (to a value the SDK's environ.setdefault will not override) is the fix.
+        content = (ROOT / "hosted-agent" / "azure.yaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("OTEL_EXPERIMENTAL_RESOURCE_DETECTORS:", content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Hosted-agent live network-isolated validation (issue #592) reproduced a deterministic HTTP 500 on every hosted /responses and /invocations call against a successfully created, ctive hosted agent (image digest, agent creation, and readiness all passed).

## Root cause
Application Insights exception traces from the live hosted agent showed:

```
urllib3.exceptions.NewConnectionError: HTTPConnection(host='169.254.169.254', port=80): Failed to establish a new connection: [Errno 111] Connection refused
...
Max retries exceeded with url: /metadata/instance/compute?api-version=2017-12-01&format=json
```

zure-monitor-opentelemetry>=1.8 (pinned ==1.8.9 by gpt-rag-orchestrator v4.0.1) unconditionally does:

```python
environ.setdefault(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS, ",".join(_SUPPORTED_RESOURCE_DETECTORS))  # "azure_app_service,azure_vm"
```

unless that variable is already set. The Foundry hosted-agent sandbox is neither an Azure VM nor an App Service, so the zure_vm detector's IMDS probe always fails. That failure was observed escaping `azure-ai-agentserver-core`'s own `try`/`except` around `configure_observability()` (confirmed by inspecting the pinned `azure-ai-agentserver-core==2.0.0b1` wheel) and surfacing later as an unhandled exception during live request handling — crashing every hosted request with HTTP 500.

## Fix
Pin `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS: ""` in `hosted-agent/azure.yaml`'s `env:` block, so the SDK's `environ.setdefault` never applies the Azure VM/App Service detectors. This is a deployment-configuration fix in this repository only — no `gpt-rag-orchestrator` code change, no classic-mode telemetry behavior change (classic Container Apps already sets its own resource attributes independently and is unaffected by this hosted-agent-only file).

## Validation
- `python -m pytest tests/ -q` → 167 passed, 20 subtests (unaffected suite).
- New regression test `test_hosted_manifest_disables_azure_vm_resource_detector` asserts the pin is present.
- Reproduced live in a disposable, network-isolated validation resource group (sanitized; no environment/resource-group name recorded here) with a real hosted agent create → HTTP 500 (before) → root cause isolated via Application Insights exception query from the jumpbox → fix applied → hosted agent redeployed with the corrected `env:` block for live re-validation.

## Component versions (informational, not a release)
Targets the exact integration matrix already pinned on `develop`: UI v2.6.0, orchestrator v4.0.1, ingestion v2.7.0, AILZ v2.5.0.