### PR TITLE
docs: repin published pages to umbrella v3.8.3 and document admin surface gating

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,9 +7,9 @@ deployments retain their persisted topology during upgrade. Network isolation,
 enterprise integration, public ingress, and optional AI capabilities remain
 separate choices.
 
-!!! info "Shipped in GPT-RAG v3.8.2"
-    [GPT-RAG `v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2)
-    pins UI `v2.6.2`, orchestrator `v4.1.1`, ingestion `v2.7.2`, and AILZ
+!!! info "Shipped in GPT-RAG v3.8.3"
+    [GPT-RAG `v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3)
+    pins UI `v2.6.2`, orchestrator `v4.1.1`, ingestion `v2.7.3`, and AILZ
     `v2.5.1` at their exact release commits, and validates the hosted chat path
     end to end. Classic, hosted/no-panel, and explicitly selected hosted-panel
     are supported topologies. Continuity, user-history, owner-binding

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ explicitly through `CHAT_BACKEND=orchestrator`.
 
 ### Chat runtime modes
 
-!!! info "Shipped in GPT-RAG v3.8.2"
-    [GPT-RAG `v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2)
-    pins UI `v2.6.2`, orchestrator `v4.1.1`, ingestion `v2.7.2`, and AILZ
+!!! info "Shipped in GPT-RAG v3.8.3"
+    [GPT-RAG `v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3)
+    pins UI `v2.6.2`, orchestrator `v4.1.1`, ingestion `v2.7.3`, and AILZ
     `v2.5.1` at their exact release commits, and validates the hosted chat path
     end to end. Classic, hosted/no-panel, and explicitly selected hosted-panel
     are supported topologies. Continuity, user-history, owner-binding
@@ -336,12 +336,15 @@ classic panel data.
 
 #### Current release
 
-[GPT-RAG `v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2) is the
+[GPT-RAG `v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3) is the
 latest published umbrella release. It pins UI `v2.6.2`, orchestrator `v4.1.1`,
-ingestion `v2.7.2`, and AI Landing Zone `v2.5.1`, and it makes hosted/no-panel
-the default topology for genuinely fresh deployments. The previous classic-only
+ingestion `v2.7.3`, and AI Landing Zone `v2.5.1`, and it makes hosted/no-panel
+the default topology for genuinely fresh deployments. It repins ingestion only:
+`v2.7.3` stops the data-ingestion administrative surface from being mounted in
+deployments that did not ask for it. UI, orchestrator, and AI Landing Zone are
+unchanged from `v3.8.2`. The previous classic-only
 umbrella release was `v3.7.0`, pinning UI `v2.3.13`, orchestrator `v3.8.0`,
-ingestion `v2.5.0`, and AI Landing Zone `v2.3.0`; do not mix the `v3.8.2`
+ingestion `v2.5.0`, and AI Landing Zone `v2.3.0`; do not mix the `v3.8.3`
 topology and configuration contract into the older `v3.7.0` hooks or manifest.
 
 !!! danger "Do not deploy `v3.8.0` or `v3.8.1`"

--- a/docs/hosted_agent_release_matrix.md
+++ b/docs/hosted_agent_release_matrix.md
@@ -1,7 +1,7 @@
 # Hosted-agent integration matrix
 
 This page records the exact hosted-agent component releases pinned by the
-GPT-RAG umbrella release [`v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2)
+GPT-RAG umbrella release [`v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3)
 and the independent evidence gates that remain fail closed.
 
 !!! danger "Do not deploy `v3.8.0` or `v3.8.1`"
@@ -9,13 +9,13 @@ and the independent evidence gates that remain fail closed.
     `v3.8.0` nor `v3.8.1` reaches a running deployment: `v3.8.0` pins
     orchestrator `v4.1.0`, whose `frontend/` SPA build fails, and `v3.8.1`
     repairs that build but still pins ingestion `v2.7.1`, which crashes on boot
-    after a successful image build. The matrix below is the `v3.8.2`
+    after a successful image build. The matrix below is the `v3.8.3`
     combination, which deploys end to end.
 
-!!! warning "Pins are shipped in umbrella `v3.8.2`; evidence gates remain fail closed"
+!!! warning "Pins are shipped in umbrella `v3.8.3`; evidence gates remain fail closed"
     The umbrella `manifest.json` pins all four exact releases below and explicit
     `hosted-panel` topology selection is supported. The manifest's umbrella tag
-    is `v3.8.2`; use only a GPT-RAG source or release that contains these pins
+    is `v3.8.3`; use only a GPT-RAG source or release that contains these pins
     rather than combining component tags independently.
     `HOSTED_CONTINUITY_ENABLED`, `PANEL_HISTORY_ENABLED`,
     `PANEL_HISTORY_OWNER_BINDING_VALIDATED`, and
@@ -29,8 +29,11 @@ and the independent evidence gates that remain fail closed.
     Readiness (item 1 of the evidence gate below) has since been re-run and
     passes under `NETWORK_ISOLATION=true` against the exact pins below: the
     hosted agent reaches active state, session readiness succeeds, and a
-    grounded answer returns with its citation. These pins shipped as umbrella
-    release [`v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2).
+    grounded answer returns with its citation. That run was recorded against
+    umbrella release [`v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2).
+    [`v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3) repins
+    ingestion only; its UI, orchestrator, and AI Landing Zone pins are
+    byte-identical, so that readiness evidence carries forward unchanged.
     Evidence-gate items 2 through 8 and the `store` contract matrix have not
     been re-run; the four flags above remain deployment-published `false`.
 
@@ -40,7 +43,7 @@ and the independent evidence gates that remain fail closed.
 | --- | --- | --- | --- |
 | GPT-RAG UI | [`v2.6.2`](https://github.com/Azure/gpt-rag-ui/releases/tag/v2.6.2) | [`f59cca9`](https://github.com/Azure/gpt-rag-ui/commit/f59cca919f0bc59631d7bba7f3e223dff3718244) | Hosted/no-panel is the fresh UI default when `CHAT_BACKEND` is absent; continuity and panel surfaces remain opt-in and fail closed. |
 | GPT-RAG orchestrator | [`v4.1.1`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.1.1) | [`9b64a5b`](https://github.com/Azure/gpt-rag-orchestrator/commit/9b64a5b962067161cb55252c6e0917a2738ba984) | Canonical hosted `/responses` is stateless and requires caller-supplied ordered input. Fixes the `dependencies`/`connectors` circular import that crashed the hosted entrypoint on startup ([PR #311](https://github.com/Azure/gpt-rag-orchestrator/pull/311)), released in `v4.0.1`. Unconditionally forces `store: false` on every hosted `POST /responses` call and rejects `background: true` with HTTP 422 ([PR #313](https://github.com/Azure/gpt-rag-orchestrator/pull/313)), released in `v4.0.2`; see "Store false wire contract" below. `v4.1.0` inverts request-field validation from a strict allowlist to ignore-and-log with a minimal deny-list: only `previous_response_id` is rejected with HTTP 422, and every other field the adapter does not act on is dropped and logged. A strict allowlist turned each newly injected Foundry client field into a hosted-agent outage. `store` and `background` handling is unchanged. `v4.1.0` also suppresses spurious `opentelemetry.context.detach` error records emitted by third-party GenAI instrumentation. `v4.1.1` repairs the `frontend/` SPA build that the `Dockerfile` runs in its first stage: `v4.1.0` could not be built at all, so every clean deployment of umbrella `v3.8.0` failed at the orchestrator image build. Runtime behaviour is unchanged. |
-| GPT-RAG ingestion | [`v2.7.2`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.7.2) | [`b9e5ac3`](https://github.com/Azure/gpt-rag-ingestion/commit/b9e5ac3b2b36810b8d720398c3b8bbffc5ba7f75) | Metadata-only operator overview and document/corpus curation APIs. Repairs the OpenTelemetry import that crashed `v2.7.1` at boot after a successful image build. |
+| GPT-RAG ingestion | [`v2.7.3`](https://github.com/Azure/gpt-rag-ingestion/releases/tag/v2.7.3) | [`38a3955`](https://github.com/Azure/gpt-rag-ingestion/commit/38a395586ee1d440a8e1ca8233413f8c25b3fdc2) | Metadata-only operator overview and document/corpus curation APIs. `v2.7.2` repaired the OpenTelemetry import that crashed `v2.7.1` at boot after a successful image build, but mounted the administrative surface unconditionally at import time and never read `DEPLOY_ADMINISTRATIVE_PANEL`. `v2.7.3` resolves the deployment mode once from App Configuration inside the ASGI `lifespan` and gates the mount on it, so `HOSTED_NO_PANEL` now returns 404 instead of exposing the surface; see "Administrative surface gating" below. |
 | AI Landing Zone | [`v2.5.1`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.5.1) | [`9cc5859`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/commit/9cc5859af5c8ab3b31709c9e16e0db11a170a404) | Two-phase hosted-agent prerequisite/handoff support; both hosted flags default to `false`. Also allows the Foundry Agent Service's `agent365.svc.cloud.microsoft` observability endpoint through Azure Firewall under network isolation (`v2.5.1`, patch). |
 
 The matrix implements the component portions of
@@ -54,7 +57,7 @@ close their independent live evidence and authorization gates.
 
 | Surface | Current behavior |
 | --- | --- |
-| Umbrella integration manifest | Pins the exact matrix above. Stamped as [`v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2). |
+| Umbrella integration manifest | Pins the exact matrix above. Stamped as [`v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3). |
 | Fresh UI `v2.6.2` process with no `CHAT_BACKEND` value | Selects `hosted_agent`; invalid or incomplete hosted configuration fails startup. |
 | Existing umbrella deployment | Its persisted topology is sticky. An unmarked pre-cutover deployment stays `classic`. |
 | `DEPLOYMENT_TOPOLOGY=classic` | Explicit supported fallback; deploys UI, orchestrator, and ingestion Container Apps. |
@@ -136,7 +139,7 @@ the UI call route with the protocol and role evidence it validates.
     [`v4.0.2`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v4.0.2)
     (commit
     [`c653b3e`](https://github.com/Azure/gpt-rag-orchestrator/commit/c653b3ec0a553f55244e197f3be993ad33ffe02f),
-    722 tests passing upstream). Umbrella release `v3.8.2` pins the successor
+    722 tests passing upstream). Umbrella release `v3.8.3` pins the successor
     commit `9b64a5b` (`v4.1.1`), which leaves `store` and `background`
     handling unchanged. **The store contract itself has not been
     re-validated.** A network-isolated run on these pins confirms readiness and
@@ -227,11 +230,24 @@ surfaces return 503.
 
 ## Operator overview and corpus curation
 
-Ingestion `v2.7.2` includes:
+Ingestion `v2.7.3` includes:
 
 - `GET /panel/overview/metrics`;
 - `GET /panel/corpus-curation/queue`; and
 - `POST /panel/corpus-curation/{item_id}/decision`.
+
+`v2.7.3` also adds the `/api/panel/*` administrative API:
+
+- `GET /api/panel/status`;
+- `GET /api/panel/overview`;
+- `GET /api/panel/feedback`; and
+- `POST /api/panel/feedback`.
+
+Every `/api/panel/*` route requires the Entra ID app role `Admin`. `v2.7.3` also
+stops `GET /api/panel/feedback` from returning a permanent HTTP 500 when a
+single malformed Cosmos document is present and from silently discarding
+documents that carry no `rating`, and stops `POST /api/panel/feedback` from
+returning HTTP 500 when the Cosmos write raises.
 
 Overview reads aggregate counts only from the panel owner-index and feedback
 metadata containers. Any bucket below `PANEL_OVERVIEW_MIN_CARDINALITY` (default
@@ -255,13 +271,39 @@ hosted-panel topology still returns 503 from these routes until the separate
 operator evidence and authorization gate is completed.
 
 !!! important "Released ingestion dashboard browser-auth status"
-    The ingestion `v2.7.2` Vite dashboard does not initialize MSAL, acquire an
+    The ingestion `v2.7.3` Vite dashboard does not initialize MSAL, acquire an
     access token, or add an `Authorization` header for the new operator panel
     requests. Its `panelFetch` uses plain browser `fetch`. The Overview and
     Curation tabs therefore show the backend's real 401/403/503 response unless
     an approved same-origin reverse-auth proxy adds the delegated operator
     bearer. This differs from the classic orchestrator dashboard, whose SPA has
     a working MSAL Authorization Code + PKCE flow.
+
+## Administrative surface gating
+
+Ingestion `v2.7.2` mounted the administrative SPA and every administrative route
+unconditionally at import time, and never read `DEPLOY_ADMINISTRATIVE_PANEL`.
+The surface was therefore reachable regardless of the topology the umbrella
+publisher selected, including hosted/no-panel.
+
+Ingestion `v2.7.3` resolves the deployment mode once from Azure App
+Configuration inside the ASGI `lifespan` and gates the mount on the resolved
+mode:
+
+| Deployment mode | Administrative surface |
+| --- | --- |
+| `CLASSIC` | Mounted; unchanged from `v2.7.2`. |
+| `HOSTED_PANEL` | Mounted; unchanged from `v2.7.2`. |
+| `HOSTED_NO_PANEL` | Not mounted; every administrative route returns 404. |
+
+`v2.7.3` also makes startup fail closed when Entra ID configuration is absent.
+Earlier releases failed startup only on missing Cosmos configuration, so an
+ingestion process could start with the administrative surface mounted and no
+identity provider configured to authorize it.
+
+Only `HOSTED_NO_PANEL` changes behaviour. Upgrading a `CLASSIC` or an explicitly
+selected `HOSTED_PANEL` deployment from `v2.7.2` to `v2.7.3` removes no surface
+that deployment was already serving.
 
 ## Data confinement
 

--- a/docs/hosted_continuity_platform_contract.md
+++ b/docs/hosted_continuity_platform_contract.md
@@ -5,12 +5,12 @@ The trusted UI BFF derives `x-ms-user-identity` from the authenticated
 server-side principal and sends it on the hosted Responses request. This is the
 preferred and default continuity architecture.
 
-!!! danger "Shipped in v3.8.2; continuity evidence gate remains closed"
+!!! danger "Shipped in v3.8.3; continuity evidence gate remains closed"
     The OQ-OWN platform pivot merged in
     [PR #633](https://github.com/Azure/GPT-RAG/pull/633) at
     [`86b17b0`](https://github.com/Azure/GPT-RAG/commit/86b17b0af672edefe6842cba0f1a8ff77ab23038),
-    and [GPT-RAG `v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2)
-    pins UI `v2.6.2`, orchestrator `v4.1.1`, ingestion `v2.7.2`, and AILZ
+    and [GPT-RAG `v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3)
+    pins UI `v2.6.2`, orchestrator `v4.1.1`, ingestion `v2.7.3`, and AILZ
     `v2.5.1` at their exact release commits. See
     [the hosted-agent component release matrix](hosted_agent_release_matrix.md#store-false-wire-contract)
     for the `/responses` `store` gap, now fixed and pinned.

--- a/docs/howto_authentication.md
+++ b/docs/howto_authentication.md
@@ -9,8 +9,8 @@ This page explains how authentication works in GPT-RAG, from the GPT-RAG UI sign
     [PR #630](https://github.com/Azure/GPT-RAG/pull/630). The delegated
     `x-ms-user-identity` platform pivot merged in
     [PR #633](https://github.com/Azure/GPT-RAG/pull/633). UI `v2.6.2`,
-    orchestrator `v4.1.1`, ingestion `v2.7.2`, and AILZ `v2.5.1` are pinned by
-    [GPT-RAG `v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2).
+    orchestrator `v4.1.1`, ingestion `v2.7.3`, and AILZ `v2.5.1` are pinned by
+    [GPT-RAG `v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3).
     Keep `HOSTED_CONTINUITY_ENABLED=false`; compatible history endpoints return
     HTTP 503 until `HOSTED_CONVERSATION_OWNER_BINDING_VALIDATED=true`.
 
@@ -336,7 +336,7 @@ off/503 behind separate deployment-published evidence gates.
 
 Admin access is enforced through an **Entra ID App Role named `Admin`** added to the same App Registration you created for user sign-in. The token the caller presents to `/api/dashboard/*` (or the ingestion equivalents) must carry `Admin` in its `roles` claim.
 
-The ingestion `v2.7.2` metadata-only Overview and Curation APIs use their own
+The ingestion `v2.7.3` metadata-only Overview and Curation APIs use their own
 explicit `PANEL_OPERATOR_APP_ROLE` or `PANEL_OPERATOR_GROUP_ID` gate. Their Vite
 tabs do not acquire a browser token or add an `Authorization` header, so they
 require an approved reverse-auth proxy to supply the delegated bearer and

--- a/docs/howto_dashboard_signin.md
+++ b/docs/howto_dashboard_signin.md
@@ -24,7 +24,7 @@ Until this release, the orchestrator dashboard SPA had no real sign-in. The `req
 The chat UI is not affected. Only the orchestrator dashboard uses this new flow.
 
 !!! important "The ingestion operator tabs use a different browser client"
-    The ingestion `v2.7.2` Overview and Curation tabs do not initialize MSAL,
+    The ingestion `v2.7.3` Overview and Curation tabs do not initialize MSAL,
     acquire an access token, or attach `Authorization` to their panel requests.
     They display the API's real 401/403/503 response unless an approved
     same-origin reverse-auth proxy adds a delegated operator bearer. Do not

--- a/docs/services_orchestrator.md
+++ b/docs/services_orchestrator.md
@@ -6,7 +6,7 @@ coordinates agent-based RAG workflows, where each agent has a defined role, to
 generate accurate, context-aware responses for complex user queries. Current
 GPT-RAG umbrella releases run it as an orchestrator Container App. Orchestrator
 `v4.1.1` also packages the runtime as a Microsoft Foundry hosted agent, which
-[GPT-RAG `v3.8.2`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2) makes
+[GPT-RAG `v3.8.3`](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3) makes
 the default for genuinely fresh deployments; see the
 [exact hosted integration matrix](hosted_agent_release_matrix.md). The separate
 [hosted continuity platform contract](hosted_continuity_platform_contract.md)

--- a/docs/whatisnew.md
+++ b/docs/whatisnew.md
@@ -6,6 +6,19 @@ patch, and fix, see the [GitHub releases](https://github.com/Azure/GPT-RAG/relea
 
 ### September 2026
 
+- **Data-ingestion administrative surface is gated on the deployment mode ([GPT-RAG v3.8.3](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.3)).**
+  The umbrella release repins ingestion to `v2.7.3`; UI `v2.6.2`, orchestrator
+  `v4.1.1`, and AILZ `v2.5.1` are unchanged from `v3.8.2`. Ingestion `v2.7.2`
+  mounted the administrative SPA and every administrative route unconditionally
+  at import time and never read `DEPLOY_ADMINISTRATIVE_PANEL`, so the surface
+  was reachable whatever topology the publisher selected. `v2.7.3` resolves the
+  deployment mode once from App Configuration inside the ASGI `lifespan` and
+  gates the mount on it, so a hosted/no-panel deployment now returns 404 instead
+  of serving the surface. Startup also fails closed when Entra ID configuration
+  is absent, not only when Cosmos configuration is. Classic and explicitly
+  selected hosted-panel deployments are unaffected. See
+  [Administrative surface gating](hosted_agent_release_matrix.md#administrative-surface-gating).
+
 - **Hosted agent on Microsoft Foundry is the fresh-deployment default ([GPT-RAG v3.8.2](https://github.com/Azure/GPT-RAG/releases/tag/v3.8.2)).**
   The umbrella release pins UI `v2.6.2`, orchestrator `v4.1.1`, ingestion
   `v2.7.2`, and AILZ `v2.5.1`, and validates the hosted chat path end to end


### PR DESCRIPTION
## Why

The `v3.8.3` umbrella release repins ingestion from `v2.7.2` to `v2.7.3`.
PR #685 repinned the legacy-diagram handoff page, but eight other published
pages still advertised the superseded pins, and **no page documented the
user-visible behaviour change that `v2.7.3` ships**.

Per `AGENTS.md`, drift between the published site and the implementation is a
bug, and a change with a user-visible effect is not complete until its docs are
updated.

## What changed

**Mechanical repins** — `architecture.md`, `deploy.md`,
`hosted_continuity_platform_contract.md`, `howto_authentication.md`,
`howto_dashboard_signin.md`, `services_orchestrator.md`, and
`hosted_agent_release_matrix.md`.

**Historical statements deliberately preserved:**

- `deploy.md` still records that `v3.8.2` was the first release in the `v3.8.x`
  line that deploys end to end. That is a fact about `v3.8.2`.
- The network-isolated readiness evidence in the matrix is still attributed to
  the `v3.8.2` run that produced it. Rather than silently restamping it as
  `v3.8.3`, the text now states that `v3.8.3` repins ingestion only and that the
  UI, orchestrator, and AI Landing Zone pins are byte-identical, so the evidence
  carries forward — no re-run is implied.

**Behaviour change now documented.** Ingestion `v2.7.2` mounted the
administrative SPA and every administrative route unconditionally at import
time and never read `DEPLOY_ADMINISTRATIVE_PANEL`, so the surface was reachable
whatever topology the publisher selected. `v2.7.3` resolves the deployment mode
once from App Configuration inside the ASGI `lifespan` and gates the mount on
it.

| Deployment mode | Administrative surface |
| --- | --- |
| `CLASSIC` | Mounted; unchanged. |
| `HOSTED_PANEL` | Mounted; unchanged. |
| `HOSTED_NO_PANEL` | Not mounted; every administrative route returns 404. |

Adds an "Administrative surface gating" section covering the per-mode outcome
and the fail-closed startup change, completes the endpoint list with the four
`/api/panel/*` routes `v2.7.3` adds (note the `/api/` prefix, which differs from
the older `/panel/*` family; all require the Entra app role `Admin`), and adds a
September 2026 entry to `whatisnew.md`.

## Verification

- Pins read from `manifest.json` on `main`: umbrella `v3.8.3`, UI `v2.6.2`,
  orchestrator `v4.1.1`, ingestion `v2.7.3`, AILZ `v2.5.1`.
- Ingestion commit `38a3955` resolved from the `v2.7.3` release tag.
- Behaviour described above taken from the `v2.7.3` release notes.
- Every remaining `v3.8.2` / `v2.7.2` mention re-checked: each is either an
  intentional `v2.7.2` to `v2.7.3` comparison, the dated readiness evidence, or
  the historical `v3.8.2` changelog entry.

Refs #683