### PR TITLE
fix: pin orchestrator v4.0.2 closing hosted store=false wire gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,29 @@
   Azure Firewall are unaffected. `.gitmodules` and the `infra` submodule
   gitlink are updated to match. See
   [AILZ `v2.5.1`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.5.1).
+- **Orchestrator pin updated to `v4.0.2`
+  (`c653b3ec0a553f55244e197f3be993ad33ffe02f`).** Closes the store-false wire
+  contract gap recorded in the hosted-agent integration matrix: the hosted
+  outer `POST /responses` now unconditionally forces `store: false` before
+  the pinned `azure-ai-agentserver-responses==2.0.0b1` host's auto-activated
+  `FoundryStorageProvider` can run, for both streaming and non-streaming
+  requests, regardless of what a caller sends or omits. Previously an omitted
+  or `true` `store` deterministically failed with a platform `storage_error`
+  under network isolation; only an explicit `store: false` succeeded.
+  `background: true` now returns an explicit HTTP 422 instead of the SDK's
+  generic 400, since it requires `store: true` and is no longer a reachable
+  combination once `store` is force-overridden. Released upstream as
+  [gpt-rag-orchestrator PR #313](https://github.com/Azure/gpt-rag-orchestrator/pull/313),
+  shipped in
+  [`v4.0.2`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.2)
+  (722 tests passing upstream). Classic (non-hosted, Cosmos-backed)
+  `/responses` and `/invocations` behavior are unaffected; the change is
+  scoped to the hosted entrypoint's `create_response` guard only. **This is a
+  code-level fix pinned into the umbrella manifest; it does not by itself
+  constitute the network-isolated live re-run of the exact `store`
+  unset/`true`/`false` matrix that the hosted-agent integration matrix
+  documentation still requires before the store-false contract can be
+  described as validated.**
 
 ### Fixed
 

--- a/manifest.json
+++ b/manifest.json
@@ -13,8 +13,8 @@
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v4.0.1",
-      "commit": "7e22840ba0e96a5ce237cf2657795768f88e3955"
+      "tag": "v4.0.2",
+      "commit": "c653b3ec0a553f55244e197f3be993ad33ffe02f"
     },
     {
       "name": "gpt-rag-ingestion",

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -31,7 +31,7 @@ class IntegrationPinTests(unittest.TestCase):
             manifest["ailz_commit"],
         )
         self.assertEqual(
-            ("v4.0.1", "7e22840ba0e96a5ce237cf2657795768f88e3955"),
+            ("v4.0.2", "c653b3ec0a553f55244e197f3be993ad33ffe02f"),
             (
                 components["gpt-rag-orchestrator"]["tag"],
                 components["gpt-rag-orchestrator"]["commit"],


### PR DESCRIPTION
Pins gpt-rag-orchestrator to v4.0.2 at exact release commit c653b3ec0a553f55244e197f3be993ad33ffe02f (previously v4.0.1 / 7e22840ba0e96a5ce237cf2657795768f88e3955).

## What changed
- manifest.json: gpt-rag-orchestrator tag/commit bumped to v4.0.2 / c653b3e.
- tests/test_release_contracts.py: exact-pin assertion updated to match.
- CHANGELOG.md [Unreleased]/Changed: new bullet documenting the v4.0.2 pin bump and the store=false fix it ships.

## Why
v4.0.2 ships upstream gpt-rag-orchestrator PR #313: the hosted outer POST /responses now unconditionally forces store: false before the pinned azure-ai-agentserver-responses==2.0.0b1 host's auto-activated FoundryStorageProvider can run (both streaming and non-streaming), closing the previously-documented gap where an omitted or true store deterministically failed with a platform storage_error under network isolation. background: true now returns an explicit HTTP 422 instead of the SDK's generic 400. Classic (non-hosted) /responses and /invocations behavior is unaffected.

## Unchanged
- AI Landing Zone stays pinned at v2.5.1 (already merged via #647, commit a0cb463) — not touched by this PR.
- gpt-rag-ui stays at v2.6.0.
- gpt-rag-ingestion stays at v2.7.0.

## Validation
- \python -m pytest -q tests/\: 169 passed, 20 subtests passed.
- \python -m pytest -q tests/ config/\ (full umbrella suite): 358 passed, 113 subtests passed.

## Docs
Companion docs-branch PR: #649 (updates docs/hosted_agent_release_matrix.md and docs/hosted_continuity_platform_contract.md). The matrix intentionally keeps 'validation-pending' status for the store contract — the live network-isolated store unset/true/false re-run has not been executed and this PR does not claim it has.

## Residual risk
No live Azure network-isolated re-validation was performed as part of this change (config/manifest pin only, following the same pattern as the prior v4.0.1 pin PR). The hosted-agent release matrix documentation explicitly retains its validation-pending warning until that re-run happens.