### PR TITLE
docs: repin legacy diagram handoff to v3.8.3

### DIFF
--- a/docs/architecture_legacy_diagram_handoff.md
+++ b/docs/architecture_legacy_diagram_handoff.md
@@ -7,11 +7,11 @@ chat-runtime views.
 
 !!! warning "Release status"
     Draw the hosted/no-panel path as the **supported fresh-deployment default**
-    and label it **shipped in v3.8.2; continuity off/503 pending evidence**.
+    and label it **shipped in v3.8.3; continuity off/503 pending evidence**.
     Label hosted-panel as **supported only when explicitly selected; history and
     operator APIs off/503 pending evidence**. UI `v2.6.2`, orchestrator
-    `v4.1.1`, ingestion `v2.7.2`, and AILZ `v2.5.1` are pinned by
-    [GPT-RAG `v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2).
+    `v4.1.1`, ingestion `v2.7.3`, and AILZ `v2.5.1` are pinned by
+    [GPT-RAG `v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3).
 
 ## Shapes and labels
 


### PR DESCRIPTION
Repins the legacy diagram handoff from umbrella `v3.8.2` to `v3.8.3`.

`manifest.json` on `main` pins `v3.8.3` with ingestion `v2.7.3`. The handoff
still instructed the diagram author to label the hosted/no-panel path as
*shipped in v3.8.2* and listed ingestion `v2.7.2`.

| Token | Before | After |
| --- | --- | --- |
| Umbrella (label + release link) | `v3.8.2` | `v3.8.3` |
| Ingestion | `v2.7.2` | `v2.7.3` |
| UI | `v2.6.2` | unchanged |
| Orchestrator | `v4.1.1` | unchanged |
| AILZ | `v2.5.1` | unchanged |

UI, orchestrator, and AILZ pins are byte-identical between `v3.8.2` and
`v3.8.3` per the umbrella release notes, so they are left alone.

No diagram artwork changes here. `media/GPT-RAG.vsdx` and
`media/architecture_zero_trust.png` were last updated on 2026-06-04 and still
depict the classic topology; that drift is tracked in #683.

### Out of scope, but found while verifying

Eight other pages on `docs` still cite `v3.8.2` / `v2.7.2`: `architecture.md`,
`deploy.md`, `hosted_agent_release_matrix.md`,
`hosted_continuity_platform_contract.md`, `howto_authentication.md`,
`howto_dashboard_signin.md`, `services_orchestrator.md`, and `whatisnew.md`.
Left untouched deliberately to keep this change reviewable.

Refs #683