### PR TITLE
feat(hosted-agent): add opt-in GenAI message-content capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ### Added
 
+- **Opt-in GenAI message-content capture for the hosted agent.** Added
+  `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` to the `env:` block of
+  the `orchestrator-agent` service in `hosted-agent/azure.yaml`, wired to a new
+  `HOSTED_AGENT_CAPTURE_MESSAGE_CONTENT` azd variable that defaults to `false`.
+  When enabled, GenAI spans carry `gen_ai.input.messages`,
+  `gen_ai.output.messages`, and `gen_ai.system_instructions`, which is what makes
+  the Foundry portal's per-agent **Conversations** view render turns instead of
+  reporting *"No conversation turns found"*. The orchestrator reads this variable
+  from the process environment before any App Configuration resolution happens,
+  so it cannot be supplied as an App Configuration key and previously had no
+  supported installation path — a hosted-agent version created by `azd deploy`
+  would silently omit it. Operators now opt in per environment with
+  `azd env set HOSTED_AGENT_CAPTURE_MESSAGE_CONTENT true` followed by
+  `azd deploy`; `scripts/preDeploy.ps1` copies the root `.azure` environment into
+  the `hosted-agent` azd project, so the value propagates automatically. The
+  default stays `false` because capturing message content ships user prompts and
+  model answers to Application Insights, which is a data-privacy decision each
+  deployment has to make for itself. Use only this variable, never the legacy
+  `AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED`: the Azure AI instrumentor
+  treats disagreeing values as a configuration error.
+
 - **Hosted administrative panel platform contract (issue #611, ADR-0004).**
   Published the versioned `contracts/conversations-panel-v1` JSON Schema
   (+ `.sha256` pin) covering the user-facing history/messages/feedback/delete

--- a/hosted-agent/azure.yaml
+++ b/hosted-agent/azure.yaml
@@ -64,3 +64,23 @@ services:
       # telemetry); disabling it does not affect Application Insights traces, logs, or
       # metrics for GPT-RAG requests.
       APPLICATIONINSIGHTS_STATSBEAT_DISABLED_ALL: "true"
+      # OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT controls whether GenAI spans carry
+      # the actual prompt and completion text (gen_ai.input.messages, gen_ai.output.messages,
+      # gen_ai.system_instructions). It is what makes the Foundry portal's per-agent
+      # "Conversations" view render conversation turns instead of "No conversation turns
+      # found". src/api/hosted_entrypoint.py (_configure_host_observability) reads it straight
+      # from the process environment before any App Configuration resolution happens, so it
+      # cannot be supplied as an App Configuration key -- it has to be a hosted-agent env var,
+      # which means it has to be declared here.
+      #
+      # It defaults to "false" deliberately: capturing message content ships user prompts and
+      # model answers to Application Insights, which is a data-privacy decision each deployment
+      # has to make for itself. Opt in per environment with:
+      #     azd env set HOSTED_AGENT_CAPTURE_MESSAGE_CONTENT true
+      #     azd deploy
+      # Note that environment variables are baked into a hosted-agent *version* and are
+      # immutable once that version exists, so flipping this value always creates a new version
+      # (the image digest can stay the same). Use only this variable, not the legacy
+      # AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED: when both are set and disagree, the
+      # Azure AI instrumentor treats it as a configuration error.
+      OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "${HOSTED_AGENT_CAPTURE_MESSAGE_CONTENT=false}"


### PR DESCRIPTION
## What

Adds `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` to the `env:` block of the `orchestrator-agent` service in `hosted-agent/azure.yaml`, wired to a new `HOSTED_AGENT_CAPTURE_MESSAGE_CONTENT` azd variable that defaults to `false`.

## Why

The Foundry portal's per-agent **Conversations** view reports *"No conversation turns found"* unless GenAI spans carry the prompt and completion text (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`). Those `invoke_agent` spans are always emitted; only the message-content attributes were missing.

That capture is gated by `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`, which `src/api/hosted_entrypoint.py` reads straight from the process environment **before** any App Configuration resolution happens. It therefore cannot be an App Configuration key, and it had **no supported installation path**: the `env:` block carried three of the four variables the deployed hosted-agent version actually needs, so any version created by `azd deploy` silently omitted this one. The only way to set it was a manual `PUT` against the versions API.

## Default is `false` on purpose

Capturing message content ships user prompts and model answers to Application Insights. That is a data-privacy decision each deployment has to make for itself, so this ships as opt-in:

```
azd env set HOSTED_AGENT_CAPTURE_MESSAGE_CONTENT true
azd deploy
```

`scripts/preDeploy.ps1` copies the root `.azure` environment into the `hosted-agent` azd project, so a single `azd env set` at the root is enough.

## Validation

Flip test against a live network-isolated deployment:

| Step | Action | Result |
| --- | --- | --- |
| baseline | — | version 8, `capture=true` |
| 1 | `azd env set … false` + `azd deploy` | **version 9 created, `capture=false`** |
| 2 | `azd env set … true` + `azd deploy` | **version 10 created, `capture=true`** |

All three versions share the same image digest, confirming an env-var change creates a new agent version without triggering a rebuild. Version 10 smoke test returns HTTP 200 with retrieval intact. `azd deploy` is idempotent when nothing changes (an earlier run reused version 8 rather than creating a new one).

## Notes

- Use only this variable, never the legacy `AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED`: the Azure AI instrumentor treats disagreeing values as a configuration error.
- Docs are in a companion PR against the `docs` branch.
- Follow-up worth tracking separately: `hostedAgentConfigurationType` in `infra/main.bicep` does not model hosted-agent environment variables, so `infra/` and `hosted-agent/azure.yaml` can drift without detection.
