### PR TITLE
docs(changelog): reference #592 as tracking, not as closed by v3.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   App Configuration inside the ASGI `lifespan` and gated on the resolved mode.
   Classic deployments are unaffected — the admin surface keeps mounting exactly
   as before — and hosted deployments without a panel now correctly return 404.
-  Closes [#592](https://github.com/Azure/GPT-RAG/issues/592).
+  Tracked under [#592](https://github.com/Azure/GPT-RAG/issues/592), the
+  umbrella issue for hosted deployment-mode validation.
 
   The same pin also hardens the new `/api/panel/*` API: startup validation now
   fails closed on missing Entra ID configuration rather than only on missing


### PR DESCRIPTION
The `v3.8.3` changelog entry stated `Closes #592`.

Issue [#592](https://github.com/Azure/GPT-RAG/issues/592) is *"[Hosted agents 09] Validate the three deployment modes end to end"* — the umbrella tracking issue for hosted deployment-mode work — and it is already closed. The `v3.8.3` repin is part of that body of work but does not close it.

This changes the wording to a tracking reference, matching how the same issue is already referenced:

- elsewhere in this changelog (`Live network-isolated validation (issue #592)`), and
- throughout `gpt-rag-ingestion`'s changelog (`([Azure/GPT-RAG#592](...))`).

The published GitHub Release notes for `v3.8.3` were corrected identically, and re-verified afterwards: 21 lines, 3 `##` headings, 6 table rows, 0 private environment names.

No functional, manifest, or pin change.
