### PR TITLE
docs: pin orchestrator v4.0.2 in hosted-agent release matrix

### DIFF
--- a/docs/hosted_agent_release_matrix.md
+++ b/docs/hosted_agent_release_matrix.md
@@ -29,7 +29,7 @@ that remain fail closed.
 | Component | Release | Reviewed release commit | Relevant contract |
 | --- | --- | --- | --- |
 | GPT-RAG UI | [`v2.6.0`](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.6.0) | [`81d6515`](https://github.com/Azure/gpt-rag-ui/commit/81d6515d8fc365402e958e861b671af037a4cc75) | Hosted/no-panel is the fresh UI default when `CHAT_BACKEND` is absent; continuity and panel surfaces remain opt-in and fail closed. |
-| GPT-RAG orchestrator | [`v4.0.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.1) | [`7e22840`](https://github.com/Azure/gpt-rag-orchestrator/commit/7e22840ba0e96a5ce237cf2657795768f88e3955) | Canonical hosted `/responses` is stateless and requires caller-supplied ordered input. Fixes the `dependencies`/`connectors` circular import that crashed the hosted entrypoint on startup ([PR #311](https://github.com/Azure/gpt-rag-orchestrator/pull/311)). |
+| GPT-RAG orchestrator | [`v4.0.2`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.2) | [`c653b3e`](https://github.com/Azure/gpt-rag-orchestrator/commit/c653b3ec0a553f55244e197f3be993ad33ffe02f) | Canonical hosted `/responses` is stateless and requires caller-supplied ordered input. Fixes the `dependencies`/`connectors` circular import that crashed the hosted entrypoint on startup ([PR #311](https://github.com/Azure/gpt-rag-orchestrator/pull/311)), released in `v4.0.1`. Unconditionally forces `store: false` on every hosted `POST /responses` call and rejects `background: true` with HTTP 422 ([PR #313](https://github.com/Azure/gpt-rag-orchestrator/pull/313)), released in `v4.0.2`; see "Store false wire contract" below — this closes the code gap but the live network-isolated re-run remains pending. |
 | GPT-RAG ingestion | [`v2.7.0`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.7.0) | [`84b9277`](https://github.com/Azure/gpt-rag-ingestion/commit/84b927769ef0839110f2d68e3ca471e2260567cf) | Metadata-only operator overview and document/corpus curation APIs. |
 | AI Landing Zone | [`v2.5.1`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.5.1) | [`9cc5859`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/9cc5859af5c8ab3b31709c9e16e0db11a170a404) | Two-phase hosted-agent prerequisite/handoff support; both hosted flags default to `false`. Also allows the Foundry Agent Service's `agent365.svc.cloud.microsoft` observability endpoint through Azure Firewall under network isolation (`v2.5.1`, patch). |
 
@@ -63,7 +63,7 @@ remove them and then assume the UI fallback values are equivalent.
 
 ## Stateless hosted runtime contract
 
-Orchestrator `v4.0.1` performs no managed-Conversations create, read, append, or
+Orchestrator `v4.0.2` performs no managed-Conversations create, read, append, or
 delete operation in the hosted container. The caller supplies the complete,
 bounded, oldest-to-newest history on every request.
 
@@ -100,36 +100,39 @@ the UI call route with the protocol and role evidence it validates.
 
 ## Store false wire contract
 
-!!! warning "Additional confirmed gap; fix pending release and re-pin"
-    Exact-matrix live validation against a network-isolated deployment showed
-    that `POST /responses` succeeds when the caller sends `store: false`, but
-    an **omitted or `true`** `store` deterministically fails with a platform
-    `storage_error`. Root cause: the pinned
+!!! warning "Gap fixed and pinned; live network-isolated re-run still pending"
+    A prior exact-matrix live validation against a network-isolated deployment
+    showed that `POST /responses` succeeded when the caller sent
+    `store: false`, but an **omitted or `true`** `store` deterministically
+    failed with a platform `storage_error`. Root cause: the pinned
     `azure-ai-agentserver-responses==2.0.0b1` host auto-activates its own
     network-bound Foundry storage provider whenever the process detects it is
     running as a hosted agent and no explicit `store` override is supplied —
     true of every real deployment — and only calls that provider when the
     **caller's** `store` is true (an omitted `store` defaults to `true` per the
     Responses contract). Orchestrator `v4.0.1`'s already-stateless design
-    (previous section) hardcodes `store: False` only on the *separate, inner*
-    call the hosted strategy makes to the model; it does not touch the
+    (previous section) hardcoded `store: False` only on the *separate, inner*
+    call the hosted strategy makes to the model; it did not touch the
     *outer*, wire-level `store` field on the incoming request, which is the
     one the auto-activated provider reads.
 
-    A fix that forces `store: False` unconditionally on every hosted
+    The fix that forces `store: False` unconditionally on every hosted
     `POST /responses` call — regardless of what a caller sends or omits, for
     both streaming and non-streaming requests, and rejecting
-    `background: true` (which requires `store: true` in the pinned SDK) — is
-    proposed in
-    [orchestrator PR #313](https://github.com/Azure/gpt-rag-orchestrator/pull/313).
-    That PR is **open, not yet released, and not yet pinned** by this
-    umbrella's `manifest.json`, which still pins orchestrator `v4.0.1`
-    (the version with the gap). Do not describe the store contract as fixed,
-    validated, or safe under network isolation until: the PR is reviewed and
-    released; the umbrella manifest is re-pinned to the released version; and
-    the exact matrix (`store` unset / `true` / `false`, under
-    `NETWORK_ISOLATION=true`, streaming and non-streaming) is re-run live and
-    passes. This warning must remain until that re-run is recorded here.
+    `background: true` with HTTP 422 (it requires `store: true` in the pinned
+    SDK) — merged as
+    [orchestrator PR #313](https://github.com/Azure/gpt-rag-orchestrator/pull/313)
+    and released as
+    [`v4.0.2`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.2)
+    (commit
+    [`c653b3e`](https://github.com/Azure/gpt-rag-orchestrator/commit/c653b3ec0a553f55244e197f3be993ad33ffe02f),
+    722 tests passing upstream). This umbrella's `manifest.json` now pins that
+    released commit. **This is a code-level fix and re-pin, not yet a live
+    re-validation.** Do not describe the store contract as validated or safe
+    under network isolation until the exact matrix (`store` unset / `true` /
+    `false`, under `NETWORK_ISOLATION=true`, streaming and non-streaming) is
+    re-run live against this pin and passes. This warning must remain until
+    that re-run is recorded here.
 
 ## Delegated owner binding
 

--- a/docs/hosted_continuity_platform_contract.md
+++ b/docs/hosted_continuity_platform_contract.md
@@ -10,10 +10,11 @@ preferred and default continuity architecture.
     The OQ-OWN platform pivot merged in
     [PR #633](https://github.com/Azure/GPT-RAG/pull/633) at
     [`86b17b0`](https://github.com/Azure/GPT-RAG/commit/86b17b0af672edefe6842cba0f1a8ff77ab23038),
-    and the umbrella integration now pins UI `v2.6.0`, orchestrator `v4.0.1`,
+    and the umbrella integration now pins UI `v2.6.0`, orchestrator `v4.0.2`,
     ingestion `v2.7.0`, and AILZ `v2.5.1` at their exact release commits. See
     [the hosted-agent component release matrix](hosted_agent_release_matrix.md#store-false-wire-contract)
-    for a still-open `/responses` `store` gap and its pending fix.
+    for the `/responses` `store` gap, now fixed and pinned but still pending
+    live network-isolated re-validation.
     Keep `HOSTED_CONTINUITY_ENABLED=false` until deployment proves the exact
     owner-binding role and protocol contract and records
     `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED=true`, continuity endpoints


### PR DESCRIPTION
Updates the hosted-agent integration matrix and continuity platform contract page to reflect the orchestrator v4.0.2 pin (commit c653b3ec0a553f55244e197f3be993ad33ffe02f), which ships gpt-rag-orchestrator PR #313 (unconditional store:false on hosted /responses; HTTP 422 for background:true).

- Matrix table row and stateless-runtime-contract section now reference v4.0.2.
- Store-false wire-contract warning updated: code gap is fixed and re-pinned, but network-isolated live re-run of the store unset/true/false matrix remains pending — status intentionally kept validation-pending, not validated.
- Continuity platform contract page's pin reference updated to match.

Companion umbrella change: Azure/GPT-RAG#<pending> (feature/pin-orchestrator-v4-0-2 -> develop) bumps manifest.json and tests/test_release_contracts.py to the same commit.