### PR TITLE
chore: pin AI Landing Zone v2.5.1 (9cc5859)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "infra"]
 	path = infra
 	url = https://github.com/Azure/bicep-ptn-aiml-landing-zone.git
-	branch = v2.5.0
+	branch = v2.5.1
 	ignore = dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,19 @@
 - **Released AI Landing Zone pin.** The temporary AI Landing Zone `develop`
   source pin is replaced by released tag `v2.5.0` at exact commit
   `cacf418216ce7381d06263e0dd704a86b8a6f225`.
+- **AI Landing Zone pin updated to `v2.5.1`
+  (`9cc5859af5c8ab3b31709c9e16e0db11a170a404`).** Patch release: Azure
+  Firewall's `AllowContainerAppsPlatform` Application Rule now also allows the
+  Microsoft Foundry Agent Service's `agent365.svc.cloud.microsoft`
+  observability endpoint for hosted agents under network isolation. Live
+  Azure validation of a network-isolated deployment had shown the capability
+  host and hosted-agent runtime start successfully, but every hosted-agent
+  request then failed because the runtime's own post-startup
+  observability/telemetry call had no firewall allow rule. Strictly additive
+  allow-list change; deployments without `NETWORK_ISOLATION=true` and the
+  Azure Firewall are unaffected. `.gitmodules` and the `infra` submodule
+  gitlink are updated to match. See
+  [AILZ `v2.5.1`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.5.1).
 
 ### Fixed
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "tag": "unreleased",
   "repo": "https://github.com/azure/gpt-rag.git",
-  "ailz_tag": "v2.5.0",
-  "ailz_commit": "cacf418216ce7381d06263e0dd704a86b8a6f225",
+  "ailz_tag": "v2.5.1",
+  "ailz_commit": "9cc5859af5c8ab3b31709c9e16e0db11a170a404",
   "components": [
     {
       "name": "gpt-rag-ui",

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -23,11 +23,11 @@ class IntegrationPinTests(unittest.TestCase):
 
         self.assertEqual("unreleased", manifest["tag"])
         self.assertEqual(
-            "v2.5.0",
+            "v2.5.1",
             manifest["ailz_tag"],
         )
         self.assertEqual(
-            "cacf418216ce7381d06263e0dd704a86b8a6f225",
+            "9cc5859af5c8ab3b31709c9e16e0db11a170a404",
             manifest["ailz_commit"],
         )
         self.assertEqual(
@@ -55,7 +55,7 @@ class IntegrationPinTests(unittest.TestCase):
     def test_gitmodule_and_gitlink_match_landing_zone_integration_pin(self) -> None:
         gitmodules = (ROOT / ".gitmodules").read_text(encoding="utf-8")
         self.assertIn(
-            "branch = v2.5.0",
+            "branch = v2.5.1",
             gitmodules,
         )
 
@@ -67,7 +67,7 @@ class IntegrationPinTests(unittest.TestCase):
             text=True,
         )
         self.assertIn(
-            "cacf418216ce7381d06263e0dd704a86b8a6f225",
+            "9cc5859af5c8ab3b31709c9e16e0db11a170a404",
             completed.stdout.strip(),
         )
 


### PR DESCRIPTION
## Changed

- **Pin AI Landing Zone (AILZ) to `v2.5.1` at exact commit
  `9cc5859af5c8ab3b31709c9e16e0db11a170a404`.**

## Why

AILZ `v2.5.1` is a backward-compatible patch release: Azure Firewall's
`AllowContainerAppsPlatform` Application Rule now also allows the Microsoft
Foundry Agent Service's `agent365.svc.cloud.microsoft` observability endpoint
for hosted agents under network isolation. Live Azure validation of a
network-isolated deployment had shown the capability host and hosted-agent
runtime start successfully, but every hosted-agent request then failed
because the runtime's own post-startup observability/telemetry call had no
firewall allow rule. See
[AILZ `v2.5.1` release notes](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.5.1).

## What changed

- `manifest.json`: `ailz_tag` `v2.5.0` → `v2.5.1`; `ailz_commit`
  `cacf418216ce7381d06263e0dd704a86b8a6f225` →
  `9cc5859af5c8ab3b31709c9e16e0db11a170a404`.
- `.gitmodules`: `infra` submodule `branch` `v2.5.0` → `v2.5.1`.
- `infra` submodule gitlink updated to the same exact commit.
- `tests/test_release_contracts.py`: updated the two `IntegrationPinTests`
  assertions that hard-code the previous exact AILZ pin/gitlink
  (`test_manifest_contains_exact_integration_pins`,
  `test_gitmodule_and_gitlink_match_landing_zone_integration_pin`).
- `CHANGELOG.md`: new `[Unreleased]` bullet under `### Changed`.
- `docs` branch (separate commit/PR, linked below): updated the AILZ
  references in `docs/hosted_agent_release_matrix.md` and
  `docs/hosted_continuity_platform_contract.md`.

## Explicitly NOT in this PR

- **`gpt-rag-ui` and `gpt-rag-orchestrator` component pins are unchanged**
  (`v2.6.0` / `v4.0.1`, both already the current pins on `develop`).
  Investigation for this same task found gpt-rag-orchestrator `v4.0.1`'s
  hosted `/responses` route has an additional, independently confirmed gap:
  the pinned `azure-ai-agentserver-responses` host auto-activates its own
  network-bound Foundry storage provider whenever a caller's `store` is
  omitted (defaults to `true`) or explicit `true`, which fails with a
  platform `storage_error` under network isolation; only explicit
  `store: false` currently avoids it. A fix that forces `store: False`
  unconditionally is proposed in
  [Azure/gpt-rag-orchestrator#313](https://github.com/Azure/gpt-rag-orchestrator/pull/313)
  (open, full test suite passing, not yet released). Per this task's
  instructions, no umbrella release is published and no orchestrator pin is
  bumped here — pinning `v4.0.1` as "the fix" would be inaccurate, and
  pinning a not-yet-existing version would be fabricated. Once a maintainer
  reviews and releases that PR, a fast-follow PR should bump the
  `gpt-rag-orchestrator` pin/commit here and update the same
  `test_release_contracts.py` assertions.
- No umbrella release/tag (e.g. a new `v3.8.0`) is published by this PR.
- `gpt-rag-ui` needs **no code change** for the `store`/continuity contract:
  it already only calls the hosted agent through the `/invocations` custom
  protocol (never constructs a raw Responses `input`/`store` payload) and its
  continuity implementation
  (`hosted_conversation_store.py`/`hosted_continuity.py`) already uses only
  explicit Conversations/items REST calls with a server-derived
  `x-ms-user-identity` header (never a top-level `conversation` or
  `previous_response_id`, never client-supplied identity), with existing
  regression test coverage.

## Validation

- `python -m pytest tests/ -q` (after `git submodule update --init
  --recursive`): 169 passed, 20 subtests passed.

## Residual risk / follow-up

- Live re-validation of the network-isolation firewall fix and the pending
  `store`-contract fix has not been re-run as part of this PR.
- The orchestrator pin bump (and the umbrella release that would follow) is
  intentionally deferred pending human review/release of
  [gpt-rag-orchestrator#313](https://github.com/Azure/gpt-rag-orchestrator/pull/313).
