### PR TITLE
docs: document hosted version rollback by digest reversal

### DIFF
--- a/docs/hosted_agent_release_matrix.md
+++ b/docs/hosted_agent_release_matrix.md
@@ -386,7 +386,50 @@ The configuration contract uses:
 | `PANEL_CONVERSATION_ENUMERATION_MODE` | `owner_index` |
 | `PANEL_CURSOR_TTL_SECONDS` / `PANEL_OVERVIEW_MIN_CARDINALITY` | `600` / `5` |
 
-Rollback is a deployment/configuration operation, never a request-time retry:
+Rollback is a deployment/configuration operation, never a request-time retry.
+It has two independent forms. Choose the narrowest one that resolves the
+regression: reverting the image version keeps the hosted topology, while
+topology rollback abandons hosted mode entirely.
+
+### Version rollback: stay hosted, serve the previous image
+
+A hosted agent version is immutable and serves 100% of the traffic, with no
+canary and no traffic splitting. Rolling back therefore means switching the
+endpoint back to a digest that was already published and validated. Revert
+only the image identity and leave the topology untouched:
+
+```powershell
+pwsh scripts/prepareHostedDeployment.ps1 --image-version sha256:<previous-digest>
+azd provision
+azd deploy
+```
+
+On POSIX systems, use `scripts/prepareHostedDeployment.sh` with the same
+argument. `--image-version` takes a canonical immutable digest, skips the image
+build entirely, and clears generated-image provenance by writing an empty
+`HOSTED_AGENT_IMAGE_SOURCE_COMMIT` and
+`HOSTED_AGENT_IMAGE_STARTUP_COMMAND_SHA256`. The second provision materializes
+the deploy handoff for the reverted digest.
+
+Clearing that provenance is required, not cosmetic. A *generated* digest is
+validated against the orchestrator commit pinned in `manifest.json`; a mismatch
+fails composition with `DeploymentTopologyError` before any resource changes,
+which is what stops a half-reverted environment from reaching Azure. An
+*operator-supplied* digest carries no generated provenance, so that coherence
+check does not apply and the older image is accepted while `manifest.json`
+keeps pointing at the newer pin. Do not work around the check by hand-editing
+`HOSTED_AGENT_IMAGE_VERSION` while leaving a stale source commit in place.
+
+Because provenance is cleared, the environment no longer records which commit
+produced the running image. Record the digest and its originating release
+outside the environment before switching, so the reverted state stays
+auditable.
+
+To return to the manifest-pinned build, re-run the preparation step without
+`--image-version`. A digest whose source commit no longer matches the manifest
+is rebuilt from the current pin rather than reused.
+
+### Topology rollback: leave hosted mode
 
 1. set `HOSTED_CONTINUITY_ENABLED=false`;
 2. select `DEPLOYMENT_TOPOLOGY=classic` and `CHAT_BACKEND=orchestrator`;


### PR DESCRIPTION
## Why

`ADR-0001` records the hosted agent version model as immutable: one version
serves 100% of the traffic, with no canary and no traffic splitting. Its
declared mitigation for that risk is to *"have the rollback by version reversal
documented"*.

That documentation did not exist. `hosted_agent_release_matrix.md` described
only **topology** rollback — leaving hosted mode for classic — so an operator
hitting a regression on a hosted version had no documented way to return to a
previously validated image while staying hosted.

## What changed

Split the rollback section into the two independent forms and document the
missing one.

**Version rollback** uses the already-implemented and tested path:

```
pwsh scripts/prepareHostedDeployment.ps1 --image-version sha256:<previous-digest>
azd provision
azd deploy
```

The page now also explains the part that is easy to get wrong. `--image-version`
clears generated-image provenance, and that is required rather than cosmetic:

- a **generated** digest is validated against the orchestrator commit pinned in
  `manifest.json`, and a mismatch fails composition with
  `DeploymentTopologyError` before any resource changes;
- an **operator-supplied** digest carries no generated provenance, so the
  coherence check does not apply and the older image is accepted while
  `manifest.json` keeps pointing at the newer pin.

Without that explanation an operator would reasonably hand-edit
`HOSTED_AGENT_IMAGE_VERSION`, leave a stale source commit behind, and hit the
composition error with no stated cause. The page now warns against exactly that.

It also records the resulting audit gap — once provenance is cleared the
environment no longer states which commit produced the running image, so the
digest and its originating release must be recorded outside the environment —
and how to return to the manifest-pinned build.

## Evidence

Behaviour documented here is the shipped behaviour, not a proposal:

| Claim | Source |
| --- | --- |
| `--image-version` skips build and clears provenance | `config/deployment/hosted_prepare.py` (argument help, and the override branch that returns a null source commit) |
| Empty provenance is persisted | `config/deployment/hosted_prepare.py` `persist_digest` |
| Coherence check only fires for generated digests | `config/deployment/composition.py` — the guard requires a non-empty generated source commit |
| Operator-supplied digest is reused without rebuild | `config/deployment/hosted_prepare.py` — current digest with no generated commit |
| Stale generated digest is rebuilt from the manifest pin | `tests/test_hosted_prepare.py::test_stale_generated_digest_rebuilds_current_manifest_pin` |
| Override clears provenance | `tests/test_hosted_prepare.py::test_command_override_clears_stale_generated_provenance` |

Docs-only change; no runtime or infrastructure behaviour is modified.

Refs: Azure/GPT-RAG#597
