### PR TITLE
docs: label the architecture diagram as the classic topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ Head to the documentation site for the complete guides:
 ## Architecture
 
 ![Zero Trust Architecture](media/architecture_zero_trust.png)
-*Zero-Trust Architecture*
+*Zero-Trust Architecture, classic topology*
+
+The diagram above shows the classic topology. A fresh deployment now defaults
+to the hosted topology, where the orchestrator is served by the Foundry Agent
+Service from an immutable image digest, and neither the orchestrator Container
+App nor Cosmos DB is provisioned. See
+[Hosted conversation continuity](#hosted-conversation-continuity) below.
 
 ### Hosted conversation continuity
 


### PR DESCRIPTION
`README.md` embeds the Zero-Trust architecture diagram and, eleven lines below
it, states that the hosted container receives "no Cosmos DB in the no-panel
topology". The figure draws Cosmos DB and an orchestrator Container App, so the
page contradicted itself.

A fresh deployment resolves to `HOSTED_NO_PANEL`
(`config/deployment/composition.py` L255), where `deployCosmosDb` is false
(L565-569) and `service_name == "orchestrator"` is filtered out of
`containerAppsList` (L624-629).

This labels the existing figure as the classic topology and points readers to
the **Hosted conversation continuity** section directly below it. The image is
not modified.

Redrawing the diagram is tracked in #683, which also records the remaining
inaccuracies (MCP Container App, the mislabelled build agent, the missing
image-lifecycle path) and the fact that `media/` holds no editable source file.