### PR TITLE
docs(adr): clarify that ADR-0001 records the revision-4 landing-zone pin

### DIFF
--- a/docs/adr/ADR-0001-hosted-agents.md
+++ b/docs/adr/ADR-0001-hosted-agents.md
@@ -423,8 +423,14 @@ the reusable landing zone:
   restores `CHAT_BACKEND=orchestrator`.
 
 No files inside the landing-zone submodule are changed by this implementation.
-The integration is limited to the exact `v2.4.1` tag/gitlink and its published
-parameter/output contract.
+The integration was limited to the exact `v2.4.1` tag/gitlink and its published
+parameter/output contract at the time revision 4 was implemented.
+
+> **Landing-zone pin in effect.** The versions named in this section record the
+> revision-4 implementation boundary and are deliberately not rewritten per
+> release. For the pin actually in effect, read `manifest.json` (`ailz_tag`,
+> `ailz_commit`) together with `.gitmodules` (`infra.branch`); those three must
+> identify the same validated landing-zone release commit.
 
 ### Hosted conversation ownership
 


### PR DESCRIPTION
## What

ADR-0001 line 426 read, in the present tense:

> The integration **is** limited to the exact `v2.4.1` tag/gitlink and its published parameter/output contract.

That sentence lives inside `### Implemented accelerator and landing-zone boundary`, the section that records what **revision 4** implemented under issue #595. The version is therefore correct as history, but the present tense reads as the pin currently in effect.

## Why it matters

The landing-zone pin has advanced since revision 4. The three pins that must agree today all say `v2.5.1`:

| Source | Value |
| --- | --- |
| `manifest.json` `ailz_tag` | `v2.5.1` |
| `manifest.json` `ailz_commit` | `9cc5859af5c8ab3b31709c9e16e0db11a170a404` |
| `.gitmodules` `infra.branch` | `v2.5.1` |

A reader landing on that section could reasonably conclude the accelerator is still pinned to `v2.4.1`.

## What this does

Rather than rewrite the historical record — ADR-0001 is explicitly structured to preserve per-revision state, and its own `## Decision history` says *"Revision 4 remains the implementation boundary implemented by issue #595"* — this change:

1. Moves the sentence to the past tense and scopes it to revision 4.
2. Adds a note naming `manifest.json` and `.gitmodules` as the source of truth for the pin in effect, and stating that the versions in that section are deliberately not rewritten per release.

The `v2.4.1` mention earlier in the same section (line 386, describing what that landing-zone version accepts) is left untouched — it is a factual statement about `v2.4.1` itself.

## Scope

- No behaviour, configuration, or deployment change.
- `docs/adr/` exists on `develop` and `main` only; it is **not** on the `docs` branch and is not published to the MkDocs site. No user-facing documentation is affected.
- No `CHANGELOG.md` entry: this documents internal architecture history and has no observable effect on the product.
- Nothing under `infra/` touched.

## Validation

```
git --no-pager diff --stat   # 1 file changed, 8 insertions(+), 2 deletions(-)
```

Pins verified against `main` at the time of writing:

```
manifest.json  ailz_tag = v2.5.1   ailz_commit = 9cc5859...
.gitmodules    branch   = v2.5.1
```