### PR TITLE
release: v3.8.1

### DIFF
--- a/.github/workflows/block-pr-to-main.yml
+++ b/.github/workflows/block-pr-to-main.yml
@@ -1,7 +1,7 @@
 name: Block PRs to main
 
-# This workflow blocks pull requests that target the main branch.
-# Contributors must target the develop branch instead.
+# This workflow blocks pull requests that target the main branch, except for
+# release branches. Contributors must target the develop branch instead.
 # Uses pull_request_target for security (does not check out PR code).
 
 on:
@@ -10,6 +10,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - edited
     branches:
       - main
 
@@ -23,8 +24,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Release branches are the documented path to main, so they are exempt.
+      # See .github/copilot-instructions.md for the full branch policy.
+      - name: Validate source branch
+        id: branch-policy
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$HEAD_REF" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Post comment on open or reopen
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        if: steps.branch-policy.outputs.allowed != 'true' && (github.event.action == 'opened' || github.event.action == 'reopened')
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
@@ -37,6 +51,8 @@ jobs:
             You can do this by:
             1. Clicking **Edit** at the top-right of this PR
             2. Changing the base branch from \`main\` to \`develop\`
+
+            Release pull requests are the exception: a branch named exactly \`release/<MAJOR>.<MINOR>.<PATCH>\` may target \`main\`.
 
             For more information, see our [Contributing Guide](https://azure.github.io/GPT-RAG/contributing/).
 
@@ -51,6 +67,7 @@ jobs:
             });
 
       - name: Fail the workflow
+        if: steps.branch-policy.outputs.allowed != 'true'
         run: |
-          echo "::error::Pull requests to the main branch are not allowed. Please change the base branch to develop."
+          echo "::error::Only release branches named exactly 'release/<MAJOR>.<MINOR>.<PATCH>' may target 'main'. Please change the base branch to develop."
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [v3.8.1] - 2026-09-03
+
+### Fixed
+
+- **Repinned `gpt-rag-orchestrator` from `v4.1.0` to
+  [`v4.1.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.1.1),
+  which restores `azd deploy`.** The orchestrator `Dockerfile` builds its
+  `frontend/` SPA in the first stage, so the frontend build failing fails the
+  whole image. `v4.1.0` could not be built at all — building `v4.0.2` exits
+  `0` while building `v4.1.0` exits `1` — which meant every clean
+  deployment of `v3.8.0` failed at the orchestrator image build.
+
+  Three unrelated dependency bumps had been merged into the orchestrator without
+  any CI job that builds the frontend, and together they broke it: `react` was
+  raised to 19 while `react-dom` stayed on 18 (fatal `ERESOLVE`);
+  `@azure/msal-react` was pinned to `^5.7.0`, a version since **unpublished
+  from npm** that now returns `E404`; and `tailwindcss` was raised from 3 to
+  4 without the required PostCSS and CSS migration. `v4.1.1` fixes all three
+  and adds the missing `frontend build` CI job.
+
+  No GPT-RAG configuration, parameter, or infrastructure change is involved. The
+  UI, ingestion, and AI Landing Zone pins are unchanged from `v3.8.0`.
+
+- **Allowed `release/*` branches to target `main` in
+  `.github/workflows/block-pr-to-main.yml`.** The guard rejected every pull
+  request into `main` unconditionally, including the release pull requests the
+  documented process requires, so each release merge needed an administrator
+  override. It now permits `^release/[0-9]+\.[0-9]+\.[0-9]+$`, matching the
+  equivalent guard already present in the component repositories, and reacts to
+  `edited` events so retargeting a pull request re-evaluates the rule.
 ## [v3.8.0] - 2026-09-03
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "tag": "v3.8.0",
+  "tag": "v3.8.1",
   "repo": "https://github.com/azure/gpt-rag.git",
   "ailz_tag": "v2.5.1",
   "ailz_commit": "9cc5859af5c8ab3b31709c9e16e0db11a170a404",
@@ -13,8 +13,8 @@
     {
       "name": "gpt-rag-orchestrator",
       "repo": "https://github.com/azure/gpt-rag-orchestrator.git",
-      "tag": "v4.1.0",
-      "commit": "935f8ed990020cc3be777dd4fe1664d7e131a3c8"
+      "tag": "v4.1.1",
+      "commit": "9b64a5b962067161cb55252c6e0917a2738ba984"
     },
     {
       "name": "gpt-rag-ingestion",


### PR DESCRIPTION
## Why

GPT-RAG `v3.8.0` pins `gpt-rag-orchestrator` at `v4.1.0`, which **cannot be
built**. The orchestrator `Dockerfile` builds its `frontend/` SPA in the first
stage, so a frontend build failure fails the whole image and therefore
`azd deploy`. Building `v4.0.2` exits `0`; building `v4.1.0` exits `1`.
Every clean deployment of `v3.8.0` fails at the orchestrator image build today.

[`gpt-rag-orchestrator v4.1.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.1.1)
fixes it. This pull request repins the manifest.

## Changes

| File | Change |
| --- | --- |
| `manifest.json` | `tag` `v3.8.0` → `v3.8.1`; `gpt-rag-orchestrator` `v4.1.0` → `v4.1.1` (commit `9b64a5b9`) |
| `CHANGELOG.md` | new `## [v3.8.1] - 2026-09-03` section |

Everything else is byte-identical to `v3.8.0`: `gpt-rag-ui v2.6.1`,
`gpt-rag-ingestion v2.7.1`, `ailz_tag v2.5.1` / `ailz_commit 9cc5859a`, and
`.gitmodules` `infra.branch = v2.5.1`. No configuration, parameter, or
infrastructure change is involved.

## Also included

Commit `0658317b` (already on `develop`, from #669) allows `release/*`
branches to target `main` in `.github/workflows/block-pr-to-main.yml`. The
guard previously rejected every pull request into `main` unconditionally,
including the release pull requests the documented process requires, so each
release merge needed an administrator override. This pull request is the first
to pass that guard on its own.

## Validation

- `manifest.json` `ailz_tag`, `ailz_commit`, and `.gitmodules`
  `infra.branch` all still identify AI Landing Zone `v2.5.1`.
- `v4.1.1` frontend validated: `npm install` and `npm run build` exit `0`;
  the new `frontend build` CI job green on
  [gpt-rag-orchestrator#344](https://github.com/Azure/gpt-rag-orchestrator/pull/344).