### PR TITLE
fix: harden hosted agent deployment

### DIFF
--- a/scripts/postProvision.ps1
+++ b/scripts/postProvision.ps1
@@ -296,18 +296,51 @@ function Set-GptRagAppConfiguration {
     # legacy "<prefix>-$nameSuffix" pattern. Discover actual names by listing resources
     # in the RG; fall back to the legacy derivation only when discovery finds nothing.
     function _resolveResource {
-        param([string]$Type, [string]$Fallback, [scriptblock]$Filter = $null)
+        param(
+            [string]$Type,
+            [string]$Fallback,
+            [scriptblock]$Filter = $null,
+            [string]$PreferredName = ''
+        )
         try {
             $json = az resource list -g $resourceGroup --resource-type $Type -o json 2>$null
             if ($LASTEXITCODE -ne 0 -or -not $json) { return $Fallback }
             $items = $json | ConvertFrom-Json
             if ($null -eq $items) { return $Fallback }
             if ($Filter) { $items = @($items | Where-Object $Filter) }
+            if (-not [string]::IsNullOrWhiteSpace($PreferredName)) {
+                $preferredMatches = @(
+                    $items | Where-Object {
+                        $_.name.Equals(
+                            $PreferredName,
+                            [StringComparison]::OrdinalIgnoreCase
+                        )
+                    }
+                )
+                if ($preferredMatches.Count -eq 1) {
+                    return $preferredMatches[0].name
+                }
+                throw "Configured resource '$PreferredName' did not uniquely match type '$Type' in resource group '$resourceGroup'."
+            }
             if ($items.Count -eq 1) { return $items[0].name }
             if ($items.Count -eq 0) { return $Fallback }
+            $locationMatches = @(
+                $items | Where-Object {
+                    $_.location -and $_.location.Equals(
+                        $location,
+                        [StringComparison]::OrdinalIgnoreCase
+                    )
+                }
+            )
+            if ($locationMatches.Count -eq 1) {
+                return $locationMatches[0].name
+            }
             Write-Warning "Multiple '$Type' resources matched; falling back to legacy name '$Fallback'."
             return $Fallback
         } catch {
+            if (-not [string]::IsNullOrWhiteSpace($PreferredName)) {
+                throw
+            }
             return $Fallback
         }
     }
@@ -316,17 +349,20 @@ function Set-GptRagAppConfiguration {
     $storageName = _resolveResource `
         -Type 'Microsoft.Storage/storageAccounts' `
         -Fallback "st$nameSuffix" `
-        -Filter { -not $_.name.StartsWith('staif') }
+        -Filter { -not $_.name.StartsWith('staif') } `
+        -PreferredName (Get-OptionalEnvValue 'AZURE_STORAGE_ACCOUNT_NAME')
     $foundryStorageName = _resolveResource `
         -Type 'Microsoft.Storage/storageAccounts' `
         -Fallback "staif$nameSuffix" `
-        -Filter { $_.name.StartsWith('staif') }
+        -Filter { $_.name.StartsWith('staif') } `
+        -PreferredName (Get-OptionalEnvValue 'AZURE_AI_FOUNDRY_STORAGE_ACCOUNT_NAME')
 
     # Key Vault: main workload vs AI Foundry KV (prefix "kv-ai")
     $keyVaultName = _resolveResource `
         -Type 'Microsoft.KeyVault/vaults' `
         -Fallback "kv-$nameSuffix" `
-        -Filter { -not $_.name.StartsWith('kv-ai') }
+        -Filter { -not $_.name.StartsWith('kv-ai') } `
+        -PreferredName (Get-OptionalEnvValue 'KEY_VAULT_NAME')
 
     # Cosmos: main vs AI Foundry-project cosmos (prefix "cosmos-aif")
     $cosmosName = if ($cosmosEnabled) {
@@ -340,12 +376,22 @@ function Set-GptRagAppConfiguration {
     $searchName = _resolveResource `
         -Type 'Microsoft.Search/searchServices' `
         -Fallback "srch-$nameSuffix" `
-        -Filter { -not $_.name.StartsWith('srch-aif') }
+        -Filter { -not $_.name.StartsWith('srch-aif') } `
+        -PreferredName (Get-OptionalEnvValue 'AZURE_AI_SEARCH_NAME')
 
     # AI Foundry Cognitive account (kind = AIServices) - LZ v2.2.0 deploys a single one
+    $foundryProjectResourceId = Get-OptionalEnvValue 'AZURE_AI_PROJECT_RESOURCE_ID'
+    $preferredFoundryName = Get-OptionalEnvValue 'AZURE_AI_FOUNDRY_NAME'
+    if (
+        -not $preferredFoundryName -and
+        $foundryProjectResourceId -match '/accounts/([^/]+)/projects/'
+    ) {
+        $preferredFoundryName = $matches[1]
+    }
     $foundryName = _resolveResource `
         -Type 'Microsoft.CognitiveServices/accounts' `
-        -Fallback "aif-$nameSuffix"
+        -Fallback "aif-$nameSuffix" `
+        -PreferredName $preferredFoundryName
 
     # Resolve the project through generic ARM discovery because the specialized
     # project-list command is absent from some supported Azure CLI versions.
@@ -395,7 +441,10 @@ function Set-GptRagAppConfiguration {
     # Container Registry / Container Apps Env / Log Analytics / App Insights
     $acrName = _resolveResource `
         -Type 'Microsoft.ContainerRegistry/registries' `
-        -Fallback "cr$nameSuffix"
+        -Fallback "cr$nameSuffix" `
+        -PreferredName (
+            (Get-OptionalEnvValue 'AZURE_CONTAINER_REGISTRY_ENDPOINT') -replace '\..*$', ''
+        )
     $containerEnvName = _resolveResource `
         -Type 'Microsoft.App/managedEnvironments' `
         -Fallback "cae-$nameSuffix"

--- a/scripts/preDeploy.ps1
+++ b/scripts/preDeploy.ps1
@@ -222,10 +222,30 @@ The preparation command builds the manifest-pinned image and stores only its imm
       Write-Error "Hosted orchestrator deployment failed."
       exit $LASTEXITCODE
     }
-    & azd ai agent invoke --protocol invocations --new-session --timeout 180 --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt "Reply with exactly: GPT-RAG hosted smoke OK." | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-      Write-Error "Hosted orchestrator smoke request failed; the classic chat path remains active."
-      exit $LASTEXITCODE
+    $smokePayloadPath = Join-Path ([IO.Path]::GetTempPath()) "gpt-rag-hosted-smoke-$([guid]::NewGuid().ToString('N')).json"
+    try {
+      [IO.File]::WriteAllText(
+        $smokePayloadPath,
+        '{"messages":[{"role":"user","content":"Reply with exactly: GPT-RAG hosted smoke OK."}]}',
+        [Text.UTF8Encoding]::new($false)
+      )
+      $smokeOutput = (
+        & azd ai agent invoke --protocol invocations --new-session --timeout 180 --environment "$($globalEnv.AZURE_ENV_NAME)" --no-prompt --input-file $smokePayloadPath 2>&1 |
+          Out-String
+      )
+      $smokeExitCode = $LASTEXITCODE
+      if (
+        $smokeExitCode -ne 0 -or
+        $smokeOutput -match '"type"\s*:\s*"error"' -or
+        $smokeOutput -notmatch [regex]::Escape('GPT-RAG hosted smoke OK.')
+      ) {
+        Write-Host $smokeOutput
+        Write-Error "Hosted orchestrator smoke request failed; the classic chat path remains active."
+        if ($smokeExitCode -ne 0) { exit $smokeExitCode }
+        exit 1
+      }
+    } finally {
+      Remove-Item -LiteralPath $smokePayloadPath -Force -ErrorAction SilentlyContinue
     }
     $hostedEnv = Get-AzdEnv -projectPath $hostedProject
   } finally {
@@ -252,18 +272,17 @@ The preparation command builds the manifest-pinned image and stores only its imm
   $env:HOSTED_AGENT_BASE_URL = $hostedBaseUrl
   $env:HOSTED_AGENT_RESOURCE_SCOPE = "$($globalEnv.HOSTED_AGENT_RESOURCE_SCOPE)"
 
-  $continuityVenv = Join-Path ([IO.Path]::GetTempPath()) "gpt-rag-continuity-$([guid]::NewGuid().ToString('N'))"
+  $continuityPackages = Join-Path ([IO.Path]::GetTempPath()) "gpt-rag-continuity-$([guid]::NewGuid().ToString('N'))"
   try {
-    & python -m venv $continuityVenv
-    if ($LASTEXITCODE -ne 0) { throw "Failed to create the continuity activation virtual environment." }
-    $continuityPython = Join-Path $continuityVenv 'Scripts/python.exe'
-    & $continuityPython -m pip install --quiet --disable-pip-version-check -r (Join-Path $repoRoot 'config/requirements.txt')
+    & python -m pip install --quiet --disable-pip-version-check --target $continuityPackages -r (Join-Path $repoRoot 'config/requirements.txt')
     if ($LASTEXITCODE -ne 0) { throw "Failed to install continuity activation dependencies." }
-    & $continuityPython -c "import os, runpy, sys; sys.path.insert(0, os.environ['GPT_RAG_REPO_ROOT']); sys.argv = ['config.continuity.setup', '--activate']; runpy.run_module('config.continuity.setup', run_name='__main__')"
+    $env:GPT_RAG_CONTINUITY_PACKAGES = $continuityPackages
+    & python -c "import os, runpy, sys; sys.path.insert(0, os.environ['GPT_RAG_REPO_ROOT']); sys.path.insert(0, os.environ['GPT_RAG_CONTINUITY_PACKAGES']); sys.argv = ['config.continuity.setup', '--activate']; runpy.run_module('config.continuity.setup', run_name='__main__')"
     if ($LASTEXITCODE -ne 0) { throw "Hosted continuity Responses 2.0.0 and exact agent-scope RBAC validation failed closed." }
   } finally {
-    if (Test-Path -LiteralPath $continuityVenv) {
-      Remove-Item -LiteralPath $continuityVenv -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item Env:GPT_RAG_CONTINUITY_PACKAGES -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $continuityPackages) {
+      Remove-Item -LiteralPath $continuityPackages -Recurse -Force -ErrorAction SilentlyContinue
     }
   }
 }

--- a/scripts/preDeploy.sh
+++ b/scripts/preDeploy.sh
@@ -199,10 +199,24 @@ if [[ "$hosted_mode" =~ ^(1|true|t|yes|y)$ ]]; then
     azd env set AZURE_AI_PROJECT_ID "$project_resource_id" --environment "$environment_name" --no-prompt >/dev/null || exit 1
     azd deploy orchestrator-agent --environment "$environment_name" --no-prompt
   ) || { red "Hosted orchestrator deployment failed."; exit 1; }
-  (
+  smoke_payload="$(mktemp)"
+  printf '%s\n' '{"messages":[{"role":"user","content":"Reply with exactly: GPT-RAG hosted smoke OK."}]}' >"$smoke_payload"
+  if ! smoke_output="$(
     cd "$hosted_project"
-    azd ai agent invoke --protocol invocations --new-session --timeout 180 --environment "$environment_name" --no-prompt "Reply with exactly: GPT-RAG hosted smoke OK." >/dev/null
-  ) || { red "Hosted orchestrator smoke request failed; the classic chat path remains active."; exit 1; }
+    azd ai agent invoke --protocol invocations --new-session --timeout 180 --environment "$environment_name" --no-prompt --input-file "$smoke_payload" 2>&1
+  )"; then
+    rm -f "$smoke_payload"
+    printf '%s\n' "$smoke_output"
+    red "Hosted orchestrator smoke request failed; the classic chat path remains active."
+    exit 1
+  fi
+  rm -f "$smoke_payload"
+  if printf '%s\n' "$smoke_output" | grep -Eq '"type"[[:space:]]*:[[:space:]]*"error"' ||
+     ! printf '%s\n' "$smoke_output" | grep -Fq 'GPT-RAG hosted smoke OK.'; then
+    printf '%s\n' "$smoke_output"
+    red "Hosted orchestrator smoke response did not complete successfully; the classic chat path remains active."
+    exit 1
+  fi
 
   invocations_endpoint="$(get_azd_value "$hosted_project" "AGENT_ORCHESTRATOR_AGENT_INVOCATIONS_ENDPOINT")"
   [ -n "$invocations_endpoint" ] || { red "Hosted deployment did not publish AGENT_ORCHESTRATOR_AGENT_INVOCATIONS_ENDPOINT."; exit 1; }
@@ -214,18 +228,17 @@ if [[ "$hosted_mode" =~ ^(1|true|t|yes|y)$ ]]; then
   export HOSTED_AGENT_BASE_URL="$hosted_base_url"
   export HOSTED_AGENT_RESOURCE_SCOPE="$hosted_scope"
 
-  continuity_venv="$(mktemp -d)"
+  continuity_packages="$(mktemp -d)"
   if ! (
-    python3 -m venv "$continuity_venv" &&
-    "$continuity_venv/bin/python" -m pip install --quiet --disable-pip-version-check -r "$repo_root/config/requirements.txt" &&
+    python3 -m pip install --quiet --disable-pip-version-check --target "$continuity_packages" -r "$repo_root/config/requirements.txt" &&
     cd "$repo_root" &&
-    "$continuity_venv/bin/python" -m config.continuity.setup --activate
+    PYTHONPATH="$repo_root:$continuity_packages${PYTHONPATH:+:$PYTHONPATH}" python3 -m config.continuity.setup --activate
   ); then
-    rm -rf "$continuity_venv"
+    rm -rf "$continuity_packages"
     red "Hosted continuity Responses 2.0.0 and exact agent-scope RBAC validation failed closed."
     exit 1
   fi
-  rm -rf "$continuity_venv"
+  rm -rf "$continuity_packages"
 fi
 
 # ---------- Iterate components ----------

--- a/scripts/preProvision.ps1
+++ b/scripts/preProvision.ps1
@@ -4,6 +4,14 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+function Invoke-PythonModule {
+    param(
+        [Parameter(Mandatory = $true)][string]$ModuleName,
+        [string[]]$Arguments = @()
+    )
+    & python -c "import os, runpy, sys; sys.path.insert(0, os.environ['GPT_RAG_REPO_ROOT']); sys.argv = ['$ModuleName'] + sys.argv[1:]; runpy.run_module('$ModuleName', run_name='__main__')" @Arguments
+}
+
 #-------------------------------------------------------------------------------
 # Mirror azd environment variables into process environment
 # This avoids persisting secrets in the User environment (registry), and makes
@@ -38,7 +46,11 @@ if (-not $expectedInfraCommit -or $expectedInfraCommit -notmatch '^[0-9a-f]{40}$
 # then fail closed if any unrelated submodule changes remain.
 Push-Location $projectRoot
 try {
-    & python -m config.deployment.infra_checkout --infra-dir $infraDir
+    $env:GPT_RAG_REPO_ROOT = (Resolve-Path $projectRoot).Path
+    Invoke-PythonModule -ModuleName 'config.deployment.infra_checkout' -Arguments @(
+        '--infra-dir',
+        $infraDir
+    )
     $infraCheckoutExitCode = $LASTEXITCODE
 } finally {
     Pop-Location
@@ -123,7 +135,7 @@ $parameterDestination = Join-Path $infraDir "main.parameters.json"
 Write-Host "Resolving GPT-RAG deployment topology..." -ForegroundColor Cyan
 Push-Location $projectRoot
 try {
-    $topologyOutput = & python -m config.deployment.topology
+    $topologyOutput = Invoke-PythonModule -ModuleName 'config.deployment.topology'
     $topologyExitCode = $LASTEXITCODE
 } finally {
     Pop-Location
@@ -159,10 +171,14 @@ try {
     ).components |
         Where-Object { $_.name -eq 'gpt-rag-orchestrator' } |
         Select-Object -ExpandProperty commit -First 1
-    & python -m config.deployment.composition `
-        --input $parameterSource `
-        --output $parameterDestination `
-        --hosted-source-commit $hostedSourceCommit
+    Invoke-PythonModule -ModuleName 'config.deployment.composition' -Arguments @(
+        '--input',
+        $parameterSource,
+        '--output',
+        $parameterDestination,
+        '--hosted-source-commit',
+        $hostedSourceCommit
+    )
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Error: GPT-RAG deployment mode composition failed." -ForegroundColor Red
         exit $LASTEXITCODE

--- a/scripts/prepareHostedDeployment.ps1
+++ b/scripts/prepareHostedDeployment.ps1
@@ -12,9 +12,9 @@ $ErrorActionPreference = 'Stop'
 $projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 Push-Location $projectRoot
 try {
-    & python -m config.deployment.hosted_prepare `
-        --manifest (Join-Path $projectRoot 'manifest.json') `
-        @args
+    $env:GPT_RAG_REPO_ROOT = $projectRoot
+    & python -c "import os, runpy, sys; sys.path.insert(0, os.environ['GPT_RAG_REPO_ROOT']); sys.argv = ['config.deployment.hosted_prepare'] + sys.argv[1:]; runpy.run_module('config.deployment.hosted_prepare', run_name='__main__')" `
+        --manifest (Join-Path $projectRoot 'manifest.json') @args
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -314,6 +314,69 @@ class LifecycleParityTests(unittest.TestCase):
             content,
         )
 
+    def test_postprovision_disambiguates_resources_by_explicit_name_or_location(
+        self,
+    ) -> None:
+        content = (ROOT / "scripts" / "postProvision.ps1").read_text(
+            encoding="utf-8-sig"
+        )
+
+        self.assertIn("$preferredMatches = @(", content)
+        self.assertIn("-PreferredName (Get-OptionalEnvValue 'KEY_VAULT_NAME')", content)
+        self.assertIn(
+            "-PreferredName (Get-OptionalEnvValue 'AZURE_AI_SEARCH_NAME')",
+            content,
+        )
+        self.assertIn("$foundryProjectResourceId -match '/accounts/([^/]+)/projects/'", content)
+        self.assertIn("$locationMatches = @(", content)
+        self.assertIn("[StringComparison]::OrdinalIgnoreCase", content)
+        self.assertIn("return $locationMatches[0].name", content)
+        self.assertIn("throw", content)
+
+    def test_windows_lifecycle_python_modules_support_jumpbox_python(self) -> None:
+        for relative_path in (
+            "scripts/preProvision.ps1",
+            "scripts/prepareHostedDeployment.ps1",
+        ):
+            content = (ROOT / relative_path).read_text(encoding="utf-8-sig")
+            self.assertIn("sys.path.insert(0", content, relative_path)
+            self.assertIn("runpy.run_module", content, relative_path)
+
+    def test_hosted_smoke_uses_json_invocations_contract(self) -> None:
+        for relative_path in (
+            "scripts/preDeploy.ps1",
+            "scripts/preDeploy.sh",
+        ):
+            content = (ROOT / relative_path).read_text(encoding="utf-8-sig")
+            self.assertIn("--input-file", content, relative_path)
+            self.assertIn(
+                '{"messages":[{"role":"user","content":',
+                content,
+                relative_path,
+            )
+            self.assertIn("GPT-RAG hosted smoke OK.", content, relative_path)
+            self.assertIn('"type"', content, relative_path)
+            self.assertIn('"error"', content, relative_path)
+        self.assertIn(
+            "$smokeOutput -notmatch",
+            (ROOT / "scripts" / "preDeploy.ps1").read_text(
+                encoding="utf-8-sig"
+            ),
+        )
+        self.assertIn(
+            "grep -Fq 'GPT-RAG hosted smoke OK.'",
+            (ROOT / "scripts" / "preDeploy.sh").read_text(
+                encoding="utf-8-sig"
+            ),
+        )
+        for relative_path in (
+            "scripts/preDeploy.ps1",
+            "scripts/preDeploy.sh",
+        ):
+            content = (ROOT / relative_path).read_text(encoding="utf-8-sig")
+            self.assertIn("--target", content, relative_path)
+            self.assertNotIn("-m venv", content, relative_path)
+
     def test_postprovision_preserves_search_user_assigned_identity(self) -> None:
         content = (ROOT / "scripts" / "postProvision.ps1").read_text(
             encoding="utf-8-sig"
@@ -372,6 +435,10 @@ class LifecycleParityTests(unittest.TestCase):
                     "-m config.deployment.topology\n" in content
                     or "-m config.deployment.topology)" in content
                     or "-m config.deployment.topology\"" in content
+                    or (
+                        "Invoke-PythonModule -ModuleName "
+                        "'config.deployment.topology'" in content
+                    )
                 )
 
         for name in (


### PR DESCRIPTION
## Summary
- make Windows jumpbox Python module execution independent of the Python launch directory
- select provisioned Azure resources deterministically by explicit AZD output or location
- send the correct JSON Invocations payload and fail on SSE error events or missing smoke success markers
- support jumpbox Python distributions without the venv module

## Validation
- real network-isolated azd provision/deploy in a retained Azure validation environment
- hosted Foundry agent smoke response succeeded
- Foundry IQ grounded retrieval returned the controlled answer with a Blob citation
- 361 tests and 113 subtests passed
- PowerShell and shell hook syntax checks passed