### PR TITLE
fix(hosted-agent): disable statsbeat IMDS probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,7 +236,18 @@
   `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS: ""` in the hosted agent's `env:`
   block so `environ.setdefault` never applies it; this is a deployment
   configuration fix in this repository, not a `gpt-rag-orchestrator` code
-  change. No behavior change for classic-mode telemetry.
+  change. No behavior change for classic-mode telemetry. **Follow-up:** live
+  re-validation with that fix alone still reproduced the same IMDS failure
+  reaching request handling. Traced it to a second, independent source:
+  `azure-monitor-opentelemetry-exporter`'s own "statsbeat" SDK
+  self-monitoring subsystem (`_get_azure_compute_metadata` in
+  `statsbeat/_statsbeat_metrics.py`) probes the same IMDS endpoint to
+  attribute usage metrics to a resource-provider type, and is not gated by
+  `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS`. `hosted-agent/azure.yaml` now also
+  pins `APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL: "true"`. Statsbeat is
+  Microsoft's own SDK-usage telemetry, not GPT-RAG application telemetry;
+  disabling it does not affect Application Insights traces, logs, or metrics
+  for GPT-RAG requests.
 
 ### Migration and rollback
 

--- a/hosted-agent/azure.yaml
+++ b/hosted-agent/azure.yaml
@@ -52,3 +52,15 @@ services:
       # /invocations call). Setting this explicitly here -- before the SDK's
       # environ.setdefault runs -- prevents both detectors from ever being registered.
       OTEL_EXPERIMENTAL_RESOURCE_DETECTORS: ""
+      # APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL disables azure-monitor-opentelemetry-
+      # exporter's separate "statsbeat" SDK self-monitoring subsystem
+      # (azure.monitor.opentelemetry.exporter.statsbeat), which independently probes the
+      # same IMDS compute-metadata endpoint (_get_azure_compute_metadata in
+      # statsbeat/_statsbeat_metrics.py) to attribute usage metrics to a resource-provider
+      # type (App Service / Functions / AKS / VM). This path is separate from, and not
+      # gated by, OTEL_EXPERIMENTAL_RESOURCE_DETECTORS above, and live validation showed
+      # the IMDS failure still reaching request handling with only that first variable
+      # set. Statsbeat is Microsoft's own SDK-usage telemetry (not GPT-RAG application
+      # telemetry); disabling it does not affect Application Insights traces, logs, or
+      # metrics for GPT-RAG requests.
+      APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL: "true"

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -590,6 +590,20 @@ class LifecycleParityTests(unittest.TestCase):
         )
         self.assertIn("OTEL_EXPERIMENTAL_RESOURCE_DETECTORS:", content)
 
+    def test_hosted_manifest_disables_statsbeat_imds_probe(self) -> None:
+        # Live re-validation of the resource-detector fix above still
+        # reproduced the same IMDS failure reaching request handling:
+        # azure-monitor-opentelemetry-exporter's own "statsbeat" SDK
+        # self-monitoring subsystem probes the same IMDS endpoint
+        # independently of OTEL_EXPERIMENTAL_RESOURCE_DETECTORS. Disabling
+        # statsbeat entirely removes that second IMDS call.
+        content = (ROOT / "hosted-agent" / "azure.yaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            'APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL: "true"', content
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Follow-up to #644. Live re-validation of `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS: ""` alone still reproduced the identical HTTP 500 (`{"detail":"internal server error"}`) on the hosted agent's `/responses` endpoint after redeploying the agent with that fix (confirmed live via the Foundry data-plane API that the env var was actually present on the deployed agent version).

## Root cause (second, independent source)
Application Insights still showed the same IMDS trace after the first fix. Inspecting the pinned `azure-monitor-opentelemetry-exporter==1.0.0b56` wheel found a **second**, independent IMDS probe: its "statsbeat" SDK self-monitoring subsystem (`_get_azure_compute_metadata` in `azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py`) calls `http://169.254.169.254/metadata/instance/compute` to attribute SDK usage metrics to a resource-provider type (App Service / Functions / AKS / VM / unknown). This path is **not** gated by `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` — it is a separate mechanism entirely.

## Fix
Pin `APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL: "true"` (the SDK's documented statsbeat opt-out) in `hosted-agent/azure.yaml`'s `env:` block, alongside the existing `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS: ""` from #644. Statsbeat is Microsoft's own SDK-usage self-telemetry, not GPT-RAG application telemetry — disabling it has no effect on Application Insights traces/logs/metrics for actual GPT-RAG requests.

## Validation
- `python -m pytest tests/ -q` → 169 passed, 20 subtests.
- New regression test `test_hosted_manifest_disables_statsbeat_imds_probe`.
- Live re-validation in progress in the same disposable, network-isolated validation resource group used for #644 (sanitized; no environment/resource-group name recorded here): redeploying the hosted agent with both env vars and re-running the same direct `/responses` smoke request.
